### PR TITLE
fix: use newly installed sync script in self-upgrade step 8

### DIFF
--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -8,8 +8,8 @@
  * - Removed hooks (core skills only) → remove
  * - User hooks (non-core skills) → preserve
  *
- * Called from postinstall.js. For self-upgrade, the equivalent logic
- * runs inline via generateMigrationHints + applyMigrationHints.
+ * Called from postinstall.js and from self-upgrade step 8 (which shells
+ * out to the newly installed copy of this script).
  *
  * Usage:
  *   node sync-settings-hooks.js           # Sync hooks


### PR DESCRIPTION
## Summary
- Self-upgrade step 8 now shells out to the **newly installed** `sync-settings-hooks.js` instead of using in-memory `generateMigrationHints()`
- Resolves bootstrap problem: old version's sync logic missed new config fields (e.g. `statusLine`)
- Falls back to in-memory hints if the new script is not found
- 43 tests pass

## Root Cause
When upgrading from v0.2.0 → v0.2.1, the Node process runs v0.2.0's step 8 code (in-memory), which doesn't have statusLine sync. Even though step 4 installs v0.2.1 on disk, the running process still uses the old code.

## Fix
Step 8 now runs `node <npm-root>/zylos/cli/lib/sync-settings-hooks.js` from the freshly installed package, so it always uses the latest sync logic regardless of which version is running the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)