### PR TITLE
fix(caddy): redirect bare path to trailing slash for wildcard routes

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -931,6 +931,7 @@ ${siteAddress} {
     }
 
     # Web Console (core built-in)
+    redir /console /console/ permanent
     handle /console/* {
         uri strip_prefix /console
         reverse_proxy localhost:3456

--- a/cli/lib/caddy.js
+++ b/cli/lib/caddy.js
@@ -40,6 +40,11 @@ function generateRouteBlocks(httpRoutes) {
   const lines = [];
   for (const route of httpRoutes) {
     if (route.type === 'reverse_proxy') {
+      // For wildcard paths like /foo/*, redirect bare /foo to /foo/
+      if (route.path.endsWith('/*')) {
+        const basePath = route.path.slice(0, -2);
+        lines.push(`    redir ${basePath} ${basePath}/ permanent`);
+      }
       lines.push(`    handle ${route.path} {`);
       if (route.strip_prefix) {
         lines.push(`        uri strip_prefix ${route.strip_prefix}`);


### PR DESCRIPTION
## Summary
- `/console` (no trailing slash) returned 404 because `handle /console/*` only matches paths after `/console/`
- Add `redir /console /console/ permanent` before the handle block in the Caddyfile template
- Also fix `generateRouteBlocks()` in caddy.js to auto-add redirects for any component route using `/*` wildcard paths

## Test plan
- [ ] `https://zero.zylos.ai/console` should redirect to `https://zero.zylos.ai/console/`
- [ ] `https://zero.zylos.ai/console/` continues to work as before
- [ ] Component routes with `/*` paths (e.g., lark webhook) are unaffected (no `/*` suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)