### PR TITLE
fix: skip caddy setcap when running as root

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -1109,6 +1109,7 @@ function downloadCaddy() {
  */
 function setCaddyCapabilities() {
   if (process.platform === 'darwin') return true; // macOS doesn't need this
+  if (process.getuid?.() === 0) return true; // root already has all capabilities
 
   try {
     // Check if capability is already set


### PR DESCRIPTION
## Summary
- Root user already has all capabilities — `setcap` is unnecessary
- In Docker containers, `sudo` is often not installed, causing `sudo setcap` to fail with a misleading warning

## Fix
One-line early return in `setCaddyCapabilities()` when `process.getuid() === 0`.

## Test plan
- [ ] `zylos init` in Docker (root) — no caddy capability warning
- [ ] `zylos init` as non-root — setcap still runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)