### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-03-04
+
+### Added
+- **Plan usage monitoring**: activity monitor periodically checks `/usage` via tmux capture during idle periods, parses session/weekly usage percentages, and sends owner notifications when thresholds are exceeded (80% warning, 90% high, 95% critical). Only checks during active hours when Claude is idle with no pending work. Configurable via `zylos config` (#225, closes #206)
+
+### Fixed
+- **Startup prompt blocking**: `ensureOnboardingComplete()` now also sets `effortCalloutDismissed` in `~/.claude.json` and `skipDangerousModePermissionPrompt` in `~/.claude/settings.json` — prevents new Claude Code interactive prompts from blocking automated startup on VMs (#227, closes #226)
+- **Usage monitor fires immediately on fresh install**: `lastUsageCheckAt` defaulted to 0, causing `/usage` to trigger 30 seconds after first startup instead of waiting the full check interval. Now defaults to current time when no persisted state exists (#229)
+
 ## [0.3.2] - 2026-03-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary

- **feat**: Plan usage monitoring — activity monitor checks `/usage` during idle, sends threshold notifications (#225)
- **fix**: Pre-accept Claude Code interactive prompts (effortCalloutDismissed + skipDangerousModePermissionPrompt) (#227)
- **fix**: Usage monitor no longer fires immediately on fresh installs (#229)

## Changelog

See CHANGELOG.md for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)