### PR TITLE
fix: move pending-channels.jsonl from comm-bridge to activity-monitor

### DIFF
--- a/skills/activity-monitor/SKILL.md
+++ b/skills/activity-monitor/SKILL.md
@@ -125,7 +125,7 @@ Each heartbeat probe is enqueued with an ack deadline. If Claude does not acknow
 
 ### Recovery Behavior
 
-When health transitions back to `ok`, the engine reads `~/zylos/comm-bridge/pending-channels.jsonl` and sends a recovery notification to each recorded channel/endpoint via C4, then clears the file.
+When health transitions back to `ok`, the engine reads `~/zylos/activity-monitor/pending-channels.jsonl` and sends a recovery notification to each recorded channel/endpoint via C4, then clears the file.
 
 ## Health Check
 

--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -18,7 +18,6 @@ const __dirname = path.dirname(__filename);
 // Core runtime config
 const SESSION = 'claude-main';
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
-const COMM_BRIDGE_DIR = path.join(ZYLOS_DIR, 'comm-bridge');
 const MONITOR_DIR = path.join(ZYLOS_DIR, 'activity-monitor');
 const STATUS_FILE = path.join(MONITOR_DIR, 'claude-status.json');
 const LOG_FILE = path.join(MONITOR_DIR, 'activity.log');
@@ -27,7 +26,7 @@ const HEALTH_CHECK_STATE_FILE = path.join(MONITOR_DIR, 'health-check-state.json'
 const DAILY_UPGRADE_STATE_FILE = path.join(MONITOR_DIR, 'daily-upgrade-state.json');
 const DAILY_MEMORY_COMMIT_STATE_FILE = path.join(MONITOR_DIR, 'daily-memory-commit-state.json');
 const CONTEXT_CHECK_STATE_FILE = path.join(MONITOR_DIR, 'context-check-state.json');
-const PENDING_CHANNELS_FILE = path.join(COMM_BRIDGE_DIR, 'pending-channels.jsonl');
+const PENDING_CHANNELS_FILE = path.join(MONITOR_DIR, 'pending-channels.jsonl');
 
 // Claude binary - relies on PATH from PM2 ecosystem.config.js
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
@@ -840,10 +839,6 @@ function init() {
   if (!fs.existsSync(MONITOR_DIR)) {
     fs.mkdirSync(MONITOR_DIR, { recursive: true });
   }
-  if (!fs.existsSync(COMM_BRIDGE_DIR)) {
-    fs.mkdirSync(COMM_BRIDGE_DIR, { recursive: true });
-  }
-
   const initialHealth = loadInitialHealth();
   engine = new HeartbeatEngine({
     enqueueHeartbeat,

--- a/skills/comm-bridge/SKILL.md
+++ b/skills/comm-bridge/SKILL.md
@@ -51,7 +51,7 @@ The activity monitor writes `~/zylos/activity-monitor/claude-status.json` which 
 
 **Fail-open semantics**: If the status file is missing or malformed, health is assumed `ok` — intake is never blocked by a read failure.
 
-When health is not `ok`, `c4-receive.js` rejects incoming messages and records the channel/endpoint in `~/zylos/comm-bridge/pending-channels.jsonl`. Once health returns to `ok`, the activity monitor sends recovery notifications to all pending channels.
+When health is not `ok`, `c4-receive.js` rejects incoming messages and records the channel/endpoint in `~/zylos/activity-monitor/pending-channels.jsonl`. Once health returns to `ok`, the activity monitor sends recovery notifications to all pending channels.
 
 ## Service Management
 

--- a/skills/comm-bridge/references/c4-receive.md
+++ b/skills/comm-bridge/references/c4-receive.md
@@ -63,7 +63,7 @@ Messages exceeding the configured size threshold are stored as files under `~/zy
 
 Before queuing a message, `c4-receive.js` reads the `health` field from `~/zylos/activity-monitor/claude-status.json`. If health is not `ok`:
 
-1. The channel/endpoint is recorded in `~/zylos/comm-bridge/pending-channels.jsonl` for recovery notification
+1. The channel/endpoint is recorded in `~/zylos/activity-monitor/pending-channels.jsonl` for recovery notification
 2. The message is rejected with a structured error:
    - `HEALTH_RECOVERING` — automatic recovery in progress
    - `HEALTH_DOWN` — manual intervention required

--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -235,7 +235,7 @@ describe('c4-receive health gating', () => {
 
       cliRaw(['--channel', 'test-chan', '--endpoint', 'ep1', '--json', '--content', 'x'], env);
 
-      const pendingPath = path.join(dataDir, 'pending-channels.jsonl');
+      const pendingPath = path.join(tmpDir, 'activity-monitor', 'pending-channels.jsonl');
       assert.ok(fs.existsSync(pendingPath), 'pending-channels.jsonl should exist');
       const lines = fs.readFileSync(pendingPath, 'utf8').trim().split('\n');
       assert.equal(lines.length, 1);
@@ -254,7 +254,7 @@ describe('c4-receive health gating', () => {
 
       cliRaw(['--channel', 'test-chan', '--endpoint', 'ep1', '--json', '--content', 'x'], env);
 
-      const pendingPath = path.join(dataDir, 'pending-channels.jsonl');
+      const pendingPath = path.join(tmpDir, 'activity-monitor', 'pending-channels.jsonl');
       assert.ok(fs.existsSync(pendingPath), 'pending-channels.jsonl should exist');
     });
   });
@@ -300,7 +300,7 @@ describe('c4-receive pending channels', () => {
 
       cliRaw(['--channel', 'my-chan', '--endpoint', 'e1', '--json', '--content', 'x'], env);
 
-      const pendingPath = path.join(dataDir, 'pending-channels.jsonl');
+      const pendingPath = path.join(tmpDir, 'activity-monitor', 'pending-channels.jsonl');
       const lines = fs.readFileSync(pendingPath, 'utf8').trim().split('\n');
       assert.equal(lines.length, 1);
       const record = JSON.parse(lines[0]);
@@ -319,7 +319,7 @@ describe('c4-receive pending channels', () => {
       cliRaw(['--channel', 'dup-chan', '--endpoint', 'e1', '--json', '--content', 'first'], env);
       cliRaw(['--channel', 'dup-chan', '--endpoint', 'e1', '--json', '--content', 'second'], env);
 
-      const pendingPath = path.join(dataDir, 'pending-channels.jsonl');
+      const pendingPath = path.join(tmpDir, 'activity-monitor', 'pending-channels.jsonl');
       const lines = fs.readFileSync(pendingPath, 'utf8').trim().split('\n');
       assert.equal(lines.length, 1, 'should have exactly 1 line after dedup');
     });
@@ -336,7 +336,7 @@ describe('c4-receive pending channels', () => {
       cliRaw(['--channel', 'chan-a', '--endpoint', 'e1', '--json', '--content', 'a'], env);
       cliRaw(['--channel', 'chan-b', '--endpoint', 'e2', '--json', '--content', 'b'], env);
 
-      const pendingPath = path.join(dataDir, 'pending-channels.jsonl');
+      const pendingPath = path.join(tmpDir, 'activity-monitor', 'pending-channels.jsonl');
       const lines = fs.readFileSync(pendingPath, 'utf8').trim().split('\n');
       assert.equal(lines.length, 2, 'should have 2 distinct entries');
     });

--- a/skills/comm-bridge/scripts/c4-config.js
+++ b/skills/comm-bridge/scripts/c4-config.js
@@ -31,7 +31,7 @@ export const DATA_DIR = path.join(ZYLOS_DIR, 'comm-bridge');
 export const DB_PATH = path.join(DATA_DIR, 'c4.db');
 export const ACTIVITY_MONITOR_DIR = path.join(ZYLOS_DIR, 'activity-monitor');
 export const CLAUDE_STATUS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'claude-status.json');
-export const PENDING_CHANNELS_FILE = path.join(DATA_DIR, 'pending-channels.jsonl');
+export const PENDING_CHANNELS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'pending-channels.jsonl');
 export const ATTACHMENTS_DIR = path.join(DATA_DIR, 'attachments');
 export const SKILLS_DIR = path.join(ZYLOS_DIR, '.claude', 'skills');
 


### PR DESCRIPTION
## Summary

- `pending-channels.jsonl` is written by `c4-receive` and consumed by `activity-monitor` for recovery notifications
- Moved it to `~/zylos/activity-monitor/` alongside `claude-status.json`
- Removed unused `COMM_BRIDGE_DIR` constant from activity-monitor

## Test plan

- [x] All 20 c4-receive tests pass
- [ ] Verify PM2 services handle pending channels correctly after path change

🤖 Generated with [Claude Code](https://claude.com/claude-code)