### PR TITLE
fix: prefer credentials.json over .env OAUTH_TOKEN

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -446,7 +446,11 @@ function approveApiKey(apiKey) {
 }
 
 function startClaude() {
-  if (!isClaudeLoggedIn()) {
+  // Check credentials.json once and reuse throughout — avoids redundant file I/O
+  // since isClaudeLoggedIn() also calls hasCredentialsFile() internally.
+  const useCredentialsFile = hasCredentialsFile();
+
+  if (!useCredentialsFile && !isClaudeLoggedIn()) {
     log('Guardian: Claude is not logged in, skipping startup');
     return;
   }
@@ -472,7 +476,6 @@ function startClaude() {
     fs.writeFileSync(HOOK_STATE_FILE, JSON.stringify({ active_tools: 0 }));
   } catch { }
 
-  const useCredentialsFile = hasCredentialsFile();
   const bypassFlag = BYPASS_PERMISSIONS ? ' --dangerously-skip-permissions' : '';
   // When credentials.json is available, also strip CLAUDE_CODE_OAUTH_TOKEN from the
   // environment. This covers the sendToTmux path where the existing tmux session may
@@ -1232,7 +1235,7 @@ function init() {
 }
 
 init();
-log(`=== Activity Monitor Started (v15 - Guardian + Heartbeat v2 + Hook Activity + DailyTasks + UpgradeCheck): ${new Date().toISOString()} tz=${timezone} ===`);
+log(`=== Activity Monitor Started (v16 - Guardian + Heartbeat v2 + Hook Activity + DailyTasks + UpgradeCheck): ${new Date().toISOString()} tz=${timezone} ===`);
 
 setInterval(monitorLoop, INTERVAL);
 monitorLoop();


### PR DESCRIPTION
## Summary

Closes #211

- When `~/.claude/.credentials.json` exists with a valid OAuth refresh token, Guardian now skips the static `CLAUDE_CODE_OAUTH_TOKEN` from `.env`
- Prevents 401 errors caused by expired static tokens overriding auto-refreshable credentials
- Backward compatible: machines without `credentials.json` continue using `.env` token as before

## Changes

**`hasCredentialsFile()`** — new helper that checks if `~/.claude/.credentials.json` contains `claudeAiOauth.refreshToken`

**`isClaudeLoggedIn()`** — checks credentials.json first, before falling back to `.env` or `claude auth status`

**`startClaude()`** — three-pronged fix:
1. Skips reading `CLAUDE_CODE_OAUTH_TOKEN` from `.env` when credentials.json is available
2. Skips injecting it via `tmux new-session -e` (new session path)
3. Strips it via `env -u` in the command (existing session path, covers leftover env from previous session creation)

## Test plan

- [ ] Machine with credentials.json: verify Guardian logs "Using ~/.claude/.credentials.json (auto-refresh)" and Claude starts without OAUTH_TOKEN in env
- [ ] Machine without credentials.json: verify existing .env OAUTH_TOKEN behavior unchanged
- [ ] Machine with both: verify credentials.json takes precedence
- [ ] Restart into existing tmux session: verify OAUTH_TOKEN is stripped from env


🤖 Generated with [Claude Code](https://claude.com/claude-code)