### PR TITLE
feat: Phase 1 infrastructure (download, manifest, config)

### DIFF
--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -4,10 +4,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const { ZYLOS_DIR } = require('./config');
+const { COMPONENTS_FILE } = require('./config');
 const { loadRegistry } = require('./registry');
-
-const COMPONENTS_FILE = path.join(ZYLOS_DIR, 'components.json');
 
 /**
  * Load installed components from components.json

--- a/cli/lib/config.js
+++ b/cli/lib/config.js
@@ -6,16 +6,20 @@ const path = require('path');
 
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(process.env.HOME, 'zylos');
 const SKILLS_DIR = path.join(ZYLOS_DIR, '.claude', 'skills');
+const CONFIG_DIR = path.join(ZYLOS_DIR, '.zylos');
 const COMPONENTS_DIR = path.join(ZYLOS_DIR, 'components');
-const LOCKS_DIR = path.join(process.env.HOME, '.zylos', '.locks');
-const REGISTRY_FILE = path.join(__dirname, '..', 'registry.json');
+const LOCKS_DIR = path.join(CONFIG_DIR, 'locks');
+const REGISTRY_FILE = path.join(CONFIG_DIR, 'registry.json');
 const REGISTRY_URL = 'https://raw.githubusercontent.com/zylos-ai/zylos-registry/main/registry.json';
+const COMPONENTS_FILE = path.join(CONFIG_DIR, 'components.json');
 
 module.exports = {
   ZYLOS_DIR,
   SKILLS_DIR,
+  CONFIG_DIR,
   COMPONENTS_DIR,
   LOCKS_DIR,
   REGISTRY_FILE,
   REGISTRY_URL,
+  COMPONENTS_FILE,
 };

--- a/cli/lib/download.js
+++ b/cli/lib/download.js
@@ -1,0 +1,118 @@
+/**
+ * Download utilities for component installation and upgrades.
+ * Supports GitHub archive tarballs and local paths. No git dependency.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const os = require('os');
+
+/**
+ * Download a GitHub archive tarball and extract it.
+ *
+ * @param {string} repo - GitHub repo in "org/name" format
+ * @param {string} version - Version tag (e.g. "1.0.0", will be prefixed with "v")
+ * @param {string} destDir - Destination directory to extract into
+ * @returns {{ success: boolean, extractedDir: string, error?: string }}
+ */
+function downloadArchive(repo, version, destDir) {
+  const tag = version.startsWith('v') ? version : `v${version}`;
+  const url = `https://github.com/${repo}/archive/refs/tags/${tag}.tar.gz`;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-download-'));
+  const tarballPath = path.join(tmpDir, 'archive.tar.gz');
+
+  try {
+    // Ensure dest directory exists
+    fs.mkdirSync(destDir, { recursive: true });
+
+    // Download tarball
+    execSync(`curl -fsSL -o "${tarballPath}" "${url}"`, {
+      timeout: 60000,
+      stdio: 'pipe',
+    });
+
+    // Extract tarball
+    const result = extractTarball(tarballPath, destDir);
+
+    // Clean up tarball
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+
+    return result;
+  } catch (err) {
+    // Clean up on failure
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    return {
+      success: false,
+      extractedDir: null,
+      error: `Failed to download ${repo}@${tag}: ${err.message}`,
+    };
+  }
+}
+
+/**
+ * Copy a component from a local path.
+ *
+ * @param {string} localPath - Absolute or relative path to component source
+ * @param {string} destDir - Destination directory
+ * @returns {{ success: boolean, error?: string }}
+ */
+function copyLocal(localPath, destDir) {
+  const srcPath = path.resolve(localPath);
+
+  if (!fs.existsSync(srcPath)) {
+    return { success: false, error: `Source path not found: ${srcPath}` };
+  }
+
+  const stat = fs.statSync(srcPath);
+  if (!stat.isDirectory()) {
+    return { success: false, error: `Source path is not a directory: ${srcPath}` };
+  }
+
+  try {
+    fs.mkdirSync(destDir, { recursive: true });
+    // Copy all files except .git
+    execSync(`rsync -a --exclude='.git' "${srcPath}/" "${destDir}/"`, {
+      timeout: 30000,
+      stdio: 'pipe',
+    });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: `Failed to copy from ${srcPath}: ${err.message}` };
+  }
+}
+
+/**
+ * Extract a tarball to a destination directory.
+ * GitHub archive tarballs contain a top-level directory (e.g. "repo-name-v1.0.0/"),
+ * so we strip the first path component.
+ *
+ * @param {string} tarballPath - Path to the .tar.gz file
+ * @param {string} destDir - Directory to extract into
+ * @returns {{ success: boolean, extractedDir: string, error?: string }}
+ */
+function extractTarball(tarballPath, destDir) {
+  try {
+    fs.mkdirSync(destDir, { recursive: true });
+
+    // Extract with strip-components to remove top-level directory
+    execSync(`tar xzf "${tarballPath}" -C "${destDir}" --strip-components=1`, {
+      timeout: 30000,
+      stdio: 'pipe',
+    });
+
+    return { success: true, extractedDir: destDir };
+  } catch (err) {
+    return {
+      success: false,
+      extractedDir: null,
+      error: `Failed to extract tarball: ${err.message}`,
+    };
+  }
+}
+
+module.exports = {
+  downloadArchive,
+  copyLocal,
+  extractTarball,
+};

--- a/cli/lib/manifest.js
+++ b/cli/lib/manifest.js
@@ -1,0 +1,146 @@
+/**
+ * Manifest utilities for tracking file hashes.
+ * Used to detect local modifications during upgrades.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const MANIFEST_DIR = '.zylos';
+const MANIFEST_FILE = 'manifest.json';
+
+/**
+ * Compute SHA-256 hash of a file.
+ *
+ * @param {string} filePath - Absolute path to file
+ * @returns {string} Hex-encoded hash
+ */
+function hashFile(filePath) {
+  const content = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Recursively collect all files in a directory, excluding certain paths.
+ *
+ * @param {string} dir - Directory to scan
+ * @param {string} baseDir - Base directory for relative paths
+ * @param {string[]} [exclude] - Directory/file names to skip
+ * @returns {string[]} Array of relative file paths
+ */
+function collectFiles(dir, baseDir, exclude = ['.git', '.zylos', 'node_modules', '.backup']) {
+  const files = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (exclude.includes(entry.name)) continue;
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(fullPath, baseDir, exclude));
+    } else if (entry.isFile()) {
+      files.push(path.relative(baseDir, fullPath));
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Generate a manifest (file hash map) for a directory.
+ *
+ * @param {string} dir - Directory to scan
+ * @returns {{ files: Object<string, string>, generated_at: string }}
+ */
+function generateManifest(dir) {
+  const files = collectFiles(dir, dir);
+  const manifest = {};
+
+  for (const file of files.sort()) {
+    manifest[file] = hashFile(path.join(dir, file));
+  }
+
+  return {
+    files: manifest,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Save manifest to the component's .zylos/ directory.
+ *
+ * @param {string} dir - Component root directory
+ * @param {Object} manifest - Manifest object from generateManifest()
+ */
+function saveManifest(dir, manifest) {
+  const manifestDir = path.join(dir, MANIFEST_DIR);
+  fs.mkdirSync(manifestDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(manifestDir, MANIFEST_FILE),
+    JSON.stringify(manifest, null, 2)
+  );
+}
+
+/**
+ * Load manifest from a component's .zylos/ directory.
+ *
+ * @param {string} dir - Component root directory
+ * @returns {Object|null} Manifest object or null if not found
+ */
+function loadManifest(dir) {
+  const manifestPath = path.join(dir, MANIFEST_DIR, MANIFEST_FILE);
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect local modifications by comparing current files against saved manifest.
+ *
+ * @param {string} dir - Component root directory
+ * @returns {{ modified: string[], added: string[], deleted: string[], unchanged: string[] } | null}
+ *   null if no manifest found (first install, no comparison possible)
+ */
+function detectChanges(dir) {
+  const saved = loadManifest(dir);
+  if (!saved || !saved.files) return null;
+
+  const current = generateManifest(dir);
+  const modified = [];
+  const added = [];
+  const deleted = [];
+  const unchanged = [];
+
+  // Check files that exist now
+  for (const [file, hash] of Object.entries(current.files)) {
+    if (!(file in saved.files)) {
+      added.push(file);
+    } else if (saved.files[file] !== hash) {
+      modified.push(file);
+    } else {
+      unchanged.push(file);
+    }
+  }
+
+  // Check files that were in manifest but no longer exist
+  for (const file of Object.keys(saved.files)) {
+    if (!(file in current.files)) {
+      deleted.push(file);
+    }
+  }
+
+  return { modified, added, deleted, unchanged };
+}
+
+module.exports = {
+  generateManifest,
+  saveManifest,
+  loadManifest,
+  detectChanges,
+};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Zylos AI",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.20.0"
   },
   "dependencies": {
     "better-sqlite3": "^9.0.0"


### PR DESCRIPTION
## Summary

Phase 1 infrastructure for the npm package refactoring. Provides foundational utilities for subsequent add/upgrade/init commands.

- **download.js**: GitHub archive tarball download + local path copy + tarball extraction (no git dependency)
- **manifest.js**: File hash tracking for detecting local modifications during upgrades
- **config.js**: Updated paths to zylos self-contained structure (CONFIG_DIR, LOCKS_DIR, REGISTRY_FILE, COMPONENTS_FILE)
- **components.js**: Use COMPONENTS_FILE constant from config instead of inline path
- **package.json**: Updated engines to node >= 20.20.0

Corresponds to refactoring plan Phase 1 tasks 1.1, 1.2, 1.3.

## Test plan

- [ ] All three new modules can be required and export correct interfaces
- [ ] manifest.js generates correct file hashes for a directory
- [ ] download.js downloads a real GitHub archive tarball
- [ ] Existing commands (list, search, status) remain compatible with config path changes