### PR TITLE
docs: add shared PM2 service check to uninstall workflow

### DIFF
--- a/skills/component-management/references/uninstall.md
+++ b/skills/component-management/references/uninstall.md
@@ -22,6 +22,7 @@ Before executing CLI uninstall, check the component's SKILL.md for external reso
 - Webhook registrations (deregister)
 - Active connections (close gracefully)
 - External service integrations (notify/cleanup)
+- **Shared PM2 services**: If the component manages PM2 services (e.g. zylos-xvfb, zylos-vnc), check whether any other installed component also uses them before stopping. Scan other components' SKILL.md files in `~/.claude/skills/` — only stop a service if no other component references it.
 
 ### Step 3: Execute Uninstall
 
@@ -54,7 +55,7 @@ Run `zylos uninstall lark --check --json`. The JSON output includes component in
 
 User: `uninstall lark confirm` (keep data) or `uninstall lark purge` (delete all)
 
-1. Check SKILL.md for external cleanup needs (webhooks, connections)
+1. Check SKILL.md for external cleanup needs (webhooks, connections, shared PM2 services)
 2. Run `zylos uninstall lark confirm --json` or `zylos uninstall lark purge --json`
 3. Clean component's environment variables from .env
 4. Reply with result


### PR DESCRIPTION
## Summary
- Added shared PM2 services check to uninstall reference doc — before stopping any PM2 service during uninstall, Claude must scan other installed components' SKILL.md to see if they also reference it. Only stop services no other component uses.
- No code changes, pure documentation — Claude follows the rule via reasoning.

## Test plan
- [ ] Uninstall browser: Claude should check if zylos-xvfb/zylos-vnc are referenced by other components before stopping them

🤖 Generated with [Claude Code](https://claude.com/claude-code)