### PR TITLE
feat: implement zylos add command (task 2.2)

### DIFF
--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -1,0 +1,366 @@
+/**
+ * zylos add - Install a component
+ *
+ * Full self-contained installation flow:
+ *   1. Resolve target → download → detect type
+ *   2. Declarative (SKILL.md): npm install, config, hook, PM2, done
+ *   3. AI (no SKILL.md): record in components.json, output task for Claude
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { ZYLOS_DIR, SKILLS_DIR, COMPONENTS_DIR } from '../lib/config.js';
+import { loadRegistry } from '../lib/registry.js';
+import { loadComponents, saveComponents, resolveTarget, outputTask } from '../lib/components.js';
+import { downloadArchive, downloadBranch } from '../lib/download.js';
+import { generateManifest, saveManifest } from '../lib/manifest.js';
+import { parseSkillMd, detectComponentType } from '../lib/skill.js';
+import { readEnvFile, writeEnvEntries } from '../lib/env.js';
+import { registerService } from '../lib/service.js';
+import { prompt, promptYesNo, promptSecret } from '../lib/prompts.js';
+
+/**
+ * Main entry: zylos add <target> [--yes]
+ */
+export async function addComponent(args) {
+  const skipConfirm = args.includes('--yes') || args.includes('-y');
+  const target = args.find(a => !a.startsWith('-'));
+
+  if (!target) {
+    printUsage();
+    process.exit(1);
+  }
+
+  // 1. Resolve target
+  const resolved = await resolveTarget(target);
+
+  if (!resolved.repo) {
+    console.error(`Unknown component: ${target}`);
+    console.log('Use "zylos search <keyword>" to find available components.');
+    process.exit(1);
+  }
+
+  // 2. Check if already installed
+  const components = loadComponents();
+  if (components[resolved.name]) {
+    console.log(`Component "${resolved.name}" is already installed (v${components[resolved.name].version}).`);
+    console.log('Use "zylos upgrade" to update.');
+    process.exit(0);
+  }
+
+  // 3. Display component info
+  const versionInfo = resolved.version ? `@${resolved.version}` : ' (latest)';
+  console.log(`\nComponent: ${resolved.name}${versionInfo}`);
+  console.log(`Repository: https://github.com/${resolved.repo}`);
+
+  if (resolved.isThirdParty) {
+    console.log('Warning: Third-party component — not verified by Zylos team.');
+  }
+
+  // Try to get description from registry
+  const registry = await loadRegistry();
+  if (registry[resolved.name]) {
+    console.log(`Description: ${registry[resolved.name].description}`);
+    console.log(`Type: ${registry[resolved.name].type}`);
+  }
+
+  // 4. User confirmation
+  if (!skipConfirm) {
+    console.log('');
+    const confirmed = await promptYesNo('Proceed with installation? [Y/n]: ', true);
+    if (!confirmed) {
+      console.log('Installation cancelled.');
+      return;
+    }
+  }
+
+  // 5. Download
+  const skillDir = path.join(SKILLS_DIR, resolved.name);
+
+  if (fs.existsSync(skillDir)) {
+    console.error(`\nSkill directory already exists: ${skillDir}`);
+    console.error('Remove it first or use "zylos upgrade".');
+    process.exit(1);
+  }
+
+  console.log(`\nDownloading ${resolved.name}...`);
+
+  let downloadResult;
+  if (resolved.version) {
+    downloadResult = downloadArchive(resolved.repo, resolved.version, skillDir);
+  } else {
+    downloadResult = downloadBranch(resolved.repo, 'main', skillDir);
+  }
+
+  if (!downloadResult.success) {
+    console.error(`Download failed: ${downloadResult.error}`);
+    cleanup(skillDir);
+    process.exit(1);
+  }
+
+  console.log('  Download complete.');
+
+  // 6. Generate manifest
+  try {
+    const manifest = generateManifest(skillDir);
+    saveManifest(skillDir, manifest);
+  } catch (err) {
+    console.log(`  Warning: Could not generate manifest: ${err.message}`);
+  }
+
+  // 7. Detect component type and install accordingly
+  const componentType = detectComponentType(skillDir);
+
+  if (componentType === 'declarative') {
+    await installDeclarative(resolved, skillDir, skipConfirm);
+  } else {
+    installAI(resolved, skillDir);
+  }
+}
+
+/**
+ * Install a declarative component (has SKILL.md).
+ */
+async function installDeclarative(resolved, skillDir, skipConfirm) {
+  console.log('\nInstalling (declarative)...');
+
+  const skill = parseSkillMd(skillDir);
+  const fm = skill?.frontmatter || {};
+  const lifecycle = fm.lifecycle || {};
+  const config = fm.config || {};
+
+  // Step 1: npm install
+  if (lifecycle.npm) {
+    const pkgJson = path.join(skillDir, 'package.json');
+    if (fs.existsSync(pkgJson)) {
+      console.log('  Installing npm dependencies...');
+      try {
+        execSync('npm install --omit=dev', {
+          cwd: skillDir,
+          stdio: 'pipe',
+          timeout: 120000,
+        });
+        console.log('  npm install complete.');
+      } catch (err) {
+        console.error(`  npm install failed: ${err.message}`);
+        cleanup(skillDir);
+        process.exit(1);
+      }
+    }
+  }
+
+  // Step 2: Create data directory
+  const dataDir = path.join(COMPONENTS_DIR, resolved.name);
+  fs.mkdirSync(dataDir, { recursive: true });
+  console.log(`  Data directory: ${dataDir}`);
+
+  // Step 3: Collect config interactively
+  const requiredConfig = config.required || [];
+  if (requiredConfig.length > 0) {
+    console.log('\n  Configuration required:');
+
+    if (skipConfirm) {
+      // In non-interactive mode, write placeholders
+      console.log('  (--yes mode: skipping prompts, set these manually in .env)');
+      const entries = {};
+      for (const item of requiredConfig) {
+        const key = typeof item === 'string' ? item : item.env;
+        if (key) {
+          entries[key] = '';
+        }
+      }
+      const result = writeEnvEntries(entries, resolved.name);
+      if (result.written.length > 0) {
+        console.log(`  Keys to configure: ${result.written.join(', ')}`);
+      }
+    } else {
+      const entries = {};
+      const existing = readEnvFile();
+      for (const item of requiredConfig) {
+        const key = typeof item === 'string' ? item : item.env;
+        const desc = typeof item === 'string' ? item : (item.description || item.env);
+        const secret = typeof item === 'object' && item.secret;
+
+        if (!key) continue;
+
+        // Check if already set
+        if (existing.has(key)) {
+          console.log(`  ${key}: already set (skipping)`);
+          continue;
+        }
+
+        let value;
+        if (secret) {
+          value = await promptSecret(`  ${desc}: `);
+        } else {
+          value = await prompt(`  ${desc}: `);
+        }
+
+        if (value) {
+          entries[key] = value;
+        }
+      }
+
+      if (Object.keys(entries).length > 0) {
+        const result = writeEnvEntries(entries, resolved.name);
+        if (result.written.length > 0) {
+          console.log(`\n  Saved ${result.written.length} config value(s) to .env`);
+        }
+      }
+    }
+  }
+
+  // Step 4: Execute post-install hook
+  const postInstall = lifecycle['post-install'];
+  if (postInstall) {
+    console.log('  Running post-install hook...');
+    try {
+      executeHook(postInstall, skillDir);
+      console.log('  Post-install hook complete.');
+    } catch (err) {
+      console.log(`  Warning: Post-install hook failed: ${err.message}`);
+      // Don't abort — warn only
+    }
+  }
+
+  // Step 5: Register PM2 service
+  const service = fm.service;
+  if (service && service.entry) {
+    console.log('  Starting service...');
+    const svcResult = registerService({
+      name: resolved.name,
+      entry: service.entry,
+      skillDir,
+      type: service.type || 'pm2',
+    });
+
+    if (svcResult.success) {
+      console.log(`  Service "zylos-${resolved.name}" started.`);
+    } else {
+      console.log(`  Warning: Service start failed: ${svcResult.error}`);
+    }
+  }
+
+  // Step 6: Update components.json
+  const components = loadComponents();
+  components[resolved.name] = {
+    version: resolved.version || '0.0.0',
+    repo: resolved.repo,
+    type: 'declarative',
+    isThirdParty: resolved.isThirdParty,
+    installedAt: new Date().toISOString(),
+    skillDir,
+    dataDir,
+  };
+  saveComponents(components);
+
+  // Done
+  console.log(`\n✓ ${resolved.name} installed successfully!`);
+
+  // Display next steps from SKILL.md
+  const nextSteps = fm['next-steps'] || fm.nextSteps;
+  if (nextSteps && Array.isArray(nextSteps)) {
+    console.log('\nNext steps:');
+    for (const step of nextSteps) {
+      console.log(`  - ${step}`);
+    }
+  }
+
+  console.log('');
+}
+
+/**
+ * Install an AI component (no SKILL.md — needs Claude to finish setup).
+ */
+function installAI(resolved, skillDir) {
+  console.log('\nInstalling (AI mode — Claude will complete setup)...');
+
+  // Update components.json with basic info
+  const components = loadComponents();
+  components[resolved.name] = {
+    version: resolved.version || '0.0.0',
+    repo: resolved.repo,
+    type: 'ai',
+    isThirdParty: resolved.isThirdParty,
+    installedAt: new Date().toISOString(),
+    skillDir,
+    setupComplete: false,
+  };
+  saveComponents(components);
+
+  // Output task for Claude to read README and finish setup
+  outputTask('install', {
+    component: resolved.name,
+    repo: resolved.repo,
+    version: resolved.version,
+    skillDir,
+    dataDir: path.join(COMPONENTS_DIR, resolved.name),
+    isThirdParty: resolved.isThirdParty,
+    steps: [
+      `Read README.md in ${skillDir} for setup instructions`,
+      `Create data directory ${COMPONENTS_DIR}/${resolved.name} if needed`,
+      `Install npm dependencies if package.json exists`,
+      `Configure environment variables as needed`,
+      `Register PM2 service if applicable`,
+      `Update components.json setupComplete to true when done`,
+    ],
+  });
+}
+
+/**
+ * Execute a post-install hook script.
+ * Detects .js vs .sh by extension.
+ */
+function executeHook(hookPath, cwd) {
+  const resolved = path.resolve(cwd, hookPath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Hook script not found: ${resolved}`);
+  }
+
+  const ext = path.extname(resolved);
+  let cmd;
+  if (ext === '.js' || ext === '.mjs') {
+    cmd = `node "${resolved}"`;
+  } else if (ext === '.sh') {
+    cmd = `bash "${resolved}"`;
+  } else {
+    cmd = `"${resolved}"`;
+  }
+
+  execSync(cmd, {
+    cwd,
+    stdio: 'inherit',
+    timeout: 60000,
+    env: { ...process.env, ZYLOS_DIR, SKILLS_DIR, COMPONENTS_DIR },
+  });
+}
+
+/**
+ * Clean up a failed installation.
+ */
+function cleanup(dir) {
+  if (fs.existsSync(dir)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best effort
+    }
+  }
+}
+
+function printUsage() {
+  console.log(`Usage: zylos add <target> [options]
+
+Arguments:
+  target    Component name, org/repo, or GitHub URL
+
+Options:
+  --yes, -y  Skip confirmation prompts
+
+Examples:
+  zylos add telegram              Official component (latest)
+  zylos add telegram@0.2.0        Specific version
+  zylos add user/my-component     Third-party
+  zylos add https://github.com/user/zylos-my-component`);
+}

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -7,10 +7,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import readline from 'node:readline';
 import { execSync, spawnSync } from 'node:child_process';
 import { ZYLOS_DIR, SKILLS_DIR, CONFIG_DIR, COMPONENTS_DIR, LOCKS_DIR, COMPONENTS_FILE } from '../lib/config.js';
 import { generateManifest, saveManifest } from '../lib/manifest.js';
+import { prompt, promptYesNo } from '../lib/prompts.js';
 
 // Source directory for Core Skills (shipped with zylos package)
 const CORE_SKILLS_SRC = path.join(import.meta.dirname, '..', '..', 'skills');
@@ -18,27 +18,6 @@ const CORE_SKILLS_SRC = path.join(import.meta.dirname, '..', '..', 'skills');
 // Minimum Node.js version
 const MIN_NODE_MAJOR = 20;
 const MIN_NODE_MINOR = 20;
-
-// ── Prompt utilities ────────────────────────────────────────────────
-
-function prompt(question) {
-  if (!process.stdin.isTTY) return Promise.resolve('');
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
-}
-
-function promptYesNo(question, defaultYes = false) {
-  if (!process.stdin.isTTY) return Promise.resolve(defaultYes);
-  return prompt(question).then((answer) => {
-    if (!answer) return defaultYes;
-    return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
-  });
-}
 
 // ── Prerequisite checks ─────────────────────────────────────────────
 

--- a/cli/lib/config.js
+++ b/cli/lib/config.js
@@ -12,3 +12,4 @@ export const LOCKS_DIR = path.join(CONFIG_DIR, 'locks');
 export const REGISTRY_FILE = path.join(CONFIG_DIR, 'registry.json');
 export const REGISTRY_URL = 'https://raw.githubusercontent.com/zylos-ai/zylos-registry/main/registry.json';
 export const COMPONENTS_FILE = path.join(CONFIG_DIR, 'components.json');
+export const ENV_FILE = path.join(ZYLOS_DIR, '.env');

--- a/cli/lib/env.js
+++ b/cli/lib/env.js
@@ -1,0 +1,79 @@
+/**
+ * .env file read/write utilities
+ *
+ * Append-only writes: never overwrites existing keys.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { ENV_FILE } from './config.js';
+
+/**
+ * Parse the .env file into a Map of key → value.
+ * Ignores comments and blank lines.
+ *
+ * @returns {Map<string, string>}
+ */
+export function readEnvFile() {
+  const env = new Map();
+  if (!fs.existsSync(ENV_FILE)) return env;
+
+  const content = fs.readFileSync(ENV_FILE, 'utf8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    // Strip surrounding quotes from value
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    env.set(key, value);
+  }
+  return env;
+}
+
+/**
+ * Append environment entries to .env file.
+ * Skips keys that already exist (append-only, never overwrites).
+ *
+ * @param {Map<string, string> | Record<string, string>} entries - Key-value pairs to write
+ * @param {string} componentName - Used as section comment header
+ * @returns {{ written: string[], skipped: string[] }}
+ */
+export function writeEnvEntries(entries, componentName) {
+  const existing = readEnvFile();
+  const written = [];
+  const skipped = [];
+
+  const pairs = entries instanceof Map ? entries : new Map(Object.entries(entries));
+
+  const lines = [];
+  for (const [key, value] of pairs) {
+    if (existing.has(key)) {
+      skipped.push(key);
+      continue;
+    }
+    // Quote values that contain spaces or special characters
+    const needsQuote = /[\s#"'$`\\]/.test(value);
+    lines.push(`${key}=${needsQuote ? `"${value}"` : value}`);
+    written.push(key);
+  }
+
+  if (lines.length === 0) return { written, skipped };
+
+  // Build block to append
+  let block = '\n';
+  block += `# ${componentName}\n`;
+  block += lines.join('\n') + '\n';
+
+  // Ensure parent directory exists
+  fs.mkdirSync(path.dirname(ENV_FILE), { recursive: true });
+
+  fs.appendFileSync(ENV_FILE, block);
+
+  return { written, skipped };
+}

--- a/cli/lib/prompts.js
+++ b/cli/lib/prompts.js
@@ -1,0 +1,95 @@
+/**
+ * Shared interactive prompt utilities
+ */
+
+import readline from 'node:readline';
+
+/**
+ * Ask the user a question and return the trimmed answer.
+ * Returns empty string if stdin is not a TTY.
+ *
+ * @param {string} question - The question to display
+ * @returns {Promise<string>}
+ */
+export function prompt(question) {
+  if (!process.stdin.isTTY) return Promise.resolve('');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * Ask a yes/no question.
+ * Returns defaultYes if stdin is not a TTY or user presses Enter.
+ *
+ * @param {string} question - The question to display (include [Y/n] hint)
+ * @param {boolean} [defaultYes=false]
+ * @returns {Promise<boolean>}
+ */
+export function promptYesNo(question, defaultYes = false) {
+  if (!process.stdin.isTTY) return Promise.resolve(defaultYes);
+  return prompt(question).then((answer) => {
+    if (!answer) return defaultYes;
+    return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+  });
+}
+
+/**
+ * Prompt for sensitive input (masks with *).
+ * Returns empty string if stdin is not a TTY.
+ *
+ * @param {string} question - The question to display
+ * @returns {Promise<string>}
+ */
+export function promptSecret(question) {
+  if (!process.stdin.isTTY) return Promise.resolve('');
+
+  return new Promise((resolve) => {
+    process.stdout.write(question);
+
+    // Enable raw mode to capture each keypress
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+
+    let input = '';
+
+    const cleanup = () => {
+      process.stdin.setRawMode(false);
+      process.stdin.removeListener('data', onData);
+      process.stdout.write('\n');
+    };
+
+    const onData = (key) => {
+      const ch = key.toString();
+      // Ctrl-C
+      if (ch === '\u0003') {
+        cleanup();
+        resolve('');
+        return;
+      }
+      // Enter
+      if (ch === '\r' || ch === '\n') {
+        cleanup();
+        resolve(input);
+        return;
+      }
+      // Backspace
+      if (ch === '\u007F' || ch === '\b') {
+        if (input.length > 0) {
+          input = input.slice(0, -1);
+          process.stdout.write('\b \b');
+        }
+        return;
+      }
+      // Printable character
+      input += ch;
+      process.stdout.write('*');
+    };
+
+    process.stdin.on('data', onData);
+  });
+}

--- a/cli/lib/service.js
+++ b/cli/lib/service.js
@@ -1,0 +1,52 @@
+/**
+ * PM2 service management for components
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+/**
+ * Register and start a PM2 service for a component.
+ *
+ * @param {object} opts
+ * @param {string} opts.name - Service name (will be prefixed with "zylos-")
+ * @param {string} opts.entry - Entry script path (relative to skillDir)
+ * @param {string} opts.skillDir - Component's skill directory
+ * @param {'pm2'} opts.type - Service type (only pm2 supported for now)
+ * @returns {{ success: boolean, error?: string }}
+ */
+export function registerService({ name, entry, skillDir, type }) {
+  if (type !== 'pm2') {
+    return { success: false, error: `Unsupported service type: ${type}. Only "pm2" is supported.` };
+  }
+
+  const serviceName = `zylos-${name}`;
+  const scriptPath = path.resolve(skillDir, entry);
+
+  if (!fs.existsSync(scriptPath)) {
+    return { success: false, error: `Entry script not found: ${scriptPath}` };
+  }
+
+  try {
+    // Stop existing service if running (ignore errors)
+    try {
+      execSync(`pm2 delete "${serviceName}" 2>/dev/null`, { stdio: 'pipe' });
+    } catch {
+      // Not running — fine
+    }
+
+    // Start service
+    execSync(`pm2 start "${scriptPath}" --name "${serviceName}"`, {
+      stdio: 'pipe',
+      timeout: 30000,
+    });
+
+    // Save PM2 process list
+    execSync('pm2 save 2>/dev/null', { stdio: 'pipe' });
+
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: `Failed to start service: ${err.message}` };
+  }
+}

--- a/cli/lib/skill.js
+++ b/cli/lib/skill.js
@@ -1,0 +1,52 @@
+/**
+ * SKILL.md parser
+ *
+ * Extracts YAML frontmatter from SKILL.md files and detects component type.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+
+/**
+ * Parse SKILL.md from a component directory.
+ * Extracts YAML frontmatter (between --- delimiters) and returns parsed object.
+ *
+ * @param {string} dir - Component directory containing SKILL.md
+ * @returns {{ frontmatter: object, body: string } | null} null if no SKILL.md found
+ */
+export function parseSkillMd(dir) {
+  const skillPath = path.join(dir, 'SKILL.md');
+  if (!fs.existsSync(skillPath)) return null;
+
+  const content = fs.readFileSync(skillPath, 'utf8');
+
+  // Extract YAML frontmatter between --- delimiters
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    return { frontmatter: {}, body: content };
+  }
+
+  try {
+    const frontmatter = yaml.load(fmMatch[1]) || {};
+    const body = content.slice(fmMatch[0].length).trim();
+    return { frontmatter, body };
+  } catch (err) {
+    console.log(`Warning: Failed to parse SKILL.md frontmatter: ${err.message}`);
+    return { frontmatter: {}, body: content };
+  }
+}
+
+/**
+ * Detect the component type based on directory contents.
+ *
+ * - 'declarative': Has SKILL.md with frontmatter (self-contained install)
+ * - 'ai': No SKILL.md (needs Claude to read README and finish setup)
+ *
+ * @param {string} dir - Component directory
+ * @returns {'declarative' | 'ai'}
+ */
+export function detectComponentType(dir) {
+  const skillPath = path.join(dir, 'SKILL.md');
+  return fs.existsSync(skillPath) ? 'declarative' : 'ai';
+}

--- a/cli/zylos.js
+++ b/cli/zylos.js
@@ -6,7 +6,8 @@
  */
 
 import { showStatus, showLogs, startServices, stopServices, restartServices } from './commands/service.js';
-import { installComponent, upgradeComponent, uninstallComponent, listComponents, searchComponents } from './commands/component.js';
+import { upgradeComponent, uninstallComponent, listComponents, searchComponents } from './commands/component.js';
+import { addComponent } from './commands/add.js';
 import { initCommand } from './commands/init.js';
 
 const commands = {
@@ -19,7 +20,7 @@ const commands = {
   stop: stopServices,
   restart: restartServices,
   // Component management
-  install: installComponent,
+  add: addComponent,
   upgrade: upgradeComponent,
   uninstall: uninstallComponent,
   list: listComponents,
@@ -59,8 +60,9 @@ Service Management:
   restart             Restart all services
 
 Component Management:
-  install <target>    Install a component
+  add <target>        Add a component
                       target: name[@ver] | org/repo[@ver] | url
+                      --yes/-y  Skip confirmation prompts
   upgrade <name>      Upgrade a specific component
   upgrade --all       Upgrade all components
   upgrade --self      Upgrade zylos-core itself
@@ -76,9 +78,9 @@ Examples:
   zylos status
   zylos logs activity
 
-  zylos install telegram
-  zylos install telegram@0.2.0
-  zylos install kevin/whatsapp
+  zylos add telegram
+  zylos add telegram@0.2.0
+  zylos add user/my-component
   zylos upgrade telegram
   zylos upgrade --all
   zylos upgrade --self

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,490 @@
+{
+  "name": "zylos",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zylos",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^9.0.0",
+        "js-yaml": "^4.1.1"
+      },
+      "bin": {
+        "zylos": "cli/zylos.js"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=20.20.0"
   },
   "dependencies": {
-    "better-sqlite3": "^9.0.0"
+    "better-sqlite3": "^9.0.0",
+    "js-yaml": "^4.1.1"
   }
 }


### PR DESCRIPTION
## Summary

- Replace placeholder `installComponent` (which delegated to Claude via C4) with a self-contained `zylos add` command
- Declarative path (SKILL.md): download → npm install → config collection → post-install hook → PM2 service → components.json
- AI path (no SKILL.md): download → record in components.json → output task for Claude to finish setup
- Extract shared prompt utilities from init.js to eliminate duplication
- Add `.env` management (append-only, never overwrites existing keys)
- Add SKILL.md YAML frontmatter parser (js-yaml dependency)
- Add PM2 service registration module
- Add `downloadBranch()` for versionless installs

## New files (5)

| File | Purpose |
|------|---------|
| `cli/commands/add.js` | Main `zylos add` implementation |
| `cli/lib/prompts.js` | Shared `prompt()`, `promptYesNo()`, `promptSecret()` |
| `cli/lib/env.js` | `.env` read/write utilities |
| `cli/lib/skill.js` | SKILL.md YAML frontmatter parser |
| `cli/lib/service.js` | PM2 service registration |

## Modified files (6)

| File | Change |
|------|--------|
| `cli/zylos.js` | Register `add` command, update help text |
| `cli/commands/component.js` | Remove `installComponent`, use shared prompts |
| `cli/commands/init.js` | Use shared prompts from `prompts.js` |
| `cli/lib/config.js` | Add `ENV_FILE` constant |
| `cli/lib/download.js` | Add `downloadBranch()` |
| `package.json` | Add `js-yaml` dependency |

## Test plan

- [x] `node --check` all 10 new/modified files
- [x] `zylos help` shows `add` command
- [x] `zylos add` (no args) shows usage
- [x] `zylos install` removed (no alias)
- [ ] `zylos add telegram --yes` end-to-end test (needs registry component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)