### PR TITLE
chore: release v0.1.0-beta.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0-beta.21] - 2026-02-10
+## [0.1.0-beta.22] - 2026-02-10
 
 ### Added
 - **SKILL.md `bin` field support**: Components can declare CLI commands in `bin` field; `zylos add` creates symlinks in `~/zylos/bin/`, `zylos component` shows them
 - **C4 control queue**: Reliable message delivery with heartbeat liveness checks and periodic task dispatch
-- **Fix C4 dispatcher**: Resolve duplicate message delivery issue
+
+### Fixed
+- **C4 dispatcher**: Resolve duplicate message delivery issue
+- **Missing dotenv dependency**: Added dotenv to package.json (required by tz.js, setup-caddy.js, shared.js)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Bump version to v0.1.0-beta.22
- Update CHANGELOG covering changes since beta.20:
  - SKILL.md `bin` field support (#62)
  - C4 control queue (#61)
  - Fix C4 dispatcher duplicate delivery (#59)
  - Fix missing dotenv dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)