### PR TITLE
Update registry versions for telegram and lark

### DIFF
--- a/cli/registry.json
+++ b/cli/registry.json
@@ -5,13 +5,13 @@
       "repo": "zylos-ai/zylos-telegram",
       "description": "Telegram Bot communication channel",
       "type": "communication",
-      "latest": "1.0.0"
+      "latest": "0.1.0-beta.9"
     },
     "lark": {
       "repo": "zylos-ai/zylos-lark",
       "description": "Lark/Feishu Bot communication channel",
       "type": "communication",
-      "latest": "1.0.0"
+      "latest": "0.1.0-beta.1"
     },
     "scheduler": {
       "repo": "zylos-ai/zylos-scheduler",


### PR DESCRIPTION
## Summary

- telegram: 1.0.0 → 0.1.0-beta.9
- lark: 1.0.0 → 0.1.0-beta.1

Aligns registry.json with actual component versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)