### PR TITLE
docs: add one-click install script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,27 @@ More LLMs support are on the way.
 
 ## Quick Start
 
-**Prerequisites:** Git, Node.js >= 20 (via [nvm](https://github.com/nvm-sh/nvm) recommended), a Linux server (or Mac), and a [Claude](https://claude.ai) subscription.
-
-> **Why nvm?** Installing Node.js via nvm avoids permission issues with `npm install -g`. System-level Node.js (from apt/yum) requires `sudo` for global installs, which can cause problems.
+**Prerequisites:** A Linux server (or Mac), a [Claude](https://claude.ai) subscription.
 
 ```bash
-# Install (--install-links required for GitHub install; will be published to npm soon)
-npm install -g --install-links https://github.com/zylos-ai/zylos-core
+curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash
+```
 
-# Initialize — sets up tmux, PM2, memory, scheduler, and more
+This installs everything you need (git, tmux, Node.js, zylos CLI). Once done, run:
+
+```bash
 zylos init
 ```
+
+<details>
+<summary>Manual install (if you already have Node.js >= 20)</summary>
+
+```bash
+npm install -g --install-links https://github.com/zylos-ai/zylos-core
+zylos init
+```
+
+</details>
 
 `zylos init` is interactive and idempotent. It will:
 1. Install missing tools (tmux, git, PM2, Claude Code)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,15 +30,27 @@ Zylos 给它一个生命。跨重启的持久记忆。你睡觉时自动工作�
 
 ## 快速开始
 
-**前置条件：** Git、Node.js >= 20、一台 Linux 服务器（或 Mac）、以及 [Claude](https://claude.ai) 订阅。
+**前置条件：** 一台 Linux 服务器（或 Mac）、[Claude](https://claude.ai) 订阅。
 
 ```bash
-# 安装（--install-links 是 GitHub 安装所需参数，后续会发布到 npm）
-npm install -g --install-links https://github.com/zylos-ai/zylos-core
+curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash
+```
 
-# 初始化 — 设置 tmux、PM2、记忆系统、调度器等
+一键安装所有依赖（git、tmux、Node.js、zylos CLI）。完成后运行：
+
+```bash
 zylos init
 ```
+
+<details>
+<summary>手动安装（如果你已有 Node.js >= 20）</summary>
+
+```bash
+npm install -g --install-links https://github.com/zylos-ai/zylos-core
+zylos init
+```
+
+</details>
 
 `zylos init` 是交互式的，可重复运行。它会：
 1. 安装缺失的工具（tmux、git、PM2、Claude Code）


### PR DESCRIPTION
## Summary

- Add `curl | bash` one-click install as the primary Quick Start method
- Simplify prerequisites (no longer need to pre-install Git/Node.js)
- Move manual `npm install` to a collapsible `<details>` section
- Updated both English and Chinese READMEs

Follows up on #150 (install.sh).

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify collapsible section works

🤖 Generated with [Claude Code](https://claude.com/claude-code)