### PR TITLE
Fix: Include uninstall in skill read instruction

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -69,7 +69,7 @@ Web server configuration (Caddy).
 
 ### component-management/
 Guidelines for installing, upgrading, and managing zylos components.
-**Read this before any component install/upgrade operation.**
+**Read this before any component install/upgrade/uninstall operation.**
 
 ## Component Management
 


### PR DESCRIPTION
## Summary
- Fix CLAUDE.md template to include "uninstall" in the instruction to read component-management skill
- Previously said "Read this before any component install/upgrade operation" 
- Now says "Read this before any component install/upgrade/uninstall operation"

## Root Cause
Claude on zylos0 wasn't following the uninstall workflow (asking about data deletion) because the CLAUDE.md template didn't tell it to read the component-management skill for uninstall operations.

## Test
After deploying this fix, Claude should properly follow the uninstall workflow which includes asking:
1. Remove code only (keep data)
2. Remove everything (code + data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)