### PR TITLE
fix: Docker entrypoint starts Claude in wrong working directory

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -131,7 +131,7 @@ if [ "${CLAUDE_BYPASS_PERMISSIONS:-true}" = "true" ]; then
 fi
 
 tmux new-session -d -s claude-main -x 220 -y 50 \
-  "cd ${HOME} && source ${ENV_FILE} 2>/dev/null; exec claude ${CLAUDE_ARGS}"
+  "cd ${ZYLOS_DIR} && source ${ENV_FILE} 2>/dev/null; exec claude ${CLAUDE_ARGS}"
 
 ok "Claude Code session started"
 


### PR DESCRIPTION
## Summary

- Fix Docker entrypoint starting Claude Code in `$HOME` instead of `$ZYLOS_DIR`
- One-line change: `cd ${HOME}` → `cd ${ZYLOS_DIR}` in tmux session creation

## Problem

`docker/entrypoint.sh` line 134 started Claude in `/home/zylos` instead of `/home/zylos/zylos`. This meant Claude Code couldn't find the project `CLAUDE.md`, breaking any features defined there (e.g., onboarding, behavioral rules).

`zylos init` (init.js line 720) correctly uses `cd $ZYLOS_DIR`, but the Docker entrypoint had its own tmux launch command with the wrong path.

## Test plan

- [ ] Build Docker image from this branch
- [ ] Run container, verify Claude starts in `~/zylos/` (check `tmux capture-pane`)
- [ ] Verify CLAUDE.md is loaded (onboarding flow triggers on first message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)