### PR TITLE
fix: preserve trailing slash + registerService ecosystem support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.16] - 2026-02-08
+
+### Fixed
+- Preserve list trailing slash bug: `data/` in SKILL.md now correctly matches `data` during upgrades
+- `syncTree` delete phase also normalizes trailing slashes before comparison
+
+### Changed
+- `registerService()` now uses `ecosystem.config.cjs` when available instead of plain `pm2 start`
+
+---
+
 ## [0.1.0-beta.15] - 2026-02-08
 
 ### Changed

--- a/cli/lib/fs-utils.js
+++ b/cli/lib/fs-utils.js
@@ -18,7 +18,7 @@ import os from 'node:os';
 function isExcluded(relativePath, excludes) {
   if (!relativePath || !excludes.length) return false;
   const topLevel = relativePath.split(path.sep)[0];
-  return excludes.includes(topLevel);
+  return excludes.some(e => e.replace(/\/+$/, '') === topLevel);
 }
 
 /**
@@ -88,8 +88,9 @@ export function syncTree(src, dest, { excludes = [] } = {}) {
   fs.mkdirSync(dest, { recursive: true });
 
   // Remove non-excluded entries in dest (equivalent to rsync --delete)
+  const normalized = excludes.map(e => e.replace(/\/+$/, ''));
   for (const entry of fs.readdirSync(dest)) {
-    if (excludes.includes(entry)) continue;
+    if (normalized.includes(entry)) continue;
     fs.rmSync(path.join(dest, entry), { recursive: true, force: true });
   }
 

--- a/cli/lib/service.js
+++ b/cli/lib/service.js
@@ -36,11 +36,19 @@ export function registerService({ name, entry, skillDir, type }) {
       // Not running — fine
     }
 
-    // Start service
-    execSync(`pm2 start "${scriptPath}" --name "${serviceName}"`, {
-      stdio: 'pipe',
-      timeout: 30000,
-    });
+    // Start service — prefer ecosystem.config.cjs if available
+    const ecosystemPath = path.join(skillDir, 'ecosystem.config.cjs');
+    if (fs.existsSync(ecosystemPath)) {
+      execSync(`pm2 start "${ecosystemPath}"`, {
+        stdio: 'pipe',
+        timeout: 30000,
+      });
+    } else {
+      execSync(`pm2 start "${scriptPath}" --name "${serviceName}"`, {
+        stdio: 'pipe',
+        timeout: 30000,
+      });
+    }
 
     // Save PM2 process list
     execSync('pm2 save 2>/dev/null', { stdio: 'pipe' });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- **isExcluded()**: strip trailing slashes before comparing — `data/` in SKILL.md preserve list now correctly matches `data` directory during upgrades
- **syncTree()**: normalize excludes before delete phase (same trailing slash fix)
- **registerService()**: use `ecosystem.config.cjs` when available instead of plain `pm2 start script.js`

## Context
Template compatibility check found that preserve lists with trailing slashes (e.g., `data/`) were silently failing — data directories were NOT being protected during upgrades. This affected all components (telegram, lark, template).

Also found that `registerService()` was overwriting PM2 ecosystem configs set up by post-install hooks, losing env vars, log paths, etc.

## Test plan
- [ ] Upgrade a component with `data/` in preserve list — verify data dir is kept
- [ ] Install a component with ecosystem.config.cjs — verify PM2 uses it
- [ ] Install a component without ecosystem.config.cjs — verify fallback to simple pm2 start

🤖 Generated with [Claude Code](https://claude.com/claude-code)