### PR TITLE
docs: add SSH install for unsupported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,32 @@ zylos init
 
 </details>
 
+<details>
+<summary>Unsupported platforms (Windows, NAS, etc.) — install via SSH</summary>
+
+On platforms without native support, use Claude Code's SSH feature to install Zylos on a remote Linux/macOS machine:
+
+```bash
+# From your local machine (any OS that runs Claude Code)
+claude --ssh user@your-linux-server
+```
+
+Once connected, Claude is running on the remote machine. Ask it to install Zylos:
+
+```
+> Install Zylos on this machine
+```
+
+Or run the installer directly in the SSH session:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash
+```
+
+This works from Windows, ChromeOS, or any platform that can run Claude Code locally. The AI handles the setup on the remote server — no need for native platform support.
+
+</details>
+
 `zylos init` is idempotent and supports both interactive and non-interactive modes. It will:
 1. Install missing tools (tmux, git, PM2, Claude Code)
 2. Set up Claude authentication (browser login, API key, or [setup token](https://code.claude.com/docs/en/authentication) for headless servers)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,6 +120,32 @@ zylos init
 
 </details>
 
+<details>
+<summary>不支持的平台（Windows、NAS 等）— 通过 SSH 安装</summary>
+
+在没有原生支持的平台上，可以用 Claude Code 的 SSH 功能远程安装 Zylos 到 Linux/macOS 服务器：
+
+```bash
+# 在本地机器上（任何能运行 Claude Code 的系统）
+claude --ssh user@your-linux-server
+```
+
+连接后，Claude 在远程机器上运行。让它安装 Zylos：
+
+```
+> 在这台机器上安装 Zylos
+```
+
+或者在 SSH 会话中直接运行安装脚本：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash
+```
+
+这适用于 Windows、ChromeOS 或任何能本地运行 Claude Code 的平台。AI 会在远程服务器上完成安装 — 无需原生平台支持。
+
+</details>
+
 `zylos init` 可重复运行，支持交互式和非交互式两种模式。它会：
 1. 安装缺失的工具（tmux、git、PM2、Claude Code）
 2. 配置 Claude 认证（浏览器登录、API key 或 [setup token](https://code.claude.com/docs/en/authentication)，适用于无浏览器的服务器）

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,7 +111,7 @@ detect_os() {
   case "$OS" in
     Linux)  OS="linux" ;;
     Darwin) OS="macos" ;;
-    *)      fail "Unsupported operating system: $OS" ;;
+    *)      fail "Unsupported operating system: $OS. Try installing via SSH: claude --ssh user@linux-server" ;;
   esac
 
   case "$ARCH" in


### PR DESCRIPTION
## Summary
- Add "Unsupported platforms" install section to README.md and README.zh-CN.md suggesting `claude --ssh` as a fallback for Windows, NAS, ChromeOS, etc.
- Update install.sh error message for unsupported OS to suggest SSH method
- Closes #263

## Changes
- **README.md / README.zh-CN.md**: New collapsible section under Quick Start with SSH install instructions
- **scripts/install.sh**: Improved error message on unsupported OS (`fail` now suggests `claude --ssh`)

## Test plan
- [ ] Verify README renders correctly on GitHub (collapsible sections, code blocks)
- [ ] Verify install.sh error message on unsupported OS shows SSH suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)