### PR TITLE
fix: docker stop hangs indefinitely

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -85,10 +85,16 @@ upsert_env "SYSTEM_PATH" "${PATH}"
 
 # ── Graceful shutdown ─────────────────────────────────────────────────────────
 # docker stop sends SIGTERM to PID 1 (this script). Clean up tmux + PM2.
+SHUTTING_DOWN=false
 cleanup() {
+  [ "${SHUTTING_DOWN}" = true ] && return
+  SHUTTING_DOWN=true
   info "Shutting down..."
   tmux kill-session -t claude-main 2>/dev/null || true
   pm2 kill 2>/dev/null || true
+  # Kill the PM2 --no-daemon process directly in case pm2 kill didn't stop it
+  [ -n "${PM2_PID:-}" ] && kill "${PM2_PID}" 2>/dev/null || true
+  exit 0
 }
 trap cleanup SIGTERM SIGINT
 
@@ -118,6 +124,12 @@ tmux new-session -d -s claude-main -x 220 -y 50 \
 info "Claude Code session started."
 
 # ── Keep container alive ──────────────────────────────────────────────────────
+# Use a sleep loop instead of waiting on PM2 directly.
+# Bash interrupts sleep (not wait on a child) reliably on SIGTERM,
+# allowing the trap handler to fire and exit cleanly.
 info "All services started. Monitoring PM2..."
-wait "${PM2_PID}" || true
+while kill -0 "${PM2_PID}" 2>/dev/null; do
+  sleep 1
+done
+info "PM2 exited unexpectedly."
 cleanup


### PR DESCRIPTION
## Summary

`docker compose stop` / `docker stop zylos` hangs indefinitely instead of stopping the container gracefully.

**Root cause:** `wait` on the PM2 `--no-daemon` child PID doesn't get interrupted by SIGTERM reliably — PM2 catches the signal itself, so the bash trap never fires.

## Fix

- Replace `wait` with a `sleep 1` loop — bash interrupts `sleep` on signals reliably
- Add direct `kill` of PM2 PID as fallback after `pm2 kill`
- Add explicit `exit 0` in cleanup handler
- Guard against double cleanup with `SHUTTING_DOWN` flag

## Test plan

- [ ] `docker compose up -d` — container starts normally
- [ ] `docker compose stop` — container stops within seconds (not hanging)
- [ ] `docker kill zylos` — still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)