### PR TITLE
chore: bump version to 0.1.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.5] - 2026-02-07
+
+### Changed
+- Version bump for self-upgrade flow testing
+
+---
+
 ## [0.1.0-beta.4] - 2026-02-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary

- Version bump to `0.1.0-beta.5` for self-upgrade flow testing on zylos0

## Test plan

- [ ] On zylos0 (after manual install of beta.4): `zylos upgrade --self` should detect beta.5, show CHANGELOG, detect services, and upgrade successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)