### PR TITLE
feat(c4): enable uninstall via C4 with two-step confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.14] - 2026-02-08
+
+### Added
+- C4 uninstall support: two-step confirmation flow (preview + confirm)
+- `zylos uninstall --check --json` for previewing what will be removed
+- `zylos uninstall --json` for structured uninstall output with `reply` field
+- `formatC4Reply` cases: `uninstall-check` and `uninstall`
+
+### Changed
+- SKILL.md: uninstall no longer rejected in C4 mode, uses two-step confirm like upgrades
+- C4 uninstall keeps data directory by default (no `--purge` via C4)
+
+---
+
 ## [0.1.0-beta.13] - 2026-02-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",

--- a/skills/component-management/SKILL.md
+++ b/skills/component-management/SKILL.md
@@ -236,7 +236,8 @@ This ensures the reply format is always correct regardless of SKILL.md version.
 | add \<name\> | `zylos add <name> --yes` |
 | upgrade zylos | `zylos upgrade --self --check --json` **(CHECK ONLY)** |
 | upgrade zylos confirm | `zylos upgrade --self --yes --json` **(only this executes)** |
-| remove / uninstall | Reject — reply: "Remove is not supported via C4. Use CLI directly." |
+| uninstall \<name\> / remove \<name\> | `zylos uninstall <name> --check --json` **(CHECK ONLY — preview what will be removed)** |
+| uninstall \<name\> confirm | `zylos uninstall <name> --yes --json` **(only this executes the uninstall)** |
 
 ### C4 Upgrade Confirm Flow
 
@@ -338,6 +339,24 @@ User: `upgrade zylos confirm`
 
 Run `zylos upgrade --self --yes --json`, parse the JSON output, and reply with the version change and changelog (same format as component upgrade completion).
 
+### C4 Uninstall Confirm Flow
+
+Same two-step pattern as upgrades.
+
+**Step 1 — User requests uninstall:**
+
+User: `uninstall lark` or `remove lark`
+
+Run `zylos uninstall lark --check --json`, parse the JSON output, and use the `reply` field.
+
+**Step 2 — User confirms:**
+
+User: `uninstall lark confirm`
+
+Run `zylos uninstall lark --yes --json`, parse the JSON output, and use the `reply` field.
+
+C4 uninstall always keeps the data directory (no `--purge`). User can purge via CLI if needed.
+
 ### C4 Output Formatting
 
 **NOTE: As of v0.1.0-beta.13, use the `reply` field from JSON output directly (see "C4 Reply Formatting" above). The rules below are kept as fallback reference only.**
@@ -357,5 +376,5 @@ Run `zylos upgrade --self --yes --json`, parse the JSON output, and reply with t
 | Confirmation | Interactive dialog | Two-step: preview + "confirm" command |
 | Output format | Rich (emoji, formatting) | Plain text only |
 | Config collection | Interactive prompts | Skip (use --yes), configure later |
-| Remove/uninstall | Supported | Rejected (too dangerous) |
+| Remove/uninstall | Supported (with data options) | Two-step confirm, keeps data |
 | Upgrade eval | Claude evaluation runs | Skipped (--skip-eval) |


### PR DESCRIPTION
## Summary
- Enable C4 uninstall support (previously rejected as "too dangerous")
- Two-step confirmation flow: `uninstall <name>` → preview, `uninstall <name> confirm` → execute
- `formatC4Reply` handles `uninstall-check` and `uninstall` cases with pre-formatted replies
- Block uninstall when component has dependents (no `--force` via C4)
- C4 uninstall always keeps data directory (no `--purge` via C4)
- SKILL.md updated with uninstall command mapping and flow documentation

## Test plan
- [ ] `zylos uninstall lark --check --json` returns preview with reply field
- [ ] `zylos uninstall lark --yes --json` executes and returns steps with reply field
- [ ] Dependent blocking: check shows "Cannot uninstall" when dependents exist
- [ ] SKILL.md C4 command mapping matches code behavior
- [ ] Plain text (non-JSON) uninstall flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)