### PR TITLE
feat: add configurable HTTP/HTTPS protocol for Caddy

### DIFF
--- a/cli/commands/config.js
+++ b/cli/commands/config.js
@@ -1,0 +1,127 @@
+/**
+ * zylos config - View and update Zylos configuration
+ *
+ * Usage:
+ *   zylos config                  Show all config
+ *   zylos config get <key>        Get a config value
+ *   zylos config set <key> <val>  Set a config value
+ */
+
+import { getZylosConfig, updateZylosConfig } from '../lib/config.js';
+import { switchProtocol, isCaddyAvailable } from '../lib/caddy.js';
+
+/** Keys that trigger side effects when changed */
+const SIDE_EFFECTS = {
+  protocol: applyProtocolChange,
+};
+
+/** Allowed values per key (for validation) */
+const ALLOWED_VALUES = {
+  protocol: ['http', 'https'],
+};
+
+/**
+ * Main config command handler.
+ */
+export async function configCommand(args) {
+  const sub = args[0];
+
+  if (!sub) {
+    return showConfig();
+  }
+
+  if (sub === 'get') {
+    const key = args[1];
+    if (!key) {
+      console.error('Usage: zylos config get <key>');
+      process.exit(1);
+    }
+    return getConfig(key);
+  }
+
+  if (sub === 'set') {
+    const key = args[1];
+    const value = args[2];
+    if (!key || value === undefined) {
+      console.error('Usage: zylos config set <key> <value>');
+      process.exit(1);
+    }
+    return setConfig(key, value);
+  }
+
+  console.error(`Unknown config subcommand: ${sub}`);
+  console.error('Usage: zylos config [get <key> | set <key> <value>]');
+  process.exit(1);
+}
+
+function showConfig() {
+  const config = getZylosConfig();
+  if (Object.keys(config).length === 0) {
+    console.log('No configuration found. Run "zylos init" first.');
+    return;
+  }
+  for (const [key, value] of Object.entries(config)) {
+    console.log(`${key} = ${value}`);
+  }
+}
+
+function getConfig(key) {
+  const config = getZylosConfig();
+  if (key in config) {
+    console.log(config[key]);
+  } else {
+    console.error(`Key not found: ${key}`);
+    process.exit(1);
+  }
+}
+
+async function setConfig(key, value) {
+  // Validate allowed values
+  if (ALLOWED_VALUES[key] && !ALLOWED_VALUES[key].includes(value)) {
+    console.error(`Invalid value for "${key}": ${value}`);
+    console.error(`Allowed values: ${ALLOWED_VALUES[key].join(', ')}`);
+    process.exit(1);
+  }
+
+  const config = getZylosConfig();
+  const oldValue = config[key];
+
+  updateZylosConfig({ [key]: value });
+  console.log(`${key} = ${value}${oldValue !== undefined ? ` (was: ${oldValue})` : ''}`);
+
+  // Apply side effects
+  if (SIDE_EFFECTS[key]) {
+    await SIDE_EFFECTS[key](value, oldValue);
+  }
+}
+
+/**
+ * Side effect: regenerate Caddyfile when protocol changes.
+ */
+async function applyProtocolChange(newProtocol, oldProtocol) {
+  if (newProtocol === oldProtocol) return;
+
+  const config = getZylosConfig();
+  if (!config.domain) {
+    console.log('  ⚠ No domain configured. Run "zylos init" to set up Caddy.');
+    return;
+  }
+
+  if (!isCaddyAvailable()) {
+    console.log('  ⚠ Caddy not available. Protocol saved but Caddyfile not updated.');
+    return;
+  }
+
+  console.log(`  Updating Caddyfile (${oldProtocol || 'https'} → ${newProtocol})...`);
+  const result = switchProtocol(config.domain, newProtocol);
+
+  if (result.success) {
+    console.log('  ✓ Caddyfile updated and Caddy reloaded');
+  } else {
+    console.error(`  ✗ Failed to update Caddyfile: ${result.error}`);
+    // Revert config
+    updateZylosConfig({ protocol: oldProtocol || 'https' });
+    console.error('  Config reverted.');
+    process.exit(1);
+  }
+}

--- a/cli/zylos.js
+++ b/cli/zylos.js
@@ -9,10 +9,12 @@ import { showStatus, showLogs, startServices, stopServices, restartServices } fr
 import { upgradeComponent, uninstallComponent, infoComponent, listComponents, searchComponents } from './commands/component.js';
 import { addComponent } from './commands/add.js';
 import { initCommand } from './commands/init.js';
+import { configCommand } from './commands/config.js';
 
 const commands = {
   // Environment setup
   init: initCommand,
+  config: configCommand,
   // Service management
   status: showStatus,
   logs: showLogs,
@@ -67,6 +69,9 @@ Usage: zylos <command> [options]
 Setup:
   init                Initialize Zylos environment
                       --yes/-y  Skip confirmation prompts
+  config              Show all configuration
+  config get <key>    Get a config value
+  config set <key> <value>  Set a config value
 
 Service Management:
   status              Show system status
@@ -94,6 +99,7 @@ Other:
 
 Examples:
   zylos init
+  zylos config set protocol http
   zylos status
   zylos logs activity
 


### PR DESCRIPTION
## Summary

- Add `protocol` field to `config.json` (`"https"` default, `"http"` for CDN/reverse proxy setups)
- `zylos init` now prompts for protocol choice during Caddy setup
- New `zylos config` command (`get`, `set`) for runtime configuration management
- `zylos config set protocol http/https` switches protocol live with Caddyfile update + Caddy reload

## Problem

When Caddy runs behind Cloudflare Flexible SSL (or similar CDN), both Caddy and the CDN attempt TLS, causing redirect loops. Previously, the only option was to manually edit the Caddyfile.

## Solution

Protocol is now a first-class config option:

**During setup (`zylos init`):**
- Asks "Set up Caddy web server?" then "Use HTTPS with auto-certificate?"
- Saves choice to `config.json` as `protocol: "https"` or `protocol: "http"`

**Post-deployment switch (`zylos config set`):**
```bash
zylos config set protocol http    # Switch to HTTP (behind CDN)
zylos config set protocol https   # Switch to HTTPS (auto-cert)
```

The switch updates the Caddyfile site address in-place, preserving all component routes, validates with `caddy validate`, reloads via PM2, and auto-rollbacks on failure.

## Files Changed

| File | Change |
|------|--------|
| `cli/commands/config.js` | New config command (get/set with side effects) |
| `cli/commands/init.js` | Protocol prompt + `generateCaddyfile()` protocol param |
| `cli/lib/caddy.js` | New `switchProtocol()` for live protocol switching |
| `cli/zylos.js` | Register config command + help text |

## Caddy Syntax

- `example.com { ... }` → HTTPS with automatic Let's Encrypt certificate
- `http://example.com { ... }` → HTTP only (no TLS)

## Test Plan

- [ ] `zylos init` with HTTPS choice → bare domain in Caddyfile
- [ ] `zylos init` with HTTP choice → `http://domain` in Caddyfile
- [ ] `zylos config` → shows all config
- [ ] `zylos config get protocol` → prints protocol
- [ ] `zylos config set protocol http` → updates Caddyfile + reloads
- [ ] `zylos config set protocol https` → switches back
- [ ] Validation failure → auto-rollback, config reverted
- [ ] Old Caddyfile (no Protocol comment) → comment added on switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)