### PR TITLE
fix: PATH for non-interactive shells + component version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.26] - 2026-02-10
+
+### Fixed
+- **PATH for non-interactive shells**: `ensureBinInPath()` now writes to `~/.profile` in addition to shell rc file, fixing `command not found` for component CLIs (e.g. `zylos-browser`) when run from Claude Code or other non-interactive bash processes (Ubuntu's `.bashrc` has an early-exit guard that skips PATH setup for non-interactive shells)
+- **Component version detection**: `zylos add` no longer falls back to `0.0.0` when installing from a branch without a tag — reads version from SKILL.md frontmatter or package.json
+
+---
+
 ## [0.1.0-beta.25] - 2026-02-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- **PATH fix**: `ensureBinInPath()` now writes to `~/.profile` in addition to shell rc file. On Ubuntu, `.bashrc` has an early-exit guard (`case $- in *i*) ;; *) return;; esac`) that skips PATH exports for non-interactive shells. Claude Code's Bash tool spawns non-interactive shells, so `~/zylos/bin` was never in PATH — causing `zylos-browser: command not found`.
- **Version fix**: `zylos add` no longer falls back to `0.0.0` when installing from a branch (no tag). Now reads version from SKILL.md frontmatter or package.json.

## Test plan
- [ ] On zylos0: run `zylos init` (re-init), verify `~/.profile` gets PATH export
- [ ] New shell session: `which zylos-browser` should resolve
- [ ] `zylos add browser` from main branch: `components.json` should show correct version (e.g. `0.1.0-beta.1`), not `0.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)