### PR TITLE
fix(upgrade): show step progress in real time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.6] - 2026-02-07
+
+### Changed
+- Upgrade steps now display in real time (both self-upgrade and component upgrade)
+
+---
+
 ## [0.1.0-beta.5] - 2026-02-07
 
 ### Changed

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -538,10 +538,10 @@ function rollbackSelf(ctx) {
  * Run the 8-step self-upgrade pipeline.
  * Lock must be acquired by caller.
  *
- * @param {{ tempDir: string, newVersion: string }} opts
+ * @param {{ tempDir: string, newVersion: string, onStep?: function }} opts
  * @returns {object} Upgrade result
  */
-export function runSelfUpgrade({ tempDir, newVersion } = {}) {
+export function runSelfUpgrade({ tempDir, newVersion, onStep } = {}) {
   const ctx = createContext({ tempDir, newVersion });
 
   const current = getCurrentVersion();
@@ -566,6 +566,7 @@ export function runSelfUpgrade({ tempDir, newVersion } = {}) {
   for (const stepFn of steps) {
     const result = stepFn(ctx);
     ctx.steps.push(result);
+    if (onStep) onStep(result);
 
     if (result.status === 'failed') {
       failedStep = result;

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -573,7 +573,7 @@ export function rollback(ctx) {
  * @param {{ tempDir: string, newVersion: string }} opts
  * @returns {object} Upgrade result
  */
-export function runUpgrade(component, { tempDir, newVersion } = {}) {
+export function runUpgrade(component, { tempDir, newVersion, onStep } = {}) {
   const ctx = createContext(component, { tempDir, newVersion });
 
   if (!fs.existsSync(ctx.skillDir)) {
@@ -609,6 +609,7 @@ export function runUpgrade(component, { tempDir, newVersion } = {}) {
   for (const stepFn of steps) {
     const result = stepFn(ctx);
     ctx.steps.push(result);
+    if (onStep) onStep(result);
 
     if (result.status === 'failed') {
       failedStep = result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.5",
+  "version": "0.1.0-beta.6",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary

- Add `onStep` callback to `runSelfUpgrade()` and `runUpgrade()` pipelines
- Each step now prints immediately as it completes, instead of buffering all output until the end
- Extract `printStep()` helper for consistent step formatting
- Bump version to `0.1.0-beta.6`

## Before

```
Proceed with zylos-core upgrade? [y/N]: y
(... silence for ~30 seconds ...)
  [1/8] backup_core_skills ✓
  [2/8] pre_upgrade_hook ○
  ...all 8 steps at once...
```

## After

```
Proceed with zylos-core upgrade? [y/N]: y
  [1/8] backup_core_skills ✓
  (appears immediately)
  [2/8] pre_upgrade_hook ○
  (appears immediately)
  [3/8] stop_core_services (scheduler, ...) ✓
  (appears as each step finishes)
  ...
```

## Test plan

- [ ] `zylos upgrade --self` — steps should appear one by one in real time
- [ ] `zylos upgrade telegram` — same real-time behavior
- [ ] `zylos upgrade --self --json` — JSON output unchanged (single blob)

🤖 Generated with [Claude Code](https://claude.com/claude-code)