### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-02-15
+
+### Added
+- Default to latest release tag instead of main branch when installing components (#105)
+
+### Fixed
+- Distinguish network errors from missing releases in `zylos add` (#105)
+- Run daily memory commit in `~/zylos/memory/` instead of `~/zylos/` (#106)
+- Remove timeout on post-install hook execution to support interactive hooks (#107)
+
 ## [0.1.4] - 2026-02-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.5
- Update CHANGELOG.md

### Changes since v0.1.4
- feat(add): default to latest release tag instead of main branch (#105)
- fix(add): distinguish network errors from missing releases (#105)
- fix(memory): run daily commit in ~/zylos/memory/ instead of ~/zylos/ (#106)
- fix(add): remove timeout on post-install hook execution (#107)

🤖 Generated with [Claude Code](https://claude.com/claude-code)