### PR TITLE
fix(claude): unify on native installer, revert npm method

### DIFF
--- a/skills/upgrade-claude/SKILL.md
+++ b/skills/upgrade-claude/SKILL.md
@@ -28,5 +28,5 @@ nohup node ~/zylos/.claude/skills/upgrade-claude/scripts/upgrade.js > /dev/null 
 1. **Idle detection**: Waits for idle state (idle_seconds >= 3)
 2. **Send /exit**: Uses C4 Communication Bridge (priority=1, --no-reply)
 3. **Wait for exit**: Monitors Claude process until it exits
-4. **Upgrade**: Runs `npm install -g @anthropic-ai/claude-code`
+4. **Upgrade**: Runs native installer (`curl -fsSL https://claude.ai/install.sh | bash`)
 5. **Daemon restart**: activity-monitor detects exit and restarts Claude automatically

--- a/skills/upgrade-claude/scripts/upgrade.js
+++ b/skills/upgrade-claude/scripts/upgrade.js
@@ -99,7 +99,7 @@ function upgradeClaudeCode() {
 
   try {
     process.chdir(os.homedir());
-    const output = execSync('npm install -g @anthropic-ai/claude-code', {
+    const output = execSync('curl -fsSL https://claude.ai/install.sh | bash', {
       encoding: 'utf8',
       stdio: 'pipe'
     });
@@ -112,7 +112,7 @@ function upgradeClaudeCode() {
 
   // Check new version
   try {
-    const newVersion = execSync('claude --version 2>/dev/null', {
+    const newVersion = execSync('~/.local/bin/claude --version 2>/dev/null', {
       encoding: 'utf8'
     }).trim();
     console.log(`New version: ${newVersion}`);


### PR DESCRIPTION
## Summary

- Revert PR #86 (upgrade-claude back to native installer)
- Update `init.js` Step 5 to use native installer instead of npm
- Add `~/.local/bin` to PATH after native install so `claude` command is available

## Problem

npm installation of `@anthropic-ai/claude-code` is deprecated since v2.1.15. The npm package actively prompts users to migrate to native installer on every startup. Previously, `init.js` used npm while `upgrade-claude` used native, causing dual-installation conflicts.

## Changes

| File | Change |
|------|--------|
| `init.js` | `npm install -g` → `curl -fsSL https://claude.ai/install.sh \| bash` + PATH handling |
| `upgrade.js` | Revert to `curl` installer + `~/.local/bin/claude --version` |
| `SKILL.md` | Update description |

## Test plan

- [ ] Fresh environment: `zylos init` installs Claude Code via native installer
- [ ] `claude --version` works after install (PATH includes ~/.local/bin)
- [ ] Step 6 auth check finds `claude` command
- [ ] `upgrade-claude` skill uses native installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)