### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-03-06
+
+### Added
+- **User message triggers recovery in all unavailable states**: user messages now trigger recovery attempts in `recovering` and `down` states (not just `rate_limited`). Recovery cooldown reduced from 5 minutes to 1 minute. Error messages are honest about the bot's actual state instead of always claiming "rate limited" (#254)
+
+### Fixed
+- **False positive rate limit detection**: replaced aggressive tick-level tmux text scanning with dual-signal detection — rate limit is now only detected when both heartbeat failure AND specific rate-limit text are present in the tmux pane. Prevents conversation content containing "rate limit" keywords from triggering false positives. Includes 71 tests (#257, closes #256)
+- **Rate-limited recovery deadlock**: `triggerRecovery` was blocked by a `rate_limited` guard that prevented recovery even when cooldown expired. Recovery now correctly proceeds after cooldown (#253)
+
 ## [0.3.4] - 2026-03-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.3.5
- Update CHANGELOG with entries for PR #253, #254, #257

## Changes since v0.3.4

### Added
- **User message triggers recovery in all unavailable states** (#254): user messages now trigger recovery attempts in `recovering` and `down` states (not just `rate_limited`). Recovery cooldown reduced from 5min to 1min. Honest error messages.

### Fixed
- **False positive rate limit detection** (#257, closes #256): dual-signal detection (heartbeat failure + tmux text match) replaces aggressive tick-level scanning. 71 tests.
- **Rate-limited recovery deadlock** (#253): `triggerRecovery` was blocked by `rate_limited` guard even after cooldown expired.

## Test plan
- [x] All 71 heartbeat-engine tests pass
- [x] Verify version bump in package.json
- [x] Verify CHANGELOG format

🤖 Generated with [Claude Code](https://claude.com/claude-code)