### PR TITLE
fix(memory): run daily commit in ~/zylos/memory/ instead of ~/zylos/

### DIFF
--- a/skills/zylos-memory/scripts/daily-commit.js
+++ b/skills/zylos-memory/scripts/daily-commit.js
@@ -2,37 +2,37 @@
 /**
  * Daily memory commit helper.
  *
- * Creates a local commit for memory/ in ~/zylos if changes exist.
+ * Creates a local commit in ~/zylos/memory/ if changes exist.
  */
 
 import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { ZYLOS_DIR, loadTimezoneFromEnv, dateInTimeZone } from './shared.js';
+import { MEMORY_DIR, loadTimezoneFromEnv, dateInTimeZone } from './shared.js';
 
 function ensureGitRepo() {
-  if (fs.existsSync(path.join(ZYLOS_DIR, '.git'))) {
+  if (fs.existsSync(path.join(MEMORY_DIR, '.git'))) {
     return;
   }
-  console.log(`Initializing git repo in ${ZYLOS_DIR}`);
+  console.log(`Initializing git repo in ${MEMORY_DIR}`);
   execFileSync('git', ['init'], {
-    cwd: ZYLOS_DIR,
+    cwd: MEMORY_DIR,
     stdio: ['ignore', 'pipe', 'pipe']
   });
   execFileSync('git', ['config', 'user.name', 'Zylos'], {
-    cwd: ZYLOS_DIR,
+    cwd: MEMORY_DIR,
     stdio: ['ignore', 'pipe', 'pipe']
   });
   execFileSync('git', ['config', 'user.email', 'zylos@local'], {
-    cwd: ZYLOS_DIR,
+    cwd: MEMORY_DIR,
     stdio: ['ignore', 'pipe', 'pipe']
   });
 }
 
 function hasMemoryChanges() {
-  const output = execFileSync('git', ['status', '--porcelain', '--', 'memory/'], {
-    cwd: ZYLOS_DIR,
+  const output = execFileSync('git', ['status', '--porcelain'], {
+    cwd: MEMORY_DIR,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe']
   });
@@ -53,13 +53,13 @@ function main() {
     const dateStr = dateInTimeZone(new Date(), tz);
     const message = `memory: daily snapshot ${dateStr}`;
 
-    execFileSync('git', ['add', 'memory/'], {
-      cwd: ZYLOS_DIR,
+    execFileSync('git', ['add', '.'], {
+      cwd: MEMORY_DIR,
       stdio: ['ignore', 'pipe', 'pipe']
     });
 
     const commitOutput = execFileSync('git', ['commit', '-m', message], {
-      cwd: ZYLOS_DIR,
+      cwd: MEMORY_DIR,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe']
     });
@@ -70,7 +70,7 @@ function main() {
     const detail = stderr || err.message;
 
     if (detail.includes('user.name') || detail.includes('user.email')) {
-      console.error(`daily-commit error: git user not configured in ${ZYLOS_DIR}. Run: git -C ${ZYLOS_DIR} config user.name "Zylos" && git -C ${ZYLOS_DIR} config user.email "zylos@local"`);
+      console.error(`daily-commit error: git user not configured in ${MEMORY_DIR}. Run: git -C ${MEMORY_DIR} config user.name "Zylos" && git -C ${MEMORY_DIR} config user.email "zylos@local"`);
     } else {
       console.error(`daily-commit error: ${detail}`);
     }


### PR DESCRIPTION
## Summary

- Daily memory commit was running git operations in `~/zylos/` (ZYLOS_DIR) instead of `~/zylos/memory/` (MEMORY_DIR)
- This caused memory snapshots to be committed into the main workspace repo rather than the memory directory's own repo
- Changed all git `cwd` from `ZYLOS_DIR` to `MEMORY_DIR` in `daily-commit.js`

## Changes

- `skills/zylos-memory/scripts/daily-commit.js`: Import `MEMORY_DIR` instead of `ZYLOS_DIR`, update all `cwd` references, simplify `git status`/`git add` paths (no longer need `memory/` prefix since we're already in the directory)

## Test Plan

- [ ] Run `node skills/zylos-memory/scripts/daily-commit.js` — should operate in `~/zylos/memory/`
- [ ] Verify git init creates `.git` in `~/zylos/memory/` (not `~/zylos/`)
- [ ] Verify commits land in `~/zylos/memory/` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)