### PR TITLE
fix: include changelog in component upgrade JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.11] - 2026-02-08
+
+### Fixed
+- Component upgrade JSON output now includes changelog (was only included in self-upgrade)
+
+---
+
 ## [0.1.0-beta.10] - 2026-02-08
 
 ### Added

--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -380,6 +380,7 @@ async function handleUpgradeFlow(component, { jsonOutput, skipConfirm, skipEval 
     // Output result
     if (jsonOutput) {
       const output = { ...result };
+      if (changelog) output.changelog = changelog;
       if (evalResult) output.evaluation = evalResult;
       console.log(JSON.stringify(output, null, 2));
     } else if (result.success) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Component upgrade JSON output now includes `changelog` field (filtered to relevant versions)
- Self-upgrade already had this (`coreChangelog` at line 699), component upgrade was missing it
- Enables Claude to report actual changes to users instead of just "8 steps passed"

One-line change in `cli/commands/component.js`.

## Test plan
- [ ] Run `zylos upgrade <component> --yes --json` and verify `changelog` field in output
- [ ] Verify self-upgrade still includes changelog (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)