### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-02-17
+
+### Added
+- Dispatcher `REQUIRE_IDLE_MIN_SECONDS` config: sustained idle check before delivering require_idle messages (#113)
+
+### Fixed
+- Remove endpoint format restriction from C4 validation — endpoint format is now channel-specific (#113)
+- restart-claude: use c4-control enqueue instead of nohup script to prevent race condition (#113)
+- upgrade-claude: use c4-control enqueue instead of script-level idle detection (#113)
+- upgrade-claude: cancel queued /exit on timeout abort to prevent orphaned restarts (#113)
+- upgrade-claude: add ack-deadline to /exit enqueue to prevent stale running records (#113)
+- check-context: use c4-control enqueue with `--with-restart-check` flag (#113)
+- Dispatcher: require `idle_seconds >= 3` (sustained idle) before delivering require_idle messages (#113)
+
+### Changed
+- Increase file attachment threshold from 1KB to 2KB (#113)
+- Simplify activity-monitor `enqueueContextCheck()` to delegate to check-context.js (#113)
+- Delete legacy `restart.js` script (no remaining callers) (#113)
+- Session-start-prompt: enqueue via c4-control instead of direct c4-receive (#113)
+
 ## [0.1.6] - 2026-02-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.7
- Update CHANGELOG.md with PR #113 changes

## Changes in v0.1.7
- Unified c4-control enqueue architecture: restart-claude, upgrade-claude, check-context, and session-start-prompt all use dispatcher's require_idle mechanism instead of script-level idle detection
- Dispatcher REQUIRE_IDLE_MIN_SECONDS: sustained idle check (3s) before delivering require_idle messages
- Remove C4 endpoint format restriction (now channel-specific)
- upgrade-claude: cancel queued /exit on timeout, add ack-deadline
- Delete legacy restart.js script
- Increase file attachment threshold to 2KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)