### PR TITLE
feat: rate_limited health state for activity monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-02-23
+
+### Added
+- **Rate-limited health state** (issue #126): New `rate_limited` health state prevents the cascading restart cycle when Claude Code hits API rate limits. Detects rate-limit screens via tmux pane capture, dismisses the interactive menu with Escape, probes every 5 minutes (vs 30 min for "down"), never escalates to restart, and auto-recovers when the limit clears. User-facing messages include estimated reset time. Activity monitor bumped to v16.
+
 ## [0.2.4] - 2026-02-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",

--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 /**
- * Activity Monitor v15 - Guardian + Heartbeat v2 + Health Check + Daily Tasks + Upgrade Check
+ * Activity Monitor v16 - Guardian + Heartbeat v2 + Rate Limit Detection + Health Check + Daily Tasks + Upgrade Check
+ *
+ * v16 changes (rate_limited health state):
+ *   - Add rate limit detection via tmux pane capture
+ *   - New rate_limited health state: no restart escalation, 5-min probes
+ *   - Dismiss rate-limit interactive menu via Escape key
+ *   - User-facing messages with estimated reset time (via c4-receive)
  *
  * v15 changes (Intl.DateTimeFormat memory leak fix):
  *   - Hoist Intl.DateTimeFormat instances to module level (reuse instead of per-call new)
@@ -97,6 +103,11 @@ const DOWN_RETRY_INTERVAL = 1800;   // 30 min periodic retry in DOWN state
 const STUCK_THRESHOLD = 300;         // 5 min of no activity → trigger immediate probe
 const STUCK_PROBE_COOLDOWN = 600;    // 10 min between stuck probes
 
+// Rate limit detection config
+const RATE_LIMIT_DETECT_THRESHOLD = 60;  // seconds of inactivity before checking tmux for rate limit
+const RATE_LIMIT_CHECK_COOLDOWN = 30;    // minimum seconds between tmux captures for rate limit detection
+const RATE_LIMIT_PROBE_INTERVAL = 300;   // 5 min heartbeat probe interval when rate limited
+
 // Health check config
 const HEALTH_CHECK_INTERVAL = 21600; // 6 hours
 
@@ -115,6 +126,7 @@ let lastState = '';
 let startupGrace = 0;
 let idleSince = 0;
 let lastStuckProbeAt = 0;
+let lastRateLimitCheckAt = 0;
 let lastDeadApiPid = null;
 
 let engine; // initialized in init()
@@ -414,7 +426,11 @@ function loadInitialHealth() {
 function writeStatusFile(statusObj) {
   try {
     ensureStatusDir();
-    fs.writeFileSync(STATUS_FILE, JSON.stringify({ ...statusObj, health: engine.health }, null, 2));
+    const extra = {};
+    if (engine.health === 'rate_limited' && engine.rateLimitResetAt) {
+      extra.rate_limit_reset_at = engine.rateLimitResetAt;
+    }
+    fs.writeFileSync(STATUS_FILE, JSON.stringify({ ...statusObj, ...extra, health: engine.health }, null, 2));
   } catch {
     // Best-effort.
   }
@@ -513,6 +529,49 @@ function readApiActivity() {
     return activity;
   } catch {
     return null;
+  }
+}
+
+// --- Rate Limit Detection ---
+
+const RATE_LIMIT_PATTERNS = [
+  /rate.?limit/i,
+  /overloaded/i
+];
+
+function captureTmuxPane() {
+  try {
+    return execSync(`tmux capture-pane -p -t "${SESSION}" 2>/dev/null`, { encoding: 'utf8' });
+  } catch {
+    return null;
+  }
+}
+
+function detectRateLimitScreen() {
+  const capture = captureTmuxPane();
+  if (!capture) return null;
+
+  for (const pattern of RATE_LIMIT_PATTERNS) {
+    if (pattern.test(capture)) {
+      const timeMatch = capture.match(/(?:retry|wait|reset|available|in)\s+(\d+)\s*(second|minute|sec|min)/i);
+      let resetSeconds = null;
+      if (timeMatch) {
+        resetSeconds = parseInt(timeMatch[1], 10);
+        if (/min/i.test(timeMatch[2])) resetSeconds *= 60;
+      }
+      return { resetSeconds };
+    }
+  }
+
+  return null;
+}
+
+function dismissRateLimitMenu() {
+  try {
+    execSync(`tmux send-keys -t "${SESSION}" Escape 2>/dev/null`);
+    log('Rate limit: dismissed menu via Escape');
+  } catch {
+    log('Rate limit: failed to send Escape to tmux');
   }
 }
 
@@ -1006,14 +1065,29 @@ function monitorLoop() {
     }
   }
 
-  // Stuck detection: if no observable activity from any source for STUCK_THRESHOLD,
-  // trigger an immediate heartbeat probe with a shorter timeout.
-  if (engine.health === 'ok') {
-    const lastAnyActivity = Math.max(activity, apiUpdatedSec);
-    const stuckSeconds = currentTime - lastAnyActivity;
+  // Inactivity tracking for rate limit detection and stuck detection
+  const lastAnyActivity = Math.max(activity, apiUpdatedSec);
+  const inactiveDuration = currentTime - lastAnyActivity;
 
-    if (stuckSeconds >= STUCK_THRESHOLD && (currentTime - lastStuckProbeAt) >= STUCK_PROBE_COOLDOWN) {
-      const ok = engine.requestImmediateProbe(`no_activity_for_${stuckSeconds}s`);
+  // Rate limit detection: check tmux screen when inactive long enough.
+  // Detects rate-limit menus before stuck detection fires, preventing
+  // the cascading restart cycle described in issue #126.
+  if (inactiveDuration >= RATE_LIMIT_DETECT_THRESHOLD &&
+      (currentTime - lastRateLimitCheckAt) >= RATE_LIMIT_CHECK_COOLDOWN) {
+    lastRateLimitCheckAt = currentTime;
+    const rlResult = detectRateLimitScreen();
+    if (rlResult) {
+      if (engine.health !== 'rate_limited') {
+        engine.enterRateLimited(rlResult.resetSeconds);
+        dismissRateLimitMenu();
+      }
+    }
+  }
+
+  // Stuck detection: only when health is ok (rate_limited and other states suppress this)
+  if (engine.health === 'ok') {
+    if (inactiveDuration >= STUCK_THRESHOLD && (currentTime - lastStuckProbeAt) >= STUCK_PROBE_COOLDOWN) {
+      const ok = engine.requestImmediateProbe(`no_activity_for_${inactiveDuration}s`);
       // Approach C: full cooldown on success, short retry (60s) on failure
       lastStuckProbeAt = ok ? currentTime : currentTime - STUCK_PROBE_COOLDOWN + 60;
     }
@@ -1046,7 +1120,8 @@ function init() {
     initialHealth,
     heartbeatInterval: HEARTBEAT_INTERVAL,
     maxRestartFailures: MAX_RESTART_FAILURES,
-    downRetryInterval: DOWN_RETRY_INTERVAL
+    downRetryInterval: DOWN_RETRY_INTERVAL,
+    rateLimitedProbeInterval: RATE_LIMIT_PROBE_INTERVAL
   });
 
   upgradeScheduler = new DailySchedule({
@@ -1091,7 +1166,7 @@ function init() {
 }
 
 init();
-log(`=== Activity Monitor Started (v15 - Guardian + Heartbeat v2 + Hook Activity + DailyTasks + UpgradeCheck): ${new Date().toISOString()} tz=${timezone} ===`);
+log(`=== Activity Monitor Started (v16 - Guardian + Heartbeat v2 + RateLimitDetect + Hook Activity + DailyTasks + UpgradeCheck): ${new Date().toISOString()} tz=${timezone} ===`);
 
 setInterval(monitorLoop, INTERVAL);
 monitorLoop();

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -205,6 +205,21 @@ function main() {
     if (health === 'down') {
       emitError(json, 'HEALTH_DOWN', "I'm currently offline and unable to recover on my own. Please let the admin know so they can take a look!");
     }
+    if (health === 'rate_limited') {
+      let msg = "I'm currently rate-limited by the API and can't process messages right now.";
+      try {
+        const status = JSON.parse(fs.readFileSync(CLAUDE_STATUS_FILE, 'utf8'));
+        if (status.rate_limit_reset_at) {
+          const secsLeft = status.rate_limit_reset_at - Math.floor(Date.now() / 1000);
+          if (secsLeft > 0) {
+            const minsLeft = Math.ceil(secsLeft / 60);
+            msg += ` Expected to be back in about ${minsLeft} minute${minsLeft !== 1 ? 's' : ''}.`;
+          }
+        }
+      } catch { }
+      msg += " I'll auto-recover once the limit resets — no need to restart me!";
+      emitError(json, 'HEALTH_RATE_LIMITED', msg);
+    }
     emitError(json, 'HEALTH_RECOVERING', "I'm temporarily unavailable but should be back shortly. I'll reach out once I'm ready!");
   }
 


### PR DESCRIPTION
## Summary
- Adds a dedicated rate_limited health state to prevent cascading restart cycles when Claude Code hits API rate limits (#126)
- Detects rate-limit screens via tmux pane capture, dismisses the interactive menu with Escape, probes every 5 min, never escalates to restart, auto-recovers on heartbeat success
- User-facing messages in c4-receive include estimated reset time
- Activity monitor v16, version 0.2.5

## Test plan
- [x] All 66 tests pass
- [ ] Manual test: simulate rate limit screen in tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)