### PR TITLE
fix(template): quote channel and endpoint in reply-via example

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -25,7 +25,7 @@ All external communication goes through C4 Communication Bridge.
 
 When you receive a message like:
 ```
-[TG DM] user said: hello ---- reply via: ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js telegram 12345
+[TG DM] user said: hello ---- reply via: ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "telegram" "12345"
 ```
 
 Reply using the exact path specified in `reply via:`.


### PR DESCRIPTION
## Summary
- Quote channel and endpoint in `templates/CLAUDE.md` reply-via example to match new c4-send.js interface

## Change
```
OLD: reply via: .../c4-send.js telegram 12345
NEW: reply via: .../c4-send.js "telegram" "12345"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)