### PR TITLE
feat(web-console): read password from .env file directly

### DIFF
--- a/skills/web-console/package-lock.json
+++ b/skills/web-console/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
+        "dotenv": "^16.6.1",
         "express": "^4.18.2",
         "ws": "^8.16.0"
       }
@@ -273,6 +274,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/skills/web-console/package.json
+++ b/skills/web-console/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
+    "dotenv": "^16.6.1",
     "express": "^4.18.2",
     "ws": "^8.16.0"
   }

--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -38,7 +38,19 @@ const STATUS_FILE = path.join(ZYLOS_DIR, 'activity-monitor', 'claude-status.json
 const SKILL_ROOT = path.join(__dirname, '..');
 
 // --- Authentication ---
-const AUTH_PASSWORD = process.env.WEB_CONSOLE_PASSWORD || '';
+import { parse as parseDotenv } from 'dotenv';
+
+function readEnvPassword() {
+  const envPath = path.join(ZYLOS_DIR, '.env');
+  try {
+    const env = parseDotenv(fs.readFileSync(envPath, 'utf8'));
+    return env.WEB_CONSOLE_PASSWORD || '';
+  } catch {
+    return '';
+  }
+}
+
+const AUTH_PASSWORD = readEnvPassword();
 const AUTH_ENABLED = AUTH_PASSWORD.length > 0;
 const sessions = new Set(); // Active session tokens
 


### PR DESCRIPTION
## Summary
- Replace `process.env.WEB_CONSOLE_PASSWORD` with `readEnvPassword()` that reads `~/zylos/.env` at startup
- Handles quoted values, comments, whitespace
- `pm2 restart web-console` now picks up password changes (no need for `pm2 delete + start`)

## Test plan
- [ ] Set `WEB_CONSOLE_PASSWORD=test123` in `~/zylos/.env`, restart web-console, verify login required
- [ ] Remove the line, restart, verify no login required
- [ ] Test with quoted value `WEB_CONSOLE_PASSWORD="test123"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)