### PR TITLE
fix: allow sudo password retry during PM2 startup setup

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -1091,10 +1091,10 @@ function setupPm2Startup() {
     if (sudoResult.status === 0) {
       console.log(`  ${success('PM2 boot auto-start configured')}`);
     } else {
-      console.log(`  ${warn('PM2 boot auto-start: sudo password incorrect or command failed')}`);
-      console.log(`    ${dim('This is optional — Zylos works fine without it.')}`);
-      console.log(`    ${dim('To enable auto-start later, run:')}`);
-      console.log(`    ${dim(sudoMatch[1])}`);
+      console.log(`  ${warn('PM2 boot auto-start: sudo password incorrect')}`);
+      console.log(`    This is optional — Zylos works fine without it.`);
+      console.log(`    ${cyan('To enable auto-start later, run:')}`);
+      console.log(`      ${bold(sudoMatch[1])}`);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- PM2 boot auto-start runs a sudo command during `zylos init`
- Previously used `stdio: 'pipe'` which made sudo non-interactive (only 1 password attempt)
- Changed to `stdio: 'inherit'` so sudo handles its own interactive retry (3 attempts by default)
- Increased timeout from 30s to 60s for multiple password attempts

## Test plan
- On macOS: run `zylos init`, enter wrong sudo password — should get retry prompt
- On Linux: same behavior with systemd startup command
- If all 3 attempts fail, shows manual fix command

Closes #186