### PR TITLE
fix: upgrade --check honors --branch flag

### DIFF
--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -471,6 +471,9 @@ async function handleCheckOnly(component, { jsonOutput, branch }) {
         console.log(`\n${dim(`Downloaded to: ${tempDir}`)}`);
       }
       console.log(`\n${dim(`Run "zylos upgrade ${component} --yes" to upgrade.`)}`);
+    } else {
+      // --branch specified but branch version matches installed version
+      console.log(success(`${bold(component)} is up to date with branch ${bold(branch)} (v${result.current})`));
     }
   }
 


### PR DESCRIPTION
## Summary
- `handleCheckOnly` now receives and handles the `--branch` parameter
- When `--branch` is specified: downloads from branch, reads version from branch's `package.json`, reports branch version as `latest`
- JSON output includes `branch` field when applicable
- Version check failure is non-fatal with `--branch` (consistent with `handleUpgradeFlow`)

Closes #159

## Test plan
- [ ] `zylos upgrade telegram --check --json` — should work as before (release tag comparison)
- [ ] `zylos upgrade telegram --branch refactor/dm-policy --check --json` — should report branch version as `latest`
- [ ] `zylos upgrade telegram --branch refactor/dm-policy --check` — should show branch info in console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)