### PR TITLE
fix: add nextSteps and SKILL.md guidance to C4 install flow

### DIFF
--- a/skills/component-management/references/install.md
+++ b/skills/component-management/references/install.md
@@ -93,3 +93,5 @@ After `zylos add <name> --json` succeeds, the JSON `skill` field tells you what 
 2. **Config**: If `skill.config.required` exists, inform user which config values are needed. In C4 mode, user provides values via follow-up messages.
 3. **Hooks**: If `skill.hooks.post-install` exists, run it (with PATH prefix if step 1 applied).
 4. **Service**: If `skill.service` exists, start it and verify.
+5. **Next Steps**: If `skill.nextSteps` exists, follow the instructions — this typically includes post-service-start guidance (e.g., configuring webhook URLs, optional security settings). Always show these to the user.
+6. **SKILL.md**: If the component's SKILL.md has additional setup documentation beyond the frontmatter, read and follow it for any remaining configuration steps.


### PR DESCRIPTION
## Summary
- Add `skill.nextSteps` display to C4 mode post-install actions (was only in Session mode)
- Add instruction to read component SKILL.md for additional setup documentation

## Context
When installing lark via C4 mode (Lark/Telegram), Claude skipped showing webhook URL and verification token guidance because the C4 post-install actions didn't include `nextSteps`. Session mode Step 6 already had this, but C4 mode was missing it.

## Test plan
- [ ] Install a component with `nextSteps` via C4 mode — verify Claude shows the guidance
- [ ] Install a component without `nextSteps` — verify no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)