### PR TITLE
fix(cli): strip \r\n from user input during config collection

### DIFF
--- a/cli/lib/env.js
+++ b/cli/lib/env.js
@@ -57,10 +57,12 @@ export function writeEnvEntries(entries, componentName) {
       skipped.push(key);
       continue;
     }
+    // Strip any embedded \r\n characters from value
+    const cleanValue = value.replace(/[\r\n]/g, '').trim();
     // Quote values that contain spaces or special characters
-    const needsQuote = /[\s#"'$`\\]/.test(value);
-    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$');
-    lines.push(`${key}=${needsQuote ? `"${escaped}"` : value}`);
+    const needsQuote = /[\s#"'$`\\]/.test(cleanValue);
+    const escaped = cleanValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$');
+    lines.push(`${key}=${needsQuote ? `"${escaped}"` : cleanValue}`);
     written.push(key);
   }
 

--- a/cli/lib/prompts.js
+++ b/cli/lib/prompts.js
@@ -17,7 +17,7 @@ export function prompt(question) {
   return new Promise((resolve) => {
     rl.question(question, (answer) => {
       rl.close();
-      resolve(answer.trim());
+      resolve(answer.replace(/[\r\n]/g, '').trim());
     });
   });
 }
@@ -75,7 +75,7 @@ export function promptSecret(question) {
       // Enter
       if (ch === '\r' || ch === '\n') {
         cleanup();
-        resolve(input);
+        resolve(input.replace(/[\r\n]/g, '').trim());
         return;
       }
       // Backspace


### PR DESCRIPTION
When users paste credentials (app_id/app_secret) from clipboard during `zylos add`, the input may contain embedded carriage return characters that break the .env file format.

Changes:
- prompts.js: Strip \r\n from both prompt() and promptSecret() output
- env.js: Add defensive trimming in writeEnvEntries() before writing values

This prevents malformed .env entries that cause authentication failures.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
