### PR TITLE
docs: add non-interactive install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 
 **When is non-interactive mode active?**
 
-Automatically when stdin is not a TTY (Docker, `curl | bash` piped execution, CI runners). Also when `CI=true` or `NONINTERACTIVE=1` is set. Use `-y` to force non-interactive in a terminal session.
+Automatically when no TTY is available — e.g. Docker containers (without `-it`), CI runners, or cron jobs. Also when `CI=true` or `NONINTERACTIVE=1` is set. Note: `curl | bash` in a terminal is still interactive (the install script redirects from `/dev/tty`). Use `-y` to force non-interactive in a terminal.
 
 **Flags:**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,7 +58,7 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 
 **何时自动进入非交互模式？**
 
-stdin 不是 TTY 时自动启用（Docker、管道执行的 `curl | bash`、CI 环境）。设置 `CI=true` 或 `NONINTERACTIVE=1` 也会启用。在终端中用 `-y` 可强制跳过所有提示。
+没有 TTY 时自动启用 — 如 Docker 容器（未加 `-it`）、CI 环境、cron 任务等。设置 `CI=true` 或 `NONINTERACTIVE=1` 也会启用。注意：在终端中执行 `curl | bash` 仍然是交互模式（安装脚本会从 `/dev/tty` 重定向输入）。在终端中用 `-y` 可强制非交互模式。
 
 **参数说明：**
 


### PR DESCRIPTION
## Summary
- Add collapsible "Non-interactive install" section to Quick Start in both English and Chinese READMEs
- Documents CLI flags (`-y`, `--setup-token`, `--timezone`, `--domain`, `--https`, `--web-password`), environment variable mappings, and resolution order
- Covers Docker, CI/CD, and headless server use cases
- Placed before the existing "branch install" and "manual install" sections

Follow-up to PR #196 (non-interactive init feature).

## Test plan
- [x] Verify README.md renders correctly on GitHub
- [x] Verify README.zh-CN.md renders correctly on GitHub
- [x] Confirm collapsible sections expand/collapse properly
- [x] Verify table formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)