### PR TITLE
fix: only use credentials.json for native auth detection

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -460,29 +460,17 @@ function approveApiKey(apiKey) {
 }
 
 function startClaude() {
-  // Detect native `claude login` auth (credentials.json on Linux, system Keychain
-  // on macOS).  When native auth is active, .env tokens MUST NOT be injected into
-  // tmux — Claude CLI errors with "Auth conflict" if it sees both a native login
-  // and ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN in the environment.
-  const useCredentialsFile = hasCredentialsFile();
-  let hasNativeAuth = useCredentialsFile;
-  let authStatusLoggedIn = false;
-  if (!hasNativeAuth) {
-    try {
-      const output = execFileSync(CLAUDE_BIN, ['auth', 'status'], {
-        encoding: 'utf8', timeout: 10000, stdio: ['ignore', 'pipe', 'pipe']
-      });
-      const status = JSON.parse(output);
-      authStatusLoggedIn = status?.loggedIn === true;
-      hasNativeAuth = authStatusLoggedIn && status?.authMethod === 'claude.ai';
-    } catch (e) {
-      log(`Guardian: claude auth status check failed: ${e.message}`);
-    }
-  }
+  // Detect native `claude login` auth via credentials.json.  When present, .env
+  // tokens MUST NOT be injected into tmux — Claude CLI errors with "Auth conflict"
+  // if it sees both a native login and ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN.
+  //
+  // Important: only credentials.json counts as native auth, NOT `claude auth status`.
+  // On macOS, `claude auth status` may report loggedIn via system Keychain, but
+  // Keychain is inaccessible from PM2-spawned tmux sessions.  If we trusted that
+  // signal and skipped .env injection, the tmux session would have no auth at all.
+  const hasNativeAuth = hasCredentialsFile();
 
-  // Use cached auth status to avoid a redundant `claude auth status` subprocess
-  // inside isClaudeLoggedIn() — the same command was already run above.
-  if (!hasNativeAuth && !authStatusLoggedIn && !isClaudeLoggedIn()) {
+  if (!hasNativeAuth && !isClaudeLoggedIn()) {
     log('Guardian: Claude is not logged in, skipping startup');
     return;
   }
@@ -533,7 +521,7 @@ function startClaude() {
   }
 
   if (hasNativeAuth) {
-    log(`Guardian: Using native claude login auth${useCredentialsFile ? ' (credentials.json)' : ' (system keychain)'} — skipping .env tokens`);
+    log('Guardian: Using native claude login auth (credentials.json) — skipping .env tokens');
   }
 
   // Pre-accept onboarding + trust dialogs for ALL auth methods — without this,


### PR DESCRIPTION
## Summary
- Removed `claude auth status` fallback from `hasNativeAuth` detection — only `credentials.json` counts as native auth
- On macOS, `claude auth status` reports loggedIn via system Keychain, but Keychain is inaccessible from PM2-spawned tmux sessions
- Trusting that signal caused Guardian to skip `.env` token injection, leaving tmux with no auth

## Test plan
- [ ] macOS: setup token in .env + previous `claude login` (Keychain) → `zylos attach` should work (setup token injected)
- [ ] Linux: credentials.json exists + API key in .env → no auth conflict (credentials.json = native auth, .env skipped)
- [ ] Linux: no credentials.json, only API key in .env → works (API key injected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)