### PR TITLE
docs: add zylos shell as primary interaction method

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ This works from Windows, ChromeOS, or any platform that can run Claude Code loca
 **Talk to your agent:**
 
 ```bash
-# Attach to the Claude session (Ctrl+B d to detach)
+# Interactive CLI — the simplest way to chat
+zylos shell
+
+# Or attach to the Claude tmux session (Ctrl+B d to detach)
 zylos attach
 
 # Or add a messaging channel

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,10 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 **与你的智能体对话：**
 
 ```bash
-# 连接到 Claude 会话（Ctrl+B d 退出）
+# 交互式命令行 — 最简单的对话方式
+zylos shell
+
+# 或连接到 Claude tmux 会话（Ctrl+B d 退出）
 zylos attach
 
 # 或添加消息通道

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -53,6 +53,15 @@ docker exec -it zylos zylos shell
 # Then ask: "What's my web console password?"
 ```
 
+### Talk to Your Agent
+
+```bash
+# Interactive CLI — the simplest way to chat
+docker exec -it zylos zylos shell
+```
+
+Or open `http://localhost:3456` to use the web console.
+
 ### Verify
 
 ```bash


### PR DESCRIPTION
## Summary
- Added `zylos shell` to README.md and README.zh-CN.md as the first option under "Talk to your agent"
- Added "Talk to Your Agent" section to Docker docs (`docs/docker.md`) with `docker exec -it zylos zylos shell`
- `zylos shell` listed before `zylos attach` since it's the lowest-barrier way to interact

## Test plan
- [ ] Verify README.md shows `zylos shell` first
- [ ] Verify README.zh-CN.md is in sync
- [ ] Verify Docker docs include the shell command

🤖 Generated with [Claude Code](https://claude.com/claude-code)