### PR TITLE
fix: redirect stdin from /dev/tty for init in curl pipe

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -244,7 +244,7 @@ if [ "$NVM_INSTALLED_NOW" = true ]; then
   # Auto-run zylos init so the user doesn't need to source manually first.
   info "Running zylos init automatically..."
   echo ""
-  zylos init
+  zylos init < /dev/tty
 
   # After init completes, show a prominent reminder as the very last output.
   # Nothing prints after this, so it won't get scrolled away.


### PR DESCRIPTION
## Summary
- Fix interactive prompts not working when `zylos init` auto-runs inside `curl | bash`
- One-line change: `zylos init` → `zylos init < /dev/tty`

## Problem
PR #176 added auto-run of `zylos init` in the install script. But when running via `curl | bash`, stdin is the pipe from curl, not the terminal. This means all interactive prompts in init (auth method selection, domain input, etc.) can't read user input.

## Fix
Redirect stdin from `/dev/tty` — standard practice used by nvm, rustup, and other installer scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)