### PR TITLE
feat(bin): support SKILL.md bin field for component CLI commands

### DIFF
--- a/cli/lib/__tests__/bin.test.js
+++ b/cli/lib/__tests__/bin.test.js
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// We need to set ZYLOS_DIR before importing bin.js (it reads BIN_DIR from config at import time)
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-bin-test-'));
+process.env.ZYLOS_DIR = tmpRoot;
+
+const { linkBins, unlinkBins } = await import('../bin.js');
+const { BIN_DIR } = await import('../config.js');
+
+describe('linkBins', () => {
+  let skillDir;
+
+  beforeEach(() => {
+    skillDir = path.join(tmpRoot, 'skills', `test-${Date.now()}`);
+    fs.mkdirSync(path.join(skillDir, 'src'), { recursive: true });
+    // Create a dummy CLI script
+    fs.writeFileSync(path.join(skillDir, 'src', 'cli.js'), '#!/usr/bin/env node\nconsole.log("hello");\n');
+  });
+
+  afterEach(() => {
+    // Clean up bin dir symlinks
+    if (fs.existsSync(BIN_DIR)) {
+      for (const entry of fs.readdirSync(BIN_DIR)) {
+        try { fs.unlinkSync(path.join(BIN_DIR, entry)); } catch { /* ignore */ }
+      }
+    }
+  });
+
+  it('returns null for empty/undefined bin field', () => {
+    assert.equal(linkBins(skillDir, undefined), null);
+    assert.equal(linkBins(skillDir, null), null);
+    assert.equal(linkBins(skillDir, {}), null);
+  });
+
+  it('returns null for non-object bin field', () => {
+    assert.equal(linkBins(skillDir, 'not-an-object'), null);
+    assert.equal(linkBins(skillDir, 42), null);
+  });
+
+  it('creates symlink for valid bin entry', () => {
+    const result = linkBins(skillDir, { 'test-cmd': 'src/cli.js' });
+
+    assert.ok(result);
+    assert.ok(result['test-cmd']);
+    assert.equal(result['test-cmd'], path.join(BIN_DIR, 'test-cmd'));
+
+    // Verify symlink exists and points to correct target
+    const linkTarget = fs.readlinkSync(path.join(BIN_DIR, 'test-cmd'));
+    assert.equal(linkTarget, path.join(skillDir, 'src', 'cli.js'));
+  });
+
+  it('makes target executable', () => {
+    // Start with non-executable
+    fs.chmodSync(path.join(skillDir, 'src', 'cli.js'), 0o644);
+
+    linkBins(skillDir, { 'test-cmd': 'src/cli.js' });
+
+    const stat = fs.statSync(path.join(skillDir, 'src', 'cli.js'));
+    // Check executable bit is set (owner)
+    assert.ok(stat.mode & 0o100, 'Expected executable bit to be set');
+  });
+
+  it('handles multiple bin entries', () => {
+    fs.writeFileSync(path.join(skillDir, 'src', 'other.js'), '#!/usr/bin/env node\n');
+
+    const result = linkBins(skillDir, {
+      'cmd-a': 'src/cli.js',
+      'cmd-b': 'src/other.js',
+    });
+
+    assert.ok(result);
+    assert.ok(result['cmd-a']);
+    assert.ok(result['cmd-b']);
+    assert.ok(fs.existsSync(path.join(BIN_DIR, 'cmd-a')));
+    assert.ok(fs.existsSync(path.join(BIN_DIR, 'cmd-b')));
+  });
+
+  it('skips entries with missing target', () => {
+    const result = linkBins(skillDir, {
+      'good-cmd': 'src/cli.js',
+      'bad-cmd': 'src/nonexistent.js',
+    });
+
+    assert.ok(result);
+    assert.ok(result['good-cmd']);
+    assert.equal(result['bad-cmd'], undefined);
+  });
+
+  it('returns null when all targets are missing', () => {
+    const result = linkBins(skillDir, {
+      'bad-a': 'missing-a.js',
+      'bad-b': 'missing-b.js',
+    });
+
+    assert.equal(result, null);
+  });
+
+  it('overwrites existing symlink pointing elsewhere', () => {
+    // Create a pre-existing symlink pointing somewhere else
+    fs.mkdirSync(BIN_DIR, { recursive: true });
+    fs.symlinkSync('/tmp/old-target', path.join(BIN_DIR, 'test-cmd'));
+
+    const result = linkBins(skillDir, { 'test-cmd': 'src/cli.js' });
+
+    assert.ok(result);
+    const linkTarget = fs.readlinkSync(path.join(BIN_DIR, 'test-cmd'));
+    assert.equal(linkTarget, path.join(skillDir, 'src', 'cli.js'));
+  });
+});
+
+describe('unlinkBins', () => {
+  let binDir;
+
+  beforeEach(() => {
+    binDir = BIN_DIR;
+    fs.mkdirSync(binDir, { recursive: true });
+  });
+
+  it('handles null/undefined gracefully', () => {
+    // Should not throw
+    unlinkBins(null);
+    unlinkBins(undefined);
+    unlinkBins({});
+  });
+
+  it('removes existing symlinks', () => {
+    const linkPath = path.join(binDir, 'test-cmd');
+    fs.symlinkSync('/tmp/some-target', linkPath);
+    assert.ok(fs.lstatSync(linkPath).isSymbolicLink());
+
+    unlinkBins({ 'test-cmd': linkPath });
+
+    // Symlink should be gone
+    assert.throws(() => fs.lstatSync(linkPath), { code: 'ENOENT' });
+  });
+
+  it('ignores already-missing symlinks', () => {
+    // Should not throw when path doesn't exist
+    unlinkBins({ 'missing-cmd': path.join(binDir, 'nonexistent') });
+  });
+
+  it('does not remove regular files (safety check)', () => {
+    const filePath = path.join(binDir, 'regular-file');
+    fs.writeFileSync(filePath, 'not a symlink');
+
+    unlinkBins({ 'regular-file': filePath });
+
+    // Regular file should still exist
+    assert.ok(fs.existsSync(filePath));
+
+    // Cleanup
+    fs.unlinkSync(filePath);
+  });
+
+  it('removes multiple symlinks', () => {
+    const linkA = path.join(binDir, 'cmd-a');
+    const linkB = path.join(binDir, 'cmd-b');
+    fs.symlinkSync('/tmp/target-a', linkA);
+    fs.symlinkSync('/tmp/target-b', linkB);
+
+    unlinkBins({ 'cmd-a': linkA, 'cmd-b': linkB });
+
+    assert.throws(() => fs.lstatSync(linkA), { code: 'ENOENT' });
+    assert.throws(() => fs.lstatSync(linkB), { code: 'ENOENT' });
+  });
+});

--- a/cli/lib/bin.js
+++ b/cli/lib/bin.js
@@ -1,0 +1,90 @@
+/**
+ * Bin symlink management for SKILL.md `bin` field.
+ *
+ * Creates and removes symlinks in ~/zylos/bin/ so component CLIs
+ * are available on $PATH.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { BIN_DIR } from './config.js';
+
+/**
+ * Create symlinks in BIN_DIR for each entry in the SKILL.md `bin` field.
+ *
+ * @param {string} skillDir - Absolute path to the component's skill directory
+ * @param {object} binField - e.g. { "zylos-browser": "src/cli.js" }
+ * @returns {object|null} Mapping of command names to symlink paths, or null if nothing to link
+ */
+export function linkBins(skillDir, binField) {
+  if (!binField || typeof binField !== 'object' || Object.keys(binField).length === 0) {
+    return null;
+  }
+
+  fs.mkdirSync(BIN_DIR, { recursive: true });
+
+  const result = {};
+
+  for (const [cmdName, scriptPath] of Object.entries(binField)) {
+    const target = path.join(skillDir, scriptPath);
+    const link = path.join(BIN_DIR, cmdName);
+
+    // Validate target exists
+    if (!fs.existsSync(target)) {
+      console.log(`  Warning: bin target not found: ${target}`);
+      continue;
+    }
+
+    // Make target executable
+    try {
+      fs.chmodSync(target, 0o755);
+    } catch (err) {
+      console.log(`  Warning: could not chmod ${target}: ${err.message}`);
+    }
+
+    // Remove existing file/symlink at link path
+    try {
+      const stat = fs.lstatSync(link);
+      if (stat) {
+        if (stat.isSymbolicLink()) {
+          const existing = fs.readlinkSync(link);
+          if (existing !== target) {
+            console.log(`  Warning: overwriting existing bin link ${cmdName} (was ${existing})`);
+          }
+        } else {
+          console.log(`  Warning: overwriting non-symlink file at ${link}`);
+        }
+        fs.unlinkSync(link);
+      }
+    } catch {
+      // lstat throws ENOENT if nothing exists — that's fine
+    }
+
+    // Create symlink
+    fs.symlinkSync(target, link);
+    result[cmdName] = link;
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Remove bin symlinks previously created for a component.
+ *
+ * @param {object} binEntries - From components.json, e.g. { "zylos-browser": "/home/.../bin/zylos-browser" }
+ */
+export function unlinkBins(binEntries) {
+  if (!binEntries || typeof binEntries !== 'object') return;
+
+  for (const [, linkPath] of Object.entries(binEntries)) {
+    try {
+      // Only remove if it's actually a symlink (safety check)
+      const stat = fs.lstatSync(linkPath);
+      if (stat.isSymbolicLink()) {
+        fs.unlinkSync(linkPath);
+      }
+    } catch {
+      // Symlink already gone — fine
+    }
+  }
+}

--- a/cli/lib/config.js
+++ b/cli/lib/config.js
@@ -11,4 +11,5 @@ export const COMPONENTS_DIR = path.join(ZYLOS_DIR, 'components');
 export const LOCKS_DIR = path.join(CONFIG_DIR, 'locks');
 export const REGISTRY_FILE = path.join(CONFIG_DIR, 'registry.json');
 export const COMPONENTS_FILE = path.join(CONFIG_DIR, 'components.json');
+export const BIN_DIR = path.join(ZYLOS_DIR, 'bin');
 export const ENV_FILE = path.join(ZYLOS_DIR, '.env');


### PR DESCRIPTION
## Summary
- Components can declare CLI commands via `bin` field in SKILL.md frontmatter (e.g. `bin: { zylos-browser: src/cli.js }`)
- Symlinks are created in `~/zylos/bin/` during `zylos add`, updated on `zylos upgrade`, and removed on `zylos remove`
- `zylos init` creates the bin directory and configures PATH by detecting the user's shell (bash/zsh) and appending to the appropriate rc file (idempotent via marker comment)

## Files changed
| File | Change |
|------|--------|
| `cli/lib/bin.js` | **New** — `linkBins()` / `unlinkBins()` utility |
| `cli/lib/__tests__/bin.test.js` | **New** — 13 unit tests |
| `cli/lib/config.js` | Added `BIN_DIR` constant |
| `cli/commands/init.js` | `ensureBinInPath()` + bin dir in directory structure |
| `cli/commands/add.js` | Create symlinks after install, persist to components.json |
| `cli/commands/component.js` | Remove symlinks on uninstall; re-link on upgrade |

## Test plan
- [x] 13 unit tests for `linkBins` and `unlinkBins` (all passing)
- [ ] Manual: `zylos init` on fresh env creates `~/zylos/bin/` and appends PATH to `.bashrc`
- [ ] Manual: `zylos add` with a component that has `bin` field creates working symlink
- [ ] Manual: `zylos remove` cleans up symlinks
- [ ] Manual: `zylos upgrade` updates symlinks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)