### PR TITLE
feat: add IM mode to component-management skill

### DIFF
--- a/skills/component-management/SKILL.md
+++ b/skills/component-management/SKILL.md
@@ -208,7 +208,7 @@ When user sends component management requests via C4 comm-bridge (Telegram, Lark
 ### Detecting C4 Mode
 
 The request is from C4 when the message arrives via a communication channel
-(e.g., `howardzhou said: ...` with a `reply via:` instruction).
+(e.g., `<user> said: ...` with a `reply via:` instruction).
 
 ### C4 Command Mapping
 


### PR DESCRIPTION
## Summary
- Extend existing `skills/component-management/SKILL.md` with IM (Telegram/Lark) mode
- Add command mapping table, two-step upgrade confirm flow, output formatting rules
- No new files — just extends the existing skill

## Changes
One file modified: `skills/component-management/SKILL.md` (v1.0.0 → v1.1.0)

Added sections:
- **IM Command Mapping** — maps IM messages to `zylos` CLI commands with `--json`
- **Upgrade Confirm Flow** — stateless two-step pattern (design doc Section 5.2)
- **Output Formatting** — plain text rules for IM replies
- **IM vs Session Differences** — comparison table

## Test plan
- [ ] Send "list" via Telegram → Claude runs `zylos list` → sends result
- [ ] Send "upgrade telegram" → Claude shows preview + confirm prompt
- [ ] Send "upgrade telegram confirm" → Claude executes upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)