### PR TITLE
fix: prevent usage monitor from firing on fresh install

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -1566,11 +1566,12 @@ function init() {
     name: 'daily-upgrade-check'
   });
 
-  // Restore usage check timestamp from persisted state
+  // Restore usage check timestamp from persisted state.
+  // On fresh installs (no usage.json), default to current time so the first
+  // check waits a full interval — prevents /usage from firing immediately
+  // after Claude's first startup.
   const usageState = loadUsageState();
-  if (usageState?.lastCheckEpoch) {
-    lastUsageCheckAt = usageState.lastCheckEpoch;
-  }
+  lastUsageCheckAt = usageState?.lastCheckEpoch || Math.floor(Date.now() / 1000);
 
   if (initialHealth !== 'ok') {
     log(`Startup with health=${initialHealth}; will verify immediately when Claude is running`);


### PR DESCRIPTION
## Summary

- On fresh installs, `usage.json` doesn't exist → `lastUsageCheckAt` defaulted to `0`
- This made the interval check `(currentTime - 0) >= 3600` always true
- Result: `/usage` fired 30 seconds after first startup, potentially destabilizing Claude
- Fix: default `lastUsageCheckAt` to current time when no persisted state exists

Found during PR #227 Docker testing — Claude crashed ~90 seconds after first startup because usage monitor sent `/usage` too early.

## Test plan

- [ ] Fresh Docker install — verify `/usage` does NOT fire within the first hour
- [ ] Existing install with `usage.json` — verify normal check interval preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)