### PR TITLE
chore: bump version to 0.1.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.7] - 2026-02-07
+
+### Changed
+- Version bump for real-time progress testing
+
+---
+
 ## [0.1.0-beta.6] - 2026-02-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.6",
+  "version": "0.1.0-beta.7",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary

- Version bump to `0.1.0-beta.7` for real-time progress testing on zylos0

## Test plan

- [ ] `zylos upgrade --self` from beta.6 → beta.7: steps should appear one by one in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)