### PR TITLE
fix: recovery notification dedup failing on |req:xxx suffix

### DIFF
--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -343,6 +343,25 @@ describe('c4-receive pending channels', () => {
     });
   });
 
+  it('deduplicates endpoints that differ only in |msg:xxx and |req:xxx suffixes', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      const dataDir = path.join(tmpDir, 'comm-bridge');
+      fs.mkdirSync(dataDir, { recursive: true });
+      fs.writeFileSync(path.join(tmpDir, 'activity-monitor', 'claude-status.json'), JSON.stringify({ health: 'recovering' }));
+      fs.mkdirSync(path.join(tmpDir, '.claude', 'skills', 'telegram'), { recursive: true });
+
+      cliRaw(['--channel', 'telegram', '--endpoint', '7446046953|msg:100|req:7446046953:100', '--json', '--content', 'first'], env);
+      cliRaw(['--channel', 'telegram', '--endpoint', '7446046953|msg:101|req:7446046953:101', '--json', '--content', 'second'], env);
+      cliRaw(['--channel', 'telegram', '--endpoint', '7446046953|msg:102|req:7446046953:102', '--json', '--content', 'third'], env);
+
+      const pendingPath = path.join(tmpDir, 'activity-monitor', 'pending-channels.jsonl');
+      const lines = fs.readFileSync(pendingPath, 'utf8').trim().split('\n');
+      assert.equal(lines.length, 1, 'same chat with different msg+req IDs should dedup to 1');
+      const record = JSON.parse(lines[0]);
+      assert.equal(record.endpoint, '7446046953', 'stored endpoint should have msg and req stripped');
+    });
+  });
+
   it('records different channel+endpoint pairs separately', () => {
     withTmpDir(({ tmpDir, env }) => {
       const dataDir = path.join(tmpDir, 'comm-bridge');

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -124,9 +124,9 @@ function recordPendingChannel(channel, endpoint) {
     if (!fs.existsSync(DATA_DIR)) {
       fs.mkdirSync(DATA_DIR, { recursive: true });
     }
-    // Strip |msg:xxx from endpoint so same chat deduplicates correctly.
+    // Strip |msg:xxx and |req:xxx from endpoint so same chat deduplicates correctly.
     // Recovery notices should go to the chat, not reply to a specific message.
-    const normalizedEndpoint = endpoint.replace(/\|msg:[^|]+/, '');
+    const normalizedEndpoint = endpoint.replace(/\|(msg|req):[^|]+/g, '');
     const key = `${channel}::${normalizedEndpoint}`;
     const keys = loadPendingChannelKeys();
     if (keys.has(key)) return;


### PR DESCRIPTION
## Summary

Closes #270.

- `c4-receive.js`: `recordPendingChannel()` now strips both `|msg:xxx` and `|req:xxx` from endpoints, so all messages from the same chat deduplicate to one pending-channels entry
- Added test case for Telegram endpoint format (`chatId|msg:xxx|req:chatId:xxx`)

**Root cause:** Telegram endpoints contain `|req:chatId:N` which is unique per message. The old regex only stripped `|msg:xxx`, leaving `|req:xxx` intact — so dedup treated each message as a different chat.

## Test plan

- [x] All 22 c4-receive tests pass (including new dedup test)
- [ ] Docker test: simulate downtime with multiple messages, verify single recovery notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)