### PR TITLE
fix(add): remove timeout on post-install hook execution

### DIFF
--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -436,7 +436,6 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
         execSync(`node "${hookPath}"`, {
           cwd: skillDir,
           stdio: 'inherit',
-          timeout: 120000,
         });
         console.log(`  ${success('Post-install hook complete.')}`);
       } catch {


### PR DESCRIPTION
## Summary
- Remove 120s `timeout` from `execSync` when running post-install hooks
- Post-install hooks run interactive prompts (verification token, connection mode, etc.) that require user input — should wait indefinitely
- Bug: if user takes >2 min to input (e.g., looking up token in developer console), process is killed, config not written, service silently falls back to defaults

## Root cause
`cli/commands/add.js` line 438: `timeout: 120000` kills the hook child process after 2 minutes. The catch block only prints a non-fatal warning, then proceeds to start the service with initial default config (websocket mode instead of user's chosen webhook mode).

## Change
One line removed: `timeout: 120000` from the post-install hook `execSync` call.

Other `timeout: 120000` instances (npm install, curl) are network operations and correctly keep their timeouts.

## Test plan
- [ ] Run `zylos add feishu`, choose webhook mode
- [ ] Wait >2 min at verification token prompt
- [ ] Verify process does not timeout
- [ ] Enter token, confirm config.json written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)