### PR TITLE
feat: add one-click install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,10 +27,11 @@ if [ -t 1 ]; then
   GREEN='\033[0;32m'
   YELLOW='\033[1;33m'
   CYAN='\033[0;36m'
+  BCYAN='\033[1;36m'
   BOLD='\033[1m'
   NC='\033[0m'
 else
-  RED='' GREEN='' YELLOW='' CYAN='' BOLD='' NC=''
+  RED='' GREEN='' YELLOW='' CYAN='' BCYAN='' BOLD='' NC=''
 fi
 
 info()  { printf "${CYAN}[zylos]${NC} %s\n" "$*"; }
@@ -190,14 +191,18 @@ install_zylos() {
 
 # ── Entry Point ───────────────────────────────────────────────
 echo ""
-printf '%b' "${BOLD}${CYAN}"
-echo "  ╔═══════════════════════════════════════╗"
-echo "  ║                                       ║"
-echo "  ║            Zylos Installer            ║"
-echo "  ║         Give your AI a life.          ║"
-echo "  ║                                       ║"
-echo "  ╚═══════════════════════════════════════╝"
+printf '%b' "${BCYAN}"
+echo "  ███████╗██╗   ██╗██╗      ██████╗ ███████╗"
+echo "  ╚══███╔╝╚██╗ ██╔╝██║     ██╔═══██╗██╔════╝"
+echo "    ███╔╝  ╚████╔╝ ██║     ██║   ██║███████╗"
+printf '%b' "${CYAN}"
+echo "   ███╔╝    ╚██╔╝  ██║     ██║   ██║╚════██║"
+echo "  ███████╗   ██║   ███████╗╚██████╔╝███████║"
+echo "  ╚══════╝   ╚═╝   ╚══════╝ ╚═════╝ ╚══════╝"
 printf '%b' "${NC}"
+echo ""
+printf '%b' "  ${BOLD}Give your AI a life.${NC}"
+echo ""
 echo ""
 
 # Warn if running as root (nvm and zylos should run as a normal user)


### PR DESCRIPTION
## Summary

- Add `scripts/install.sh` — a one-click bootstrap script for new Zylos deployments
- Detects OS (Linux/macOS) and architecture (x64/arm64)
- Installs prerequisites automatically: git, tmux, Node.js (via nvm)
- Installs zylos-core from GitHub and runs `zylos init`

## Usage

```bash
curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash
```

## What it does

1. Detect OS + architecture
2. Install git (if missing)
3. Install tmux (if missing)
4. Install nvm + Node.js 24 (if missing or below v20)
5. `npm install -g --install-links` from GitHub
6. Run `zylos init`

## Supported platforms

- Linux: Debian/Ubuntu (apt), RHEL/CentOS (yum/dnf)
- macOS: via Homebrew

## Test plan

- [ ] Test on fresh Ubuntu 22.04
- [ ] Test on fresh macOS
- [ ] Test with existing Node.js installation
- [ ] Test idempotency (run twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)