### PR TITLE
fix(upgrade): add Claude eval to --check mode

### DIFF
--- a/skills/component-management/SKILL.md
+++ b/skills/component-management/SKILL.md
@@ -244,7 +244,7 @@ Local changes: none
 Reply "upgrade telegram confirm" to proceed.
 ```
 
-If there are local modifications, show them:
+If there are local modifications, show them with Claude's analysis:
 ```
 telegram: 0.1.0 -> 0.2.0
 
@@ -255,8 +255,16 @@ WARNING: Local modifications detected:
   M src/bot.js
   A custom-plugin.js
 
+Upgrade analysis:
+  src/bot.js: safe - changes are in config section, upgrade won't overwrite
+  custom-plugin.js: safe - new file, preserved by lifecycle.preserve
+
+Recommendation: Safe to upgrade.
+
 Reply "upgrade telegram confirm" to proceed.
 ```
+
+The `evaluation` field in JSON contains `files` (array of `{file, verdict, reason}`) and `recommendation`.
 
 **Step 2 — User confirms:**
 
@@ -273,7 +281,7 @@ When formatting `--json` output for C4 replies:
 
 - Plain text only, no markdown
 - For `info --json`: format as `<name> v<version>\nType: <type>\nRepo: <repo>\nService: <name> (<status>)`
-- For `check --json`: format as `<name>: <current> -> <latest>`, include `changelog` field if present, warn about `localChanges` if present
+- For `check --json`: format as `<name>: <current> -> <latest>`, include `changelog` field if present, warn about `localChanges` if present, show `evaluation` analysis if present
 - For errors: when JSON has both `error` and `message` fields, display `message` (human-readable)
 - Send reply via the appropriate channel's send script
 


### PR DESCRIPTION
## Summary
- When `--check` detects local modifications, downloads the new version to temp and runs Claude eval
- Evaluation result (per-file verdict + recommendation) included in both JSON and text output
- IM users now get complete upgrade preview: version diff, changelog, local changes, and safety analysis
- Updated component-management SKILL.md with C4 formatting examples

## Test plan
- [ ] `zylos upgrade telegram --check` with no local changes (should skip eval)
- [ ] `zylos upgrade telegram --check` with local changes (should show eval)
- [ ] `zylos upgrade telegram --check --json` verify JSON includes `evaluation` field
- [ ] IM flow: "upgrade telegram" via Telegram shows full preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)