### PR TITLE
Fix: Update missed SKILLS_DIR paths

### DIFF
--- a/cli/lib/config.js
+++ b/cli/lib/config.js
@@ -5,7 +5,7 @@
 const path = require('path');
 
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(process.env.HOME, 'zylos');
-const SKILLS_DIR = path.join(process.env.HOME, '.claude', 'skills');
+const SKILLS_DIR = path.join(ZYLOS_DIR, '.claude', 'skills');
 const COMPONENTS_DIR = path.join(ZYLOS_DIR, 'components');
 const LOCKS_DIR = path.join(process.env.HOME, '.zylos', '.locks');
 const REGISTRY_FILE = path.join(__dirname, '..', 'registry.json');

--- a/skills/comm-bridge/scripts/c4-notify.js
+++ b/skills/comm-bridge/scripts/c4-notify.js
@@ -12,7 +12,7 @@ import fs from 'fs';
 import os from 'os';
 import { spawn } from 'child_process';
 
-const SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
+const SKILLS_DIR = path.join(os.homedir(), 'zylos', '.claude', 'skills');
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 
 function printUsage() {

--- a/skills/comm-bridge/scripts/c4-send.js
+++ b/skills/comm-bridge/scripts/c4-send.js
@@ -13,7 +13,7 @@ import fs from 'fs';
 import { spawn } from 'child_process';
 import { insertConversation } from './c4-db.js';
 
-const SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
+const SKILLS_DIR = path.join(os.homedir(), 'zylos', '.claude', 'skills');
 
 function printUsage() {
   console.log('Usage: node c4-send.js <source> [endpoint_id] "<message>"');

--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -28,7 +28,7 @@ const PORT = process.env.WEB_CONSOLE_PORT || 3456;
 
 // Paths
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
-const SKILLS_DIR = path.join(os.homedir(), '.claude', 'skills');
+const SKILLS_DIR = path.join(os.homedir(), 'zylos', '.claude', 'skills');
 const DB_DIR = path.join(ZYLOS_DIR, 'comm-bridge');
 const DB_PATH = path.join(DB_DIR, 'c4.db');
 const STATUS_FILE = path.join(os.homedir(), '.claude-status');


### PR DESCRIPTION
## Summary
Fix SKILLS_DIR paths missed in bb3adf5 when changing from `~/.claude/skills` to `~/zylos/.claude/skills`.

## Files Fixed
- `cli/lib/config.js` - CLI component install path
- `skills/comm-bridge/scripts/c4-notify.js` - Channel script lookup
- `skills/comm-bridge/scripts/c4-send.js` - Channel script lookup  
- `skills/web-console/scripts/server.js` - C4 receive path

## Problem
After bb3adf5, components would install to wrong location (`~/.claude/skills/`) while core skills are at `~/zylos/.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)