### PR TITLE
fix(deps): ensure skill dependencies are always installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.23] - 2026-02-10
+
+### Fixed
+- **Skill dependency installation**: `zylos init` now always runs `npm install --production` for skills instead of skipping when `node_modules/` exists, ensuring new dependencies are installed after upgrades
+- **Self-upgrade skill deps**: Added step 6 (install skill dependencies) to self-upgrade pipeline (9→10 steps), so skill dependencies are updated after syncing skill files
+
+---
+
 ## [0.1.0-beta.22] - 2026-02-10
 
 ### Added

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -411,7 +411,6 @@ function installSkillDependencies() {
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
       if (!pkg.dependencies || Object.keys(pkg.dependencies).length === 0) continue;
-      if (fs.existsSync(path.join(skillDir, 'node_modules'))) continue;
 
       console.log(`  Installing ${entry.name} dependencies...`);
       execSync('npm install --production', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- **init.js**: Remove `node_modules` existence check — always run `npm install --production` for skills with dependencies. Fixes the bug where new dependencies added after initial install were never installed.
- **self-upgrade.js**: Add step 6 (install skill deps) to pipeline (9→10 steps). After syncing skill files, runs `npm install --production` for each skill, ensuring dependencies stay up to date after upgrades.

## Root Cause
`installSkillDependencies()` in init.js skipped `npm install` if `node_modules/` existed. When a skill's `package.json` gained new deps (e.g., dotenv added to scheduler), the existing `node_modules/` caused the check to skip, leaving the new dep uninstalled.

Self-upgrade had no skill dependency step at all — it synced skill files but never ran `npm install`.

## Test plan
- [ ] `zylos init` on a fresh setup — verify all skill deps installed
- [ ] `zylos init` on existing setup with `node_modules/` — verify deps still reinstalled
- [ ] Self-upgrade — verify step 6 runs and installs skill deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)