### PR TITLE
docs: add Chinese transliteration (赛洛丝) to pronunciation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 🐙 Zylos
 
-> **Zylos** (/ˈzaɪ.lɒs/) — Give your AI a life
+> **Zylos** (/ˈzaɪ.lɒs/ 赛洛丝) — Give your AI a life
 
 ### Give your AI a life.
 


### PR DESCRIPTION
Add Chinese transliteration 赛洛丝 to the Zylos pronunciation note in README.