### PR TITLE
fix: changelog filter + service startup after upgrade

### DIFF
--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -202,7 +202,7 @@ async function handleUpgradeFlow(component, { jsonOutput, skipConfirm, skipEval 
     // 4. Show info: version diff, changelog, local changes + Claude eval
     const changes = detectChanges(skillDir);
     const fullChangelog = readChangelog(tempDir);
-    const changelog = filterChangelog(fullChangelog, check.current) || fullChangelog;
+    const changelog = filterChangelog(fullChangelog, check.current);
     let evalResult = null;
 
     if (!jsonOutput) {
@@ -487,7 +487,7 @@ async function upgradeSelfCore() {
       console.log(`\nzylos-core: ${check.current} → ${check.latest}`);
 
       const fullCoreChangelog = readCoreChangelog(tempDir);
-      const coreChangelog = filterChangelog(fullCoreChangelog, check.current) || fullCoreChangelog;
+      const coreChangelog = filterChangelog(fullCoreChangelog, check.current);
       if (coreChangelog) {
         console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);
         console.log('CHANGELOG');


### PR DESCRIPTION
## Summary
Two bugs found during testing on zylos0:

### 1. Changelog filter shows full text when no newer entries
- **Bug**: When upgrading beta.9→beta.10 and the changelog has no entry for beta.10, `filterChangelog` returned the full changelog (all versions back to beta.1)
- **Root cause**: `foundAny` was only set when finding headers NEWER than fromVersion. When fromVersion was the first header, `foundAny` stayed false → returned full text as fallback
- **Fix**: Renamed to `foundHeaders` which tracks whether ANY parseable `## [version]` header was found. If headers exist but nothing is newer than fromVersion, returns null (no new changelog)
- Also removed `|| fullChangelog` fallback in component.js — if filter returns null, the CHANGELOG section is simply not shown

### 2. Service not starting after upgrade
- **Bug**: After upgrade, step 8 only restarted the service if it was already running. When PM2 had no registered service (e.g., PM2 process was deleted), the service was never started
- **Fix**: Step 8 now reads `lifecycle.service` from SKILL.md and handles three cases:
  - Was running → restart (existing behavior)
  - Was stopped but registered → leave stopped (respect user intent)
  - Not registered + SKILL.md declares service → start fresh using `ecosystem.config.cjs` or entry point
- Also: service name now consistently read from SKILL.md in step2, step8, and rollback

### Bonus: version not bumped in beta.10
- The tag `v0.1.0-beta.10` has SKILL.md still showing `version: 0.1.0-beta.9` — needs a new release with bumped version

## Test plan
- [x] Syntax check on all modified files
- [x] Changelog filter: fromVersion is first header → returns null
- [x] Changelog filter: fromVersion in middle → returns only newer entries
- [x] Changelog filter: fromVersion not found → returns full text (can't determine cutoff)
- [x] Changelog filter: no parseable headers → returns full text
- [ ] End-to-end: `zylos upgrade telegram` on zylos0

🤖 Generated with [Claude Code](https://claude.com/claude-code)