### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-02-14
+
+### Added
+- Terminal color highlighting for all CLI commands — zero-dependency ANSI colors (#102)
+- Web console: auto-configure Caddy route, password generation, and URL display (#101)
+
+### Fixed
+- Fix PM2 startup: use spawnSync to capture output on non-zero exit (#99)
+- Adapt auth flow to new Claude Code CLI commands (#100)
+- Redirect bare `/console` to `/console/` for Caddy wildcard routes (#103)
+
 ## [0.1.3] - 2026-02-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "zylos",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^16.4.7",
         "js-yaml": "^4.1.1"
       },
       "bin": {
@@ -24,6 +25,18 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.4
- Update CHANGELOG with changes since v0.1.3

### Changes in v0.1.4
- Terminal color highlighting for all CLI commands (#102)
- Web console: auto-configure Caddy route, password, URL display (#101)
- Fix PM2 startup spawnSync (#99)
- Adapt auth flow to new Claude Code CLI (#100)
- Redirect bare `/console` to `/console/` (#103)

🤖 Generated with [Claude Code](https://claude.com/claude-code)