### PR TITLE
feat(caddy): auto-configure Caddy routes for components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.24] - 2026-02-10
+
+### Added
+- **Caddy auto-configuration**: Components declaring `http_routes` in SKILL.md get Caddy reverse proxy routes auto-configured during install, upgrade, and removed during uninstall
+- New `cli/lib/caddy.js` module: marker-based Caddyfile management with `caddy validate` before reload and auto-rollback on failure
+- Upgrade pipeline expanded from 5 to 6 steps (added step 6: update Caddy routes)
+
+---
+
 ## [0.1.0-beta.23] - 2026-02-10
 
 ### Fixed

--- a/cli/lib/caddy.js
+++ b/cli/lib/caddy.js
@@ -1,0 +1,247 @@
+/**
+ * Caddy route management for zylos components.
+ *
+ * Components declare `http_routes` in SKILL.md frontmatter.
+ * This module manages marker-based route blocks in the Caddyfile:
+ *   # BEGIN zylos-component:<name>
+ *   ...routes...
+ *   # END zylos-component:<name>
+ *
+ * Routes are inserted inside the existing domain { ... } block.
+ * Uses `caddy validate` before reload; auto-rollback on failure.
+ */
+
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const CADDYFILE = '/etc/caddy/Caddyfile';
+
+/**
+ * Check if Caddy is available (binary + Caddyfile exist).
+ */
+export function isCaddyAvailable() {
+  try {
+    execSync('which caddy', { stdio: 'pipe' });
+    return fs.existsSync(CADDYFILE);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Generate Caddy handle blocks from http_routes array.
+ *
+ * Supported route types:
+ *   - reverse_proxy: proxies to a target, optionally stripping a prefix
+ *
+ * @param {Array} httpRoutes - Array of { path, type, target, strip_prefix? }
+ * @returns {string} Caddy configuration block (indented for domain block)
+ */
+function generateRouteBlocks(httpRoutes) {
+  const lines = [];
+  for (const route of httpRoutes) {
+    if (route.type === 'reverse_proxy') {
+      lines.push(`    handle ${route.path} {`);
+      if (route.strip_prefix) {
+        lines.push(`        uri strip_prefix ${route.strip_prefix}`);
+      }
+      lines.push(`        reverse_proxy ${route.target}`);
+      lines.push(`    }`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Remove a marker block (BEGIN to END, inclusive) from content.
+ * Handles leading whitespace on marker lines and cleans up blank lines.
+ */
+function stripMarkerBlock(content, beginMarker, endMarker) {
+  const lines = content.split('\n');
+  const result = [];
+  let skipping = false;
+
+  for (const line of lines) {
+    if (line.includes(beginMarker)) {
+      skipping = true;
+      continue;
+    }
+    if (skipping && line.includes(endMarker)) {
+      skipping = false;
+      continue;
+    }
+    if (!skipping) {
+      result.push(line);
+    }
+  }
+
+  // Clean up consecutive blank lines (max 2 newlines in a row)
+  return result.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Apply Caddy routes for a component.
+ * Reads Caddyfile, removes existing markers for this component (if any),
+ * generates new route blocks, inserts before closing `}` of the domain block,
+ * validates, and reloads.
+ *
+ * @param {string} componentName
+ * @param {Array} httpRoutes - Array of { path, type, target, strip_prefix? }
+ * @returns {{ success: boolean, action: string, error?: string }}
+ */
+export function applyCaddyRoutes(componentName, httpRoutes) {
+  if (!isCaddyAvailable()) {
+    return { success: false, action: 'skipped', error: 'caddy_not_available' };
+  }
+
+  if (!httpRoutes || !Array.isArray(httpRoutes) || httpRoutes.length === 0) {
+    return { success: true, action: 'skipped' };
+  }
+
+  const beginMarker = `# BEGIN zylos-component:${componentName}`;
+  const endMarker = `# END zylos-component:${componentName}`;
+
+  let original;
+  try {
+    original = fs.readFileSync(CADDYFILE, 'utf8');
+  } catch (err) {
+    return { success: false, action: 'skipped', error: `Cannot read Caddyfile: ${err.message}` };
+  }
+
+  // Remove existing marker block for this component (if any)
+  let content = original;
+  const isUpdate = content.includes(beginMarker);
+  if (isUpdate) {
+    content = stripMarkerBlock(content, beginMarker, endMarker);
+  }
+
+  // Generate new route block
+  const routeBlock = generateRouteBlocks(httpRoutes);
+  const markedBlock = [
+    `    ${beginMarker}`,
+    routeBlock,
+    `    ${endMarker}`,
+  ].join('\n');
+
+  // Find the last closing `}` in the file (end of domain block)
+  const lastBrace = content.lastIndexOf('}');
+  if (lastBrace === -1) {
+    return { success: false, action: 'skipped', error: 'Cannot find domain block in Caddyfile' };
+  }
+
+  // Insert marked block before the closing brace, with proper spacing
+  const before = content.slice(0, lastBrace).trimEnd();
+  const after = content.slice(lastBrace);
+  const newContent = `${before}\n\n${markedBlock}\n${after}`;
+
+  // Write to temp file, validate, then deploy
+  const result = validateAndDeploy(newContent, original);
+  if (!result.success) {
+    return { success: false, action: isUpdate ? 'updated' : 'added', error: result.error };
+  }
+
+  return { success: true, action: isUpdate ? 'updated' : 'added' };
+}
+
+/**
+ * Remove Caddy routes for a component.
+ *
+ * @param {string} componentName
+ * @returns {{ success: boolean, action: string, error?: string }}
+ */
+export function removeCaddyRoutes(componentName) {
+  if (!isCaddyAvailable()) {
+    return { success: true, action: 'not_found' };
+  }
+
+  const beginMarker = `# BEGIN zylos-component:${componentName}`;
+  const endMarker = `# END zylos-component:${componentName}`;
+
+  let original;
+  try {
+    original = fs.readFileSync(CADDYFILE, 'utf8');
+  } catch (err) {
+    return { success: false, action: 'not_found', error: `Cannot read Caddyfile: ${err.message}` };
+  }
+
+  if (!original.includes(beginMarker)) {
+    return { success: true, action: 'not_found' };
+  }
+
+  // Remove the marker block
+  const newContent = stripMarkerBlock(original, beginMarker, endMarker);
+
+  const result = validateAndDeploy(newContent, original);
+  if (!result.success) {
+    return { success: false, action: 'removed', error: result.error };
+  }
+
+  return { success: true, action: 'removed' };
+}
+
+/**
+ * Write new Caddyfile to temp, validate with `caddy validate`,
+ * then deploy with `sudo cp` and `sudo caddy reload`.
+ * On validation failure, restores original.
+ *
+ * @param {string} newContent - New Caddyfile content
+ * @param {string} originalContent - Original content for rollback
+ * @returns {{ success: boolean, error?: string }}
+ */
+function validateAndDeploy(newContent, originalContent) {
+  const tmpFile = `/tmp/Caddyfile.zylos-${Date.now()}`;
+
+  try {
+    fs.writeFileSync(tmpFile, newContent);
+
+    // Validate
+    try {
+      execSync(`caddy validate --config ${tmpFile} --adapter caddyfile`, {
+        stdio: 'pipe',
+        timeout: 10000,
+      });
+    } catch (err) {
+      // Validation failed — clean up temp file
+      try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+      const stderr = err.stderr?.toString().trim() || err.message;
+      return { success: false, error: `Caddy validation failed: ${stderr}` };
+    }
+
+    // Deploy: sudo cp to /etc/caddy/Caddyfile
+    try {
+      execSync(`sudo cp ${tmpFile} ${CADDYFILE}`, { stdio: 'pipe', timeout: 5000 });
+    } catch (err) {
+      try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+      return { success: false, error: `Failed to deploy Caddyfile: ${err.message}` };
+    }
+
+    // Reload Caddy
+    try {
+      execSync('sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile', {
+        stdio: 'pipe',
+        timeout: 10000,
+      });
+    } catch (err) {
+      // Reload failed — rollback
+      const rollbackTmp = `/tmp/Caddyfile.rollback-${Date.now()}`;
+      try {
+        fs.writeFileSync(rollbackTmp, originalContent);
+        execSync(`sudo cp ${rollbackTmp} ${CADDYFILE}`, { stdio: 'pipe', timeout: 5000 });
+        execSync('sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile', {
+          stdio: 'pipe',
+          timeout: 10000,
+        });
+        fs.unlinkSync(rollbackTmp);
+      } catch { /* rollback best-effort */ }
+      try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+      return { success: false, error: `Caddy reload failed (rolled back): ${err.message}` };
+    }
+
+    // Clean up temp file
+    try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+    return { success: true };
+  } catch (err) {
+    try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+    return { success: false, error: err.message };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- New `cli/lib/caddy.js` module for marker-based Caddyfile route management
- Components declaring `http_routes` in SKILL.md get Caddy reverse proxy routes auto-configured during install, upgrade, and removed during uninstall
- Uses `caddy validate` before reload with auto-rollback on failure
- Upgrade pipeline expanded from 5 to 6 steps (step 6: update Caddy routes)

## Changes
| File | Change |
|------|--------|
| `cli/lib/caddy.js` | **NEW** — `applyCaddyRoutes()`, `removeCaddyRoutes()`, `isCaddyAvailable()` |
| `cli/commands/add.js` | Step 5: apply Caddy routes after bin symlinks |
| `cli/lib/upgrade.js` | Step 6: update Caddy routes (5→6 step pipeline) |
| `cli/commands/component.js` | Remove Caddy routes during uninstall |
| `CHANGELOG.md` | Document v0.1.0-beta.24 |
| `package.json` | Bump to v0.1.0-beta.24 |

## How it works
1. Component SKILL.md declares `http_routes` (e.g., browser declares `/vnc/* → localhost:6080`)
2. `zylos add` / `zylos upgrade` reads routes and calls `applyCaddyRoutes()`
3. Routes are inserted with marker comments (`# BEGIN/END zylos-component:<name>`)
4. `caddy validate` runs before deploying; on failure, original Caddyfile is restored
5. `zylos uninstall` removes the component's marker block

## Test plan
- [ ] `node cli/zylos.js --version` returns `0.1.0-beta.24`
- [ ] `node -e "import('./cli/lib/caddy.js')"` loads without errors
- [ ] `zylos add browser --json` includes `caddy` field in output
- [ ] End-to-end on zylos0: `zylos add browser` auto-adds `/vnc/*` route to Caddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)