### PR TITLE
fix: clarify lark description in built-in registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -8,7 +8,7 @@
     },
     "lark": {
       "repo": "zylos-ai/zylos-lark",
-      "description": "Lark/Feishu messaging component for Zylos agents",
+      "description": "Lark (international) messaging component for Zylos agents",
       "type": "communication",
       "official": true
     },


### PR DESCRIPTION
## Summary
- Built-in registry had "Lark/Feishu" which conflated two separate components
- Changed to "Lark (international)" to match remote registry (zylos-registry PR #21)

## Context
Companion to zylos-ai/zylos-registry#21. The built-in registry is the fallback when remote registry is unreachable, so it needs the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)