### PR TITLE
feat: add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-slim
+
+# procps is critical for Claude process detection (pgrep/ps)
+RUN apt-get update -qq && \
+    apt-get install -y -qq git tmux curl procps && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Zylos and Claude Code
+RUN npm install -g --install-links https://github.com/zylos-ai/zylos-core#v0.3.5 && \
+    npm install -g @anthropic-ai/claude-code
+
+# Web console listens on all interfaces
+ENV WEB_CONSOLE_BIND=0.0.0.0
+
+# Persist data
+VOLUME ["/root/zylos", "/root/.claude", "/root/.local"]
+
+EXPOSE 3456
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+services:
+  zylos:
+    build: .
+    container_name: zylos
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
+      # Or use API key instead:
+      # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    volumes:
+      - zylos-data:/root/zylos
+      - claude-data:/root/.claude
+      - local-data:/root/.local
+
+volumes:
+  zylos-data:
+  claude-data:
+  local-data:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,49 @@
+# Zylos on Docker (Synology NAS Compatible)
+
+One-click deploy Zylos AI assistant on Docker, optimized for Synology NAS and other environments with older kernels.
+
+## Quick Start
+
+```bash
+# 1. Get your token: run `claude setup-token` locally and copy the output
+
+# 2. Set token
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-your-token-here"
+
+# 3. Build and run
+docker-compose up -d
+
+# 4. Check status
+docker exec zylos zylos status
+
+# 5. Open web console
+#    http://your-nas-ip:3456/
+#    Password: docker exec zylos grep WEB_PASSWORD /root/zylos/.env
+```
+
+## Manual Docker Run
+
+```bash
+docker build -t zylos .
+
+docker run -d \
+  --name zylos \
+  --restart unless-stopped \
+  --network host \
+  -e CLAUDE_CODE_OAUTH_TOKEN="your-token" \
+  -v zylos-data:/root/zylos \
+  -v claude-data:/root/.claude \
+  -v local-data:/root/.local \
+  zylos
+```
+
+## Commands
+
+```bash
+docker exec zylos zylos status           # Check status
+docker exec zylos zylos logs activity    # View logs
+docker exec -it zylos zylos attach       # Attach to Claude session
+docker exec zylos zylos add telegram     # Add Telegram bot
+docker exec zylos zylos add lark         # Add Lark bot
+docker exec zylos zylos restart          # Restart services
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if [ ! -f /root/zylos/.env ]; then
+  echo "[zylos-docker] First run, initializing..."
+  if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+    zylos init --yes --setup-token "$CLAUDE_CODE_OAUTH_TOKEN"
+  elif [ -n "$ANTHROPIC_API_KEY" ]; then
+    zylos init --yes --api-key "$ANTHROPIC_API_KEY"
+  else
+    echo "[zylos-docker] ERROR: Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY"
+    exit 1
+  fi
+  # Patch web-console to listen on all interfaces
+  WC_SERVER="/root/zylos/.claude/skills/web-console/scripts/server.js"
+  if [ -f "$WC_SERVER" ]; then
+    sed -i "s/|| '127.0.0.1'/|| '0.0.0.0'/" "$WC_SERVER"
+    npx pm2 restart web-console 2>/dev/null || true
+  fi
+else
+  echo "[zylos-docker] Starting services..."
+  cd /root/zylos && npx pm2 resurrect 2>/dev/null || zylos start
+fi
+
+echo "[zylos-docker] Zylos is running. Web console on port 3456."
+exec tail -f /dev/null


### PR DESCRIPTION
## Summary
- Adds Docker deployment support for zylos-core
- Based on Kevin's reference implementation from `hxa-teams/projects/writings/topics/synology-zylos/zylos-docker/`
- Optimized for Synology NAS and environments with older kernels

## Files
- `Dockerfile` — node:20-slim base, installs zylos + Claude Code, volumes for persistence
- `docker-compose.yml` — host network mode, named volumes, auth via env vars
- `entrypoint.sh` — first-run init with auth, web-console bind patch, PM2 startup
- `docs/docker.md` — quick start guide with manual docker run and common commands

## Note
This is independent from PR #276 (Lisa's Docker implementation). This PR follows Kevin's reference design directly.

## Test plan
- [ ] `docker build -t zylos .` succeeds
- [ ] `docker-compose up -d` with CLAUDE_CODE_OAUTH_TOKEN starts correctly
- [ ] First-run init creates .env and starts services
- [ ] Web console accessible on port 3456
- [ ] Named volumes persist data across container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)