### PR TITLE
feat(c4): add reply field to JSON outputs for SKILL.md-independent formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.13] - 2026-02-08
+
+### Added
+- `reply` field in all `--json` outputs: pre-formatted C4 reply that Claude can use directly
+- `formatC4Reply()` function centralizes C4 reply formatting in CLI (decouples from SKILL.md)
+- Changelog now included in plain text upgrade success output (backward compatibility)
+
+### Changed
+- C4 reply formatting moved from SKILL.md instructions to CLI-generated `reply` field
+- SKILL.md: added "C4 Reply Formatting" section documenting `reply` field usage
+
+---
+
 ## [0.1.0-beta.12] - 2026-02-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",

--- a/skills/component-management/SKILL.md
+++ b/skills/component-management/SKILL.md
@@ -215,6 +215,12 @@ When user sends component management requests via C4 comm-bridge (Telegram, Lark
 The request is from C4 when the message arrives via a communication channel
 (e.g., `<user> said: ...` with a `reply via:` instruction).
 
+### C4 Reply Formatting
+
+**All `--json` outputs include a `reply` field with a pre-formatted plain text reply.**
+**When the JSON output has a `reply` field, use it directly as the C4 reply.**
+This ensures the reply format is always correct regardless of SKILL.md version.
+
 ### C4 Command Mapping
 
 **CRITICAL: "upgrade \<name\>" MUST ONLY run --check. NEVER execute the actual upgrade without the word "confirm" in the user's message.**
@@ -334,7 +340,7 @@ Run `zylos upgrade --self --yes --json`, parse the JSON output, and reply with t
 
 ### C4 Output Formatting
 
-When formatting `--json` output for C4 replies:
+**NOTE: As of v0.1.0-beta.13, use the `reply` field from JSON output directly (see "C4 Reply Formatting" above). The rules below are kept as fallback reference only.**
 
 - Plain text only, no markdown
 - For `info --json`: format as `<name> v<version>\nType: <type>\nRepo: <repo>\nService: <name> (<status>)`


### PR DESCRIPTION
## Summary
- Add `reply` field to all `--json` outputs with pre-formatted C4 reply
- Add `formatC4Reply()` function centralizing reply formatting in CLI
- Add changelog to plain text upgrade success output (backward compat)
- Add "C4 Reply Formatting" section to SKILL.md

## Problem
After `zylos upgrade --self`, the SKILL.md on disk is updated but the running Claude session still uses the old version. This caused upgrade completion messages to be generic ("8步全部通过") instead of including changelog.

## Solution
Move C4 reply formatting from SKILL.md instructions to CLI-generated `reply` field. Since the CLI always runs the latest version, the reply is always correctly formatted regardless of SKILL.md version.

SKILL.md now only needs one stable instruction: "if JSON has `reply`, use it as the response."

## Test plan
- [ ] `zylos upgrade telegram --check --json` — verify `reply` field in output
- [ ] `zylos upgrade telegram --yes --skip-eval --json` — verify `reply` includes changelog
- [ ] `zylos upgrade --self --check --json` — verify `reply` field
- [ ] `zylos info telegram --json` — verify `reply` field
- [ ] Plain text mode: `zylos upgrade telegram --yes` — verify changelog in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)