### PR TITLE
feat(add): interactive setup in terminal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.27] - 2026-02-10
+
+### Added
+- **Interactive component setup**: `zylos add` in terminal mode now completes the full installation — prompts for required config (e.g. bot tokens), writes to `.env`, runs post-install hooks, and starts the PM2 service. Previously it stopped after code install and expected Claude to handle the rest, which didn't work in terminal mode.
+
+### Unchanged
+- JSON mode (`--json`) for IM/C4 installations is not affected — still outputs metadata for Claude to handle config/hooks/service conversationally.
+
+---
+
 ## [0.1.0-beta.26] - 2026-02-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.0-beta.26",
+  "version": "0.1.0-beta.27",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- `zylos add` in terminal mode now completes the full installation interactively:
  1. Prompts for required config vars from SKILL.md (sensitive values masked with `*`)
  2. Writes to `~/zylos/.env` via `writeEnvEntries()`
  3. Runs post-install hook if declared
  4. Starts PM2 service via `registerService()`
- Previously stopped after code install with "Claude will now collect configuration..." which didn't trigger anything in terminal mode
- JSON mode (`--json`) for IM/C4 is unchanged — still outputs metadata for Claude

## Expected terminal flow
```
$ zylos add telegram
...
Installing (declarative)...
  Installing npm dependencies...
  npm install complete.
  Data directory: /home/ubuntu/zylos/components/telegram

Configuration:
  TELEGRAM_BOT_TOKEN (Telegram Bot Token): ********
  ✓ Saved 1 variable(s) to .env
  Running post-install hook...
  ✓ Post-install hook complete.

Starting service...
  ✓ zylos-telegram started

✓ telegram installed successfully!
```

## Test plan
- [ ] `zylos add telegram` in terminal — prompts for token, writes .env, starts service
- [ ] `zylos add telegram --json` — unchanged JSON output, no prompts
- [ ] Non-TTY stdin — gracefully skips prompts (prompt functions return empty)
- [ ] Config var already in .env — shows "Skipped existing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)