### PR TITLE
Fix outputTask to use --no-reply flag for C4 queue

### DIFF
--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -99,7 +99,8 @@ function outputTask(action, data) {
   try {
     const taskMessage = `[COMPONENT_TASK] ${JSON.stringify(task)}`;
     // Use spawnSync with args array to avoid shell escaping issues
-    const result = spawnSync('node', [c4ReceivePath, '--source', 'zylos-cli', '--content', taskMessage], {
+    // Use --no-reply since CLI tasks don't need a reply channel (zylos-cli has no send.js)
+    const result = spawnSync('node', [c4ReceivePath, '--source', 'zylos-cli', '--no-reply', '--content', taskMessage], {
       stdio: 'pipe',
       encoding: 'utf8'
     });


### PR DESCRIPTION
## Summary

- Add `--no-reply` flag when outputTask calls c4-receive.js
- CLI-initiated tasks don't need a reply channel since zylos-cli has no send.js
- Without this fix, c4-send.js tries to find `~/.claude/skills/zylos-cli/send.js` which doesn't exist

## Test plan

- [ ] Run `zylos upgrade telegram` and verify no "Channel script not found" error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)