### PR TITLE
install: always show source reminder after install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -363,29 +363,32 @@ _detect_shell_rc() {
 }
 
 # Show the post-install hint for activating PATH in the current terminal.
-# For bash/zsh: source the rc file. For fish/unknown: open a new terminal.
+# Styled as a separator + prominent command, not a box (avoids clashing with
+# zylos init's own boxed output).
 _show_source_hint() {
   local shell_rc
   shell_rc="$(_detect_shell_rc)"
 
   echo ""
-  printf '%b' "${YELLOW}"
-  echo "  ┌────────────────────────────────────────────────────────┐"
-  echo "  │                                                        │"
-  echo "  │  Setup complete! Your agent is running.                │"
-  echo "  │                                                        │"
-  if [ -n "$shell_rc" ]; then
-    echo "  │  To use zylos commands in this terminal, run:          │"
-    echo "  │                                                        │"
-    printf "  │    source %-44s │\n" "$shell_rc"
-  else
-    echo "  │  To use zylos commands, open a new terminal.           │"
-  fi
-  echo "  │                                                        │"
-  echo "  │  New terminal sessions will work automatically.        │"
-  echo "  │                                                        │"
-  echo "  └────────────────────────────────────────────────────────┘"
+  printf '%b' "${CYAN}"
+  echo "  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   printf '%b' "${NC}"
+  echo ""
+  if [ -n "$shell_rc" ]; then
+    printf '%b' "${BOLD}"
+    echo "  To activate zylos commands in this terminal:"
+    printf '%b' "${NC}"
+    echo ""
+    printf '%b' "${GREEN}${BOLD}"
+    echo "    source $shell_rc"
+    printf '%b' "${NC}"
+  else
+    printf '%b' "${BOLD}"
+    echo "  To activate zylos commands, open a new terminal."
+    printf '%b' "${NC}"
+  fi
+  echo ""
+  info "New terminal sessions will work automatically."
   echo ""
 }
 


### PR DESCRIPTION
## Summary
- The source/new-terminal reminder was only shown when nvm was freshly installed, but PATH is always stale after `curl | bash` (runs in a subshell)
- Now the reminder is always displayed after install completes
- **Auto-modify shell profile**: add `~/.local/bin` (claude) and `~/zylos/bin` (component CLIs) to the user's shell profile, so new terminal sessions have correct PATH without relying on `zylos init` to succeed
- Supports bash (.bashrc), zsh (.zshrc), fish (conf.d/zylos.fish), and falls back to .profile for other shells
- Idempotent: uses the same grep patterns as init.js (`ensureLocalBinInProfile` / `ensureBinInPath`) to avoid duplicate entries; skips commented-out lines
- Redesigned source hint: separator + bold green command instead of bordered box (avoids clashing with init's own boxed output)
- Remove dead `NVM_INSTALLED_NOW` variable

## Changes
1. `_ensure_path_in_profile()` — new function, runs after `install_zylos`, before `zylos init`
2. `_show_source_hint()` — shell-aware post-install hint (source for bash/zsh, "open new terminal" for fish)
3. `_detect_shell_rc()` — fixed fallback (was `~/.bashrc or ~/.zshrc` which is not a valid command)
4. `--no-init` path — same shell-aware hint

## Test plan
- [ ] Fresh install on bash — verify .bashrc gets PATH entries, source hint shows `source ~/.bashrc`
- [ ] Fresh install on zsh — verify .zshrc gets PATH entries, source hint shows `source ~/.zshrc`
- [ ] Re-install — verify no duplicate PATH entries appended
- [ ] Install with `--no-init` — verify source command adapts to shell
- [ ] New terminal after install — verify zylos, pm2, claude commands work without manual source
- [ ] Profile with commented-out PATH line — verify installer still adds the entry

Fixes #207
Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)