### PR TITLE
feat(self-upgrade): sync project settings + auto-restart Claude

### DIFF
--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -7,7 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import { SKILLS_DIR, ZYLOS_DIR } from './config.js';
 import { downloadArchive, downloadBranch } from './download.js';
 import { generateManifest, loadManifest, saveManifest } from './manifest.js';
@@ -342,7 +342,32 @@ function syncClaudeMd(templateDir) {
 }
 
 // ---------------------------------------------------------------------------
-// 9-step self-upgrade pipeline
+// Template helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively copy files from src to dest, only creating files that don't exist.
+ * Never overwrites existing files (preserves user modifications).
+ * @returns {number} Number of files added
+ */
+function copyMissingTree(src, dest) {
+  let added = 0;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      added += copyMissingTree(srcPath, destPath);
+    } else if (!fs.existsSync(destPath)) {
+      fs.copyFileSync(srcPath, destPath);
+      added++;
+    }
+  }
+  return added;
+}
+
+// ---------------------------------------------------------------------------
+// 11-step self-upgrade pipeline
 // ---------------------------------------------------------------------------
 
 /**
@@ -388,6 +413,12 @@ function step1_backupCoreSkills(ctx) {
     const claudeMdPath = path.join(ZYLOS_DIR, 'CLAUDE.md');
     if (fs.existsSync(claudeMdPath)) {
       fs.copyFileSync(claudeMdPath, path.join(backupDir, 'CLAUDE.md'));
+    }
+
+    // Backup .claude/ project settings (will be modified in step 7)
+    const claudeSettingsDir = path.join(ZYLOS_DIR, '.claude');
+    if (fs.existsSync(claudeSettingsDir)) {
+      copyTree(claudeSettingsDir, path.join(backupDir, '.claude'));
     }
 
     ctx.backupDir = backupDir;
@@ -557,22 +588,45 @@ function step6_syncClaudeMd(ctx) {
 }
 
 /**
- * Step 7: post-upgrade hook (placeholder for future use)
+ * Step 7: sync project settings (templates/.claude/ → ~/zylos/.claude/)
+ * Copies missing files only — never overwrites user modifications.
  */
-function step7_postUpgradeHook(ctx) {
+function step7_syncProjectSettings(ctx) {
   const startTime = Date.now();
-  // No core post-upgrade hook yet — reserved for future
-  return { step: 7, name: 'post_upgrade_hook', status: 'skipped', duration: Date.now() - startTime };
+
+  const settingsSrc = path.join(ctx.tempDir, 'templates', '.claude');
+  if (!fs.existsSync(settingsSrc)) {
+    return { step: 7, name: 'sync_project_settings', status: 'skipped', message: 'no .claude/ in templates', duration: Date.now() - startTime };
+  }
+
+  try {
+    const settingsDest = path.join(ZYLOS_DIR, '.claude');
+    const added = copyMissingTree(settingsSrc, settingsDest);
+    const msg = added > 0 ? `${added} file(s) added` : 'no changes';
+    return { step: 7, name: 'sync_project_settings', status: 'done', message: msg, duration: Date.now() - startTime };
+  } catch (err) {
+    // Non-fatal — settings sync failure shouldn't block the upgrade
+    return { step: 7, name: 'sync_project_settings', status: 'skipped', message: err.message, duration: Date.now() - startTime };
+  }
 }
 
 /**
- * Step 8: start core services
+ * Step 8: post-upgrade hook (placeholder for future use)
  */
-function step8_startCoreServices(ctx) {
+function step8_postUpgradeHook(ctx) {
+  const startTime = Date.now();
+  // No core post-upgrade hook yet — reserved for future
+  return { step: 8, name: 'post_upgrade_hook', status: 'skipped', duration: Date.now() - startTime };
+}
+
+/**
+ * Step 9: start core services
+ */
+function step9_startCoreServices(ctx) {
   const startTime = Date.now();
 
   if (ctx.servicesWereRunning.length === 0) {
-    return { step: 8, name: 'start_core_services', status: 'skipped', message: 'no services to restart', duration: Date.now() - startTime };
+    return { step: 9, name: 'start_core_services', status: 'skipped', message: 'no services to restart', duration: Date.now() - startTime };
   }
 
   const started = [];
@@ -588,20 +642,20 @@ function step8_startCoreServices(ctx) {
   }
 
   if (failed.length > 0) {
-    return { step: 8, name: 'start_core_services', status: 'failed', error: `Failed to restart: ${failed.join(', ')}`, duration: Date.now() - startTime };
+    return { step: 9, name: 'start_core_services', status: 'failed', error: `Failed to restart: ${failed.join(', ')}`, duration: Date.now() - startTime };
   }
 
-  return { step: 8, name: 'start_core_services', status: 'done', message: started.join(', '), duration: Date.now() - startTime };
+  return { step: 9, name: 'start_core_services', status: 'done', message: started.join(', '), duration: Date.now() - startTime };
 }
 
 /**
- * Step 9: verify services
+ * Step 10: verify services
  */
-function step9_verifyServices(ctx) {
+function step10_verifyServices(ctx) {
   const startTime = Date.now();
 
   if (ctx.servicesWereRunning.length === 0) {
-    return { step: 9, name: 'verify_services', status: 'skipped', message: 'no services to verify', duration: Date.now() - startTime };
+    return { step: 10, name: 'verify_services', status: 'skipped', message: 'no services to verify', duration: Date.now() - startTime };
   }
 
   // Brief wait for services to start
@@ -621,12 +675,39 @@ function step9_verifyServices(ctx) {
     }
 
     if (notOnline.length > 0) {
-      return { step: 9, name: 'verify_services', status: 'failed', error: `Not online: ${notOnline.join(', ')}`, duration: Date.now() - startTime };
+      return { step: 10, name: 'verify_services', status: 'failed', error: `Not online: ${notOnline.join(', ')}`, duration: Date.now() - startTime };
     }
 
-    return { step: 9, name: 'verify_services', status: 'done', duration: Date.now() - startTime };
+    return { step: 10, name: 'verify_services', status: 'done', duration: Date.now() - startTime };
   } catch (err) {
-    return { step: 9, name: 'verify_services', status: 'failed', error: err.message, duration: Date.now() - startTime };
+    return { step: 10, name: 'verify_services', status: 'failed', error: err.message, duration: Date.now() - startTime };
+  }
+}
+
+/**
+ * Step 11: schedule Claude restart to load new skills/hooks
+ * Spawns restart-claude in background (detached).
+ * It waits for Claude to be idle, then sends /exit.
+ * activity-monitor restarts Claude, which triggers SessionStart hooks.
+ */
+function step11_scheduleRestart(ctx) {
+  const startTime = Date.now();
+
+  const restartScript = path.join(SKILLS_DIR, 'restart-claude', 'scripts', 'restart.js');
+  if (!fs.existsSync(restartScript)) {
+    return { step: 11, name: 'schedule_restart', status: 'skipped', message: 'restart-claude skill not found', duration: Date.now() - startTime };
+  }
+
+  try {
+    const child = spawn('node', [restartScript], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    return { step: 11, name: 'schedule_restart', status: 'done', message: 'restart scheduled (background)', duration: Date.now() - startTime };
+  } catch (err) {
+    // Non-fatal — manual restart is always an option
+    return { step: 11, name: 'schedule_restart', status: 'skipped', message: err.message, duration: Date.now() - startTime };
   }
 }
 
@@ -663,6 +744,16 @@ function rollbackSelf(ctx) {
     }
   }
 
+  // Restore .claude/ project settings from backup
+  if (ctx.backupDir && fs.existsSync(path.join(ctx.backupDir, '.claude'))) {
+    try {
+      syncTree(path.join(ctx.backupDir, '.claude'), path.join(ZYLOS_DIR, '.claude'));
+      results.push({ action: 'restore_project_settings', success: true });
+    } catch (err) {
+      results.push({ action: 'restore_project_settings', success: false, error: err.message });
+    }
+  }
+
   // Restart services if they were running
   for (const name of ctx.servicesWereRunning) {
     try {
@@ -681,7 +772,7 @@ function rollbackSelf(ctx) {
 // ---------------------------------------------------------------------------
 
 /**
- * Run the 9-step self-upgrade pipeline.
+ * Run the 11-step self-upgrade pipeline.
  * Lock must be acquired by caller.
  *
  * @param {{ tempDir: string, newVersion: string, onStep?: function }} opts
@@ -703,9 +794,11 @@ export function runSelfUpgrade({ tempDir, newVersion, onStep } = {}) {
     step4_npmInstallGlobal,
     step5_syncCoreSkills,
     step6_syncClaudeMd,
-    step7_postUpgradeHook,
-    step8_startCoreServices,
-    step9_verifyServices,
+    step7_syncProjectSettings,
+    step8_postUpgradeHook,
+    step9_startCoreServices,
+    step10_verifyServices,
+    step11_scheduleRestart,
   ];
 
   const total = steps.length;


### PR DESCRIPTION
## Summary
- Add Step 7: sync `templates/.claude/` (settings.json with hooks) to `~/zylos/.claude/` during self-upgrade — fixes gap where SessionStart hooks were only deployed during `zylos init`
- Add Step 11: spawn `restart-claude` skill in background after successful upgrade — Claude restarts when idle to load new skills/hooks
- Backup + rollback support for `.claude/` project settings

## Pipeline (9 → 11 steps)
| Step | Name | New? |
|------|------|------|
| 1 | Backup core skills + CLAUDE.md + .claude/ | Updated |
| 2 | Pre-upgrade hook | - |
| 3 | Stop core services | - |
| 4 | npm install -g | - |
| 5 | Sync core skills | - |
| 6 | Sync CLAUDE.md | - |
| **7** | **Sync project settings (.claude/)** | **New** |
| 8 | Post-upgrade hook | Renumbered |
| 9 | Start core services | Renumbered |
| 10 | Verify services | Renumbered |
| **11** | **Schedule Claude restart** | **New** |

## Test plan
- [ ] Verify `copyMissingTree` only creates missing files, never overwrites
- [ ] Verify Step 7 deploys settings.json on fresh upgrade (no existing .claude/)
- [ ] Verify Step 7 skips when settings.json already exists
- [ ] Verify Step 11 spawns restart-claude in detached mode
- [ ] Verify rollback restores .claude/ from backup on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)