### PR TITLE
feat: diagnostic logging for hooks, delivery failures, and tmux captures

### DIFF
--- a/skills/activity-monitor/scripts/session-start-prompt.js
+++ b/skills/activity-monitor/scripts/session-start-prompt.js
@@ -10,7 +10,9 @@
 import { execFileSync } from 'child_process';
 import path from 'path';
 import os from 'os';
+import { logHookTiming } from '../../comm-bridge/scripts/c4-diagnostic.js';
 
+const startMs = Date.now();
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const C4_CONTROL = path.join(ZYLOS_DIR, '.claude/skills/comm-bridge/scripts/c4-control.js');
 
@@ -28,4 +30,6 @@ try {
   ], { stdio: 'pipe' });
 } catch {
   // Silently fail — session still starts even if enqueue fails
+} finally {
+  logHookTiming('session-start-prompt', Date.now() - startMs);
 }

--- a/skills/comm-bridge/scripts/c4-diagnostic.js
+++ b/skills/comm-bridge/scripts/c4-diagnostic.js
@@ -1,0 +1,100 @@
+/**
+ * C4 Diagnostic Logging Utilities
+ * Shared by dispatcher, hooks, and other C4 scripts.
+ *
+ * Log files are stored in ~/zylos/activity-monitor/ with automatic rotation.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
+const DIAG_DIR = path.join(ZYLOS_DIR, 'activity-monitor');
+
+const MAX_LOG_SIZE = 100 * 1024; // 100KB — rotate when exceeded
+const KEEP_RATIO = 0.5;          // Keep last 50% of lines after rotation
+
+/**
+ * Ensure diagnostic directory exists.
+ */
+function ensureDir() {
+  if (!fs.existsSync(DIAG_DIR)) {
+    fs.mkdirSync(DIAG_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Rotate a log file if it exceeds MAX_LOG_SIZE.
+ * Keeps the last KEEP_RATIO of lines.
+ */
+function rotateIfNeeded(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return;
+    const stats = fs.statSync(filePath);
+    if (stats.size < MAX_LOG_SIZE) return;
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+    const keepFrom = Math.floor(lines.length * (1 - KEEP_RATIO));
+    fs.writeFileSync(filePath, lines.slice(keepFrom).join('\n'));
+  } catch {
+    // Best effort — don't break caller on rotation failure
+  }
+}
+
+/**
+ * Log hook execution timing.
+ * @param {string} hookName - e.g. 'session-start-prompt', 'c4-session-init'
+ * @param {number} durationMs - execution time in milliseconds
+ */
+export function logHookTiming(hookName, durationMs) {
+  try {
+    ensureDir();
+    const filePath = path.join(DIAG_DIR, 'hook-timing.log');
+    const ts = new Date().toISOString().replace('T', ' ').substring(0, 19);
+    fs.appendFileSync(filePath, `[${ts}] hook=${hookName} duration=${durationMs}ms\n`);
+    rotateIfNeeded(filePath);
+  } catch {
+    // Best effort
+  }
+}
+
+/**
+ * Log C4 delivery failure.
+ * @param {string} itemType - 'control' or 'conversation'
+ * @param {number|string} itemId - message/control ID
+ * @param {string} reason - failure reason (e.g. 'TMUX_PASTE_FAILED', 'paste_error')
+ * @param {object} [extra] - optional extra context
+ */
+export function logDeliveryFailure(itemType, itemId, reason, extra = {}) {
+  try {
+    ensureDir();
+    const filePath = path.join(DIAG_DIR, 'delivery-failures.log');
+    const ts = new Date().toISOString().replace('T', ' ').substring(0, 19);
+    const extraStr = Object.keys(extra).length > 0
+      ? ' ' + Object.entries(extra).map(([k, v]) => `${k}=${v}`).join(' ')
+      : '';
+    fs.appendFileSync(filePath, `[${ts}] type=${itemType} id=${itemId} reason=${reason}${extraStr}\n`);
+    rotateIfNeeded(filePath);
+  } catch {
+    // Best effort
+  }
+}
+
+/**
+ * Save tmux capture on separator detection failure.
+ * @param {string} capture - raw tmux pane content
+ * @param {string} context - e.g. 'separator-fail-attempt-1'
+ */
+export function saveTmuxCapture(capture, context) {
+  try {
+    ensureDir();
+    const filePath = path.join(DIAG_DIR, 'tmux-captures.log');
+    const ts = new Date().toISOString().replace('T', ' ').substring(0, 19);
+    const separator = '\u2500'.repeat(60);
+    fs.appendFileSync(filePath, `\n[${ts}] context=${context}\n${separator}\n${capture}\n${separator}\n`);
+    rotateIfNeeded(filePath);
+  } catch {
+    // Best effort
+  }
+}

--- a/skills/comm-bridge/scripts/c4-session-init.js
+++ b/skills/comm-bridge/scripts/c4-session-init.js
@@ -17,6 +17,9 @@ import {
   close
 } from './c4-db.js';
 import { CHECKPOINT_THRESHOLD, SESSION_INIT_RECENT_COUNT } from './c4-config.js';
+import { logHookTiming } from './c4-diagnostic.js';
+
+const startMs = Date.now();
 
 function main() {
   try {
@@ -57,6 +60,7 @@ function main() {
     process.exit(1);
   } finally {
     close();
+    logHookTiming('c4-session-init', Date.now() - startMs);
   }
 }
 

--- a/skills/zylos-memory/scripts/session-start-inject.js
+++ b/skills/zylos-memory/scripts/session-start-inject.js
@@ -9,6 +9,9 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { MEMORY_DIR } from './shared.js';
+import { logHookTiming } from '../../comm-bridge/scripts/c4-diagnostic.js';
+
+const startMs = Date.now();
 
 function readFileSafe(filePath) {
   try {
@@ -51,5 +54,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     main();
   } catch (err) {
     console.error(`session-start-inject error: ${err.message}`);
+  } finally {
+    logHookTiming('session-start-inject', Date.now() - startMs);
   }
 }


### PR DESCRIPTION
## Summary
- New shared `c4-diagnostic.js` utility with automatic log file rotation (100KB threshold, keeps last 50% of lines)
- **Hook timing**: `session-start-prompt`, `session-start-inject`, `c4-session-init` log execution duration to `activity-monitor/hook-timing.log`
- **Delivery failure logging**: dispatcher writes to `activity-monitor/delivery-failures.log` with timestamp, item type/ID, failure reason, and context (channel, retry count, error message)
- **tmux capture on separator fail**: saves raw pane content to `activity-monitor/tmux-captures.log` when input box separator detection fails

Motivated by zylos100 incident where a stuck ack command caused cascading heartbeat failures and recovery issues that were difficult to diagnose without persistent logs.

## Test plan
- [ ] Verify `node --check` passes on all modified files
- [ ] Deploy to test instance and confirm hook-timing.log is written on session start
- [ ] Simulate delivery failure and verify delivery-failures.log entry
- [ ] Verify log rotation triggers at 100KB threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)