### PR TITLE
fix: insert component routes into primary server block

### DIFF
--- a/cli/lib/caddy.js
+++ b/cli/lib/caddy.js
@@ -141,19 +141,38 @@ export function switchProtocol(domain, protocol) {
 /**
  * Find the closing `}` of the first (primary) server block in a Caddyfile.
  * Tracks brace depth starting from the first `{` to find its matching `}`.
+ * Skips comment lines and Caddy global options blocks (label-less `{` at top).
  * Returns the character index of the closing brace, or -1 if not found.
  */
 function findPrimaryBlockEnd(content) {
   let depth = 0;
   let inBlock = false;
+  let skippingGlobal = false;
 
   for (let i = 0; i < content.length; i++) {
+    // Skip comment lines (# to end of line)
+    if (content[i] === '#') {
+      while (i < content.length && content[i] !== '\n') i++;
+      continue;
+    }
+
     if (content[i] === '{') {
       depth++;
-      inBlock = true;
+      if (!inBlock && !skippingGlobal) {
+        // Check if this is a global options block: no site address before {
+        const lineStart = content.lastIndexOf('\n', i) + 1;
+        const before = content.slice(lineStart, i).trim();
+        if (before === '' && depth === 1) {
+          skippingGlobal = true;
+        } else {
+          inBlock = true;
+        }
+      }
     } else if (content[i] === '}') {
       depth--;
-      if (inBlock && depth === 0) {
+      if (skippingGlobal && depth === 0) {
+        skippingGlobal = false;
+      } else if (inBlock && depth === 0) {
         return i;
       }
     }


### PR DESCRIPTION
## Summary

- Fix `applyCaddyRoutes()` in `cli/lib/caddy.js` to target the first (primary) server block instead of the last one
- Add `findPrimaryBlockEnd()` helper that tracks brace depth to find the correct insertion point
- Prevents component webhook routes from being inserted into user-added server blocks

## Problem

`applyCaddyRoutes()` uses `content.lastIndexOf('}')` to find where to insert component routes. This assumes the Caddyfile has only one server block. When users add additional server blocks (e.g. reverse proxies for other services), `lastIndexOf` returns the closing brace of the **last** block, causing component routes to be inserted into the wrong host context.

**Real-world impact:** After upgrading zylos-lark (v0.1.7 → v0.1.9), the lark webhook route was inserted into a secondary `http://aidep.online` block instead of the primary `:80` block. Since Lark sends webhooks to the primary domain (`zylos305.coco.site`), all webhook requests returned 404 and the bot stopped receiving messages.

## Fix

Replace `lastIndexOf('}')` with `findPrimaryBlockEnd()` which scans from the start of the file, tracking brace depth (`{` increments, `}` decrements). When depth returns to 0, we've found the end of the first server block — always the zylos-managed one.

## Test plan

- [ ] Upgrade a component with `http_routes` on a single-block Caddyfile → route inserted correctly
- [ ] Upgrade on a multi-block Caddyfile → route inserted into first block, not last
- [ ] Nested `handle` blocks inside the primary block don't cause premature match