### PR TITLE
docs: remove redundant 🐙 from H1 (logo image provides branding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./assets/logo.png" alt="Zylos" height="120">
 
-# 🐙 Zylos
+# Zylos
 
 > **Zylos** (/ˈzaɪ.lɒs/ 赛洛丝) — Give your AI a life
 


### PR DESCRIPTION
This PR removes the redundant 🐙 emoji from the H1 title since the logo image above already provides branding.