### PR TITLE
feat(skill): require active change analysis for upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.19] - 2026-02-09
+
+### Changed
+- **Upgrade change analysis**: Claude now always actively analyzes changes between versions using commit history + changelog, instead of passively relaying changelog text
+- SKILL.md upgrade flows (session + C4) updated to require synthesized change summaries
+- Applies to both component upgrades and zylos-core self-upgrades
+
+---
+
 ## [0.1.0-beta.18] - 2026-02-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Claude now always actively analyzes what changed between versions using commit history + changelog, instead of passively relaying changelog text
- Updated all upgrade flows (session + C4 modes) in component-management SKILL.md to require synthesized change summaries
- Applies to both component upgrades and zylos-core self-upgrades
- Bump to v0.1.0-beta.19

## Context
When Hongyun tested `upgrade lark` on zylos0, the response only showed version numbers without explaining what changed (because changelog was missing). This led to the design insight: Claude should **always** actively analyze changes using commits/diffs, with changelog as one supplementary input — not the sole source. Even when changelog exists, Claude should synthesize and explain, not just copy text.

## Test plan
- [ ] Test `upgrade <component>` via C4 — verify Claude fetches commit history and synthesizes change summary
- [ ] Test `upgrade zylos` via C4 — same pattern for self-upgrade
- [ ] Test with component that has no CHANGELOG.md — Claude should still analyze via commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)