### PR TITLE
init: remove unnecessary "Start services now?" prompt

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -2049,17 +2049,8 @@ export async function initCommand(args) {
   }
 
   // Step 11: Start services
-  let servicesStarted = 0;
-  if (!skipConfirm) {
-    const startNow = await promptYesNo('\nStart services now? [Y/n]: ', true);
-    if (startNow) {
-      if (!quiet) console.log(`\n${heading('Starting services...')}`);
-      servicesStarted = startCoreServices(opts.webPassword);
-    }
-  } else {
-    if (!quiet) console.log(`\n${heading('Starting services...')}`);
-    servicesStarted = startCoreServices(opts.webPassword);
-  }
+  if (!quiet) console.log(`\n${heading('Starting services...')}`);
+  const servicesStarted = startCoreServices(opts.webPassword);
 
   if (servicesStarted > 0) {
     setupPm2Startup();


### PR DESCRIPTION
## Summary
- Remove the "Start services now? [Y/n]" prompt from `zylos init`
- Services are a required part of initialization, not optional — always start them
- The non-interactive path (`-y`) already started services unconditionally, confirming this was the intended behavior

## Changes
- `cli/commands/init.js`: Replace the conditional prompt + two branches with a single unconditional `startCoreServices()` call (net -9 lines)

## Test plan
- [ ] `zylos init` — verify services start without being asked
- [ ] `zylos init -y` — verify non-interactive still works (no behavior change)
- [ ] `zylos init --no-caddy` — verify other prompts still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)