### PR TITLE
feat: support pre-uninstall lifecycle hook

### DIFF
--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -1332,6 +1332,28 @@ async function handleRemoveFlow(target, { purge, skipConfirm, force, jsonOutput 
   // Execute removal, collect step results
   const steps = [];
 
+  // 0. Run pre-uninstall hook (before stopping service or removing files)
+  const skillMd = parseSkillMd(skillDir);
+  const hooks = skillMd?.frontmatter?.lifecycle?.hooks || {};
+  if (hooks['pre-uninstall']) {
+    const hookPath = path.resolve(skillDir, hooks['pre-uninstall']);
+    if (fs.existsSync(hookPath)) {
+      if (!jsonOutput) console.log(`  ${cyan('Running pre-uninstall hook...')}`);
+      try {
+        execFileSync('node', [hookPath], {
+          cwd: skillDir,
+          stdio: jsonOutput ? 'pipe' : 'inherit',
+          env: { ...process.env, ZYLOS_COMPONENT: target, ZYLOS_SKILL_DIR: skillDir, ZYLOS_DATA_DIR: dataDir },
+        });
+        steps.push({ action: 'Pre-uninstall hook complete', success: true });
+        if (!jsonOutput) console.log(`  ${success('Pre-uninstall hook complete.')}`);
+      } catch (err) {
+        steps.push({ action: 'Pre-uninstall hook failed', success: false, error: err.message });
+        if (!jsonOutput) console.log(`  ${warn('Pre-uninstall hook had issues (continuing anyway).')}`);
+      }
+    }
+  }
+
   // 1. Stop + delete PM2 service (use execFileSync to avoid shell injection)
   try {
     try { execFileSync('pm2', ['stop', serviceName], { stdio: 'pipe' }); } catch { /* ignore */ }

--- a/skills/component-management/references/uninstall.md
+++ b/skills/component-management/references/uninstall.md
@@ -16,15 +16,11 @@ Choose an option:
 2. Remove everything (code + data)
 ```
 
-### Step 2: Pre-Uninstall Cleanup
+### Step 2: Execute Uninstall
 
-Before executing CLI uninstall, check the component's SKILL.md for external resources that need cleanup:
-- Webhook registrations (deregister)
-- Active connections (close gracefully)
-- External service integrations (notify/cleanup)
-- **Shared PM2 services**: If the component manages PM2 services (e.g. zylos-xvfb, zylos-vnc), check whether any other installed component also uses them before stopping. Scan other components' SKILL.md files in `~/.claude/skills/` — only stop a service if no other component references it.
+The CLI automatically runs `pre-uninstall` hooks declared in SKILL.md before stopping services and removing files. Components use this hook to clean up runtime resources (PM2 processes, PID files, connections).
 
-### Step 3: Execute Uninstall
+If the hook fails, the CLI warns and continues with the uninstall.
 
 After user chooses:
 ```bash
@@ -35,7 +31,7 @@ zylos uninstall <component> --yes --json
 zylos uninstall <component> --purge --yes --json
 ```
 
-### Step 4: Clean Environment Variables
+### Step 3: Clean Environment Variables
 
 Remove the component's declared environment variables from `~/zylos/.env` to avoid stale credentials.
 
@@ -55,7 +51,6 @@ Run `zylos uninstall lark --check --json`. The JSON output includes component in
 
 User: `uninstall lark confirm` (keep data) or `uninstall lark purge` (delete all)
 
-1. Check SKILL.md for external cleanup needs (webhooks, connections, shared PM2 services)
-2. Run `zylos uninstall lark confirm --json` or `zylos uninstall lark purge --json`
+1. Run `zylos uninstall lark confirm --json` or `zylos uninstall lark purge --json` (CLI handles pre-uninstall hooks automatically)
 3. Clean component's environment variables from .env
 4. Reply with result


### PR DESCRIPTION
## Summary

- Add `pre-uninstall` hook execution to the CLI uninstall flow
- Hook runs before stopping PM2 services and removing files
- Hook failure warns but does not block uninstall
- Passes `ZYLOS_COMPONENT`, `ZYLOS_SKILL_DIR`, `ZYLOS_DATA_DIR` env vars
- Update uninstall docs to reflect automated hook execution

Closes #251

## Test plan

- [ ] Uninstall a component with a `pre-uninstall` hook (e.g. browser) — verify hook runs
- [ ] Uninstall a component without a hook — verify no errors
- [ ] Test with a failing hook — verify warning shown and uninstall continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)