### PR TITLE
fix: web console password env var mismatch

### DIFF
--- a/skills/web-console/SKILL.md
+++ b/skills/web-console/SKILL.md
@@ -78,7 +78,7 @@ Browser ──► Web Console Server ──► C4 Bridge ──► Claude
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `WEB_CONSOLE_PORT` | 3456 | Server port |
-| `WEB_CONSOLE_PASSWORD` | (empty) | Set to enable password protection |
+| `ZYLOS_WEB_PASSWORD` | (empty) | Set to enable password protection (also reads `WEB_CONSOLE_PASSWORD` as fallback) |
 | `WEB_CONSOLE_BIND` | 127.0.0.1 | Bind address |
 | `ZYLOS_DIR` | ~/zylos | Data directory |
 
@@ -87,7 +87,7 @@ Browser ──► Web Console Server ──► C4 Bridge ──► Claude
 By default, no password is required (suitable for local access).
 
 To enable password protection (recommended when exposing externally):
-1. Set `WEB_CONSOLE_PASSWORD` in `~/zylos/.env`
+1. Set `ZYLOS_WEB_PASSWORD` in `~/zylos/.env`
 2. Restart the web-console service
 
 ## Features

--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -44,7 +44,7 @@ function readEnvPassword() {
   const envPath = path.join(ZYLOS_DIR, '.env');
   try {
     const env = parseDotenv(fs.readFileSync(envPath, 'utf8'));
-    return env.WEB_CONSOLE_PASSWORD || '';
+    return env.ZYLOS_WEB_PASSWORD || env.WEB_CONSOLE_PASSWORD || '';
   } catch {
     return '';
   }

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -39,4 +39,4 @@ CLAUDE_BYPASS_PERMISSIONS=true
 # LARK_APP_SECRET=your_app_secret
 
 # Web Console
-# WEB_CONSOLE_PASSWORD=your_password_here
+# ZYLOS_WEB_PASSWORD=your_password_here


### PR DESCRIPTION
## Summary
- `zylos init` writes `ZYLOS_WEB_PASSWORD` to .env
- `server.js` only reads `WEB_CONSOLE_PASSWORD`
- Result: password auth silently fails on new installs

## Fix
- `server.js`: read `ZYLOS_WEB_PASSWORD` first, fall back to `WEB_CONSOLE_PASSWORD` for backwards compatibility
- `SKILL.md`: update docs to reference `ZYLOS_WEB_PASSWORD`
- `.env.example`: update template variable name

## Test plan
- [ ] Set `ZYLOS_WEB_PASSWORD=test` in .env, restart web-console, verify auth is required
- [ ] Set `WEB_CONSOLE_PASSWORD=test` (legacy), verify it still works as fallback
- [ ] No password set → verify no auth required (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)