### PR TITLE
feat(activity-monitor): enqueue startup control after launching Claude

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -258,6 +258,7 @@ function enqueueStartupControl() {
     '--content', content,
     '--priority', '3',
     '--require-idle',
+    '--available-in', '3',
     '--ack-deadline', '600'
   ]);
 


### PR DESCRIPTION
When activity-monitor starts Claude Code, it now enqueues a require-idle control command (priority normal) that prompts Claude to reply to any waiting human partner or continue ongoing work from previous conversations.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
