### PR TITLE
fix: map macOS to 'mac' for Caddy download URL

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -1111,7 +1111,7 @@ function setupPm2Startup() {
  * @returns {{ os: string, arch: string }}
  */
 function detectPlatform() {
-  const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+  const platform = process.platform === 'darwin' ? 'mac' : 'linux';
   const archMap = { x64: 'amd64', arm64: 'arm64', arm: 'armv7' };
   const arch = archMap[process.arch] || 'amd64';
   return { os: platform, arch };


### PR DESCRIPTION
## Summary
- Caddy GitHub releases use `mac` (not `darwin`) in asset filenames for macOS
- `detectPlatform()` in `init.js` was returning `darwin`, causing a 404 when downloading Caddy on macOS
- One-line fix: map `darwin` → `mac`

## Test plan
- Verified Caddy v2.11.1 release assets use `mac_amd64` and `mac_arm64` naming
- The generated URL now matches actual release asset names

Closes #185