### PR TITLE
fix(upgrade-claude): use npm instead of native installer

### DIFF
--- a/skills/upgrade-claude/SKILL.md
+++ b/skills/upgrade-claude/SKILL.md
@@ -28,5 +28,5 @@ nohup node ~/zylos/.claude/skills/upgrade-claude/scripts/upgrade.js > /dev/null 
 1. **Idle detection**: Waits for idle state (idle_seconds >= 3)
 2. **Send /exit**: Uses C4 Communication Bridge (priority=1, --no-reply)
 3. **Wait for exit**: Monitors Claude process until it exits
-4. **Upgrade**: Runs official upgrade script (`curl -fsSL https://claude.ai/install.sh | bash`)
+4. **Upgrade**: Runs `npm install -g @anthropic-ai/claude-code`
 5. **Daemon restart**: activity-monitor detects exit and restarts Claude automatically

--- a/skills/upgrade-claude/scripts/upgrade.js
+++ b/skills/upgrade-claude/scripts/upgrade.js
@@ -99,7 +99,7 @@ function upgradeClaudeCode() {
 
   try {
     process.chdir(os.homedir());
-    const output = execSync('curl -fsSL https://claude.ai/install.sh | bash', {
+    const output = execSync('npm install -g @anthropic-ai/claude-code', {
       encoding: 'utf8',
       stdio: 'pipe'
     });
@@ -112,7 +112,7 @@ function upgradeClaudeCode() {
 
   // Check new version
   try {
-    const newVersion = execSync('~/.local/bin/claude --version 2>/dev/null', {
+    const newVersion = execSync('claude --version 2>/dev/null', {
       encoding: 'utf8'
     }).trim();
     console.log(`New version: ${newVersion}`);


### PR DESCRIPTION
## Summary

- Change `upgrade-claude` skill to use `npm install -g @anthropic-ai/claude-code` instead of `curl -fsSL https://claude.ai/install.sh | bash`
- Fix version check to use `claude --version` instead of hardcoded `~/.local/bin/claude --version`
- Update SKILL.md to reflect the change

## Problem

`init.js` installs Claude Code via npm (`npm install -g @anthropic-ai/claude-code`), but `upgrade-claude` used the native installer (`curl install.sh`). This caused dual installations:
- npm version at `<nvm-path>/bin/claude`
- native version at `~/.local/bin/claude`

The two installations conflict (error: "Native installation exists but ~/.local/bin is not in your PATH").

## Test plan

- [ ] Run upgrade-claude on a test environment, verify it uses npm install
- [ ] Verify `claude --version` works after upgrade
- [ ] Confirm no native binary appears at `~/.local/bin/claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)