### PR TITLE
fix(c4): PM2 ESM compatibility and schema migration

### DIFF
--- a/skills/comm-bridge/scripts/c4-dispatcher.js
+++ b/skills/comm-bridge/scripts/c4-dispatcher.js
@@ -5,8 +5,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, existsSync, statSync, realpathSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { readFileSync, existsSync, statSync } from 'fs';
 import {
   getNextPending,
   claimConversation,
@@ -450,7 +449,6 @@ async function main() {
   process.exit(0);
 }
 
-const isMainModule = process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
-if (isMainModule) {
-  main();
-}
+// Always call main() — PM2 sets argv[1] to its own ProcessContainerFork.js,
+// breaking realpathSync-based isMainModule checks for ESM scripts.
+main();


### PR DESCRIPTION
## Summary
- **c4-dispatcher.js**: Remove `isMainModule` check — PM2 sets `process.argv[1]` to its own `ProcessContainerFork.js`, not the actual script path, so the `realpathSync` comparison always fails and `main()` never executes. The dispatcher appeared "online" in PM2 but was completely inert.
- **c4-db.js**: Run schema migrations on every startup. Uses regex to extract `CREATE TABLE/INDEX IF NOT EXISTS` statements (inherently idempotent) from `init-db.sql`. Ensures new tables (like `control_queue` added in beta.22) are automatically created when upgrading existing installations. Seed data (`INSERT`) only runs on fresh databases.

## Root Cause
After upgrading to beta.22 on zylos0:
1. The new `control_queue` table wasn't created because `getDb()` only ran `initSchema()` for new databases
2. The c4-dispatcher crashed on startup due to the missing table
3. PM2 restarted it, but the `isMainModule` check (comparing `realpathSync(import.meta.url)` vs `realpathSync(process.argv[1])`) silently failed, so `main()` was never called
4. Result: dispatcher appeared online but never processed any messages

## Test plan
- [ ] Fresh `zylos init` — verify DB created with all tables
- [ ] Existing DB without `control_queue` — verify table auto-created on startup
- [ ] PM2 `pm2 start c4-dispatcher.js` — verify startup logs appear and messages are delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)