### PR TITLE
feat(upgrade): download at check time + --temp-dir reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.20] - 2026-02-09
+
+### Changed
+- **Download at check time**: `upgrade --check` now downloads new version to temp dir, enabling Claude to compare files before user confirms
+- **`--temp-dir` flag**: `upgrade --yes --temp-dir <dir>` reuses previously downloaded package, avoiding duplicate downloads
+- **SKILL.md upgrade flow redesign**: All info (changes + file diffs) presented before confirmation; pure execution after
+- Applies to both component upgrades and zylos-core self-upgrades
+
+---
+
 ## [0.1.0-beta.19] - 2026-02-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- upgrade --check now always downloads new version to temp dir, enabling Claude to compare files before user confirms
- upgrade --yes supports --temp-dir flag to reuse previously downloaded package
- Both component and self-upgrade flows updated consistently
- SKILL.md redesigned: all info presented before confirmation; pure execution after
- Bump to v0.1.0-beta.20

## Changes
- cli/commands/component.js: handleCheckOnly/handleSelfCheckOnly download to temp; handleUpgradeFlow/upgradeSelfCore accept providedTempDir
- skills/component-management/SKILL.md: Session + C4 flows restructured
- package.json: v0.1.0-beta.20
- CHANGELOG.md: Added beta.20 entry

Design ref: https://zylos10.jinglever.com/upgrade-flow-review.md