### PR TITLE
fix(skill): clarify zylos CLI path and enforce changelog display

### DIFF
--- a/skills/component-management/SKILL.md
+++ b/skills/component-management/SKILL.md
@@ -7,6 +7,11 @@ description: Guidelines for managing zylos components via CLI and C4 channels.
 
 Guidelines for installing, upgrading, and managing zylos components.
 
+## CLI
+
+`zylos` is a **global npm command** (installed via `npm install -g zylos`).
+Run it directly as `zylos`, NOT as `~/zylos/zylos` or `./zylos`.
+
 ## General Principles
 
 1. **Always confirm before executing** - User must explicitly approve install/upgrade/uninstall
@@ -233,13 +238,22 @@ Upgrades use two-step confirmation. No state is stored between messages.
 
 User: `upgrade telegram`
 
-Run `zylos upgrade telegram --check --json`, format the JSON, and reply:
+Run `zylos upgrade telegram --check --json`, parse the JSON output, and reply with ALL of the following:
 
+1. Version change: `<name>: <current> -> <latest>`
+2. Changelog: MUST include the full changelog from the JSON output
+3. Local changes: show if any, or "none"
+4. Confirm instruction
+
+**You MUST show the changelog. Do NOT just show version numbers and ask to confirm.**
+
+Example reply:
 ```
 telegram: 0.1.0 -> 0.2.0
 
 Changelog:
 - Fixed dotenv path issue
+- Added admin CLI
 
 Local changes: none
 


### PR DESCRIPTION
## Summary
- Added CLI section clarifying `zylos` is a global npm command (not `~/zylos/zylos`)
- Made C4 upgrade step 1 more explicit: MUST show changelog, not just version numbers

Fixes two issues observed during zylos0 testing:
1. Claude tried `~/zylos/zylos` instead of global `zylos` command
2. Upgrade response only showed "0.1.0-beta.2 → 0.1.0-beta.3" without changelog

## Test plan
- [ ] Ask Claude to upgrade a component via Lark/TG — should show full changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)