### PR TITLE
fix: warn when PM2 daemon runs in foreign cgroup

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -1250,7 +1250,9 @@ function warnIfForeignCgroup() {
 
     // PM2 daemon is in a foreign cgroup — warn
     // Extract the service name from the cgroup path for a clear message
-    const serviceMatch = cgroup.match(/\/([^/]+\.service)$/);
+    // cgroup v2: single line "0::/system.slice/foo.service"
+    // cgroup v1: multiple lines "12:pids:/system.slice/foo.service\n..."
+    const serviceMatch = cgroup.match(/\/([^/\n]+\.service)/);
     const foreignService = serviceMatch ? serviceMatch[1] : null;
 
     if (foreignService) {


### PR DESCRIPTION
## Summary
- After `pm2 startup` succeeds, detect if PM2 daemon is running inside another service's cgroup
- If so, warn user to reboot so PM2 starts under its own systemd unit (`pm2-<user>.service`)
- Prevents silent failure where PM2 gets killed when parent service is restarted (e.g., by `needrestart`)

## Context
When `zylos init` runs inside a systemd service (e.g., `coco-bootstrap.service`), PM2 inherits that service's cgroup. `pm2 startup` creates a systemd unit for future boots, but the current PM2 daemon remains in the caller's cgroup. If that service is restarted, systemd sends SIGTERM to all processes in the cgroup — killing PM2 and everything it manages.

## Detection approach
1. Read PM2 daemon PID from `~/.pm2/pm2.pid`
2. Read `/proc/<pid>/cgroup`
3. Check if it contains `pm2-<user>.service`
4. If not (and not Docker), warn with the foreign service name and advise reboot

Best-effort only — wrapped in try/catch, Linux-only, skips Docker containers.

Closes #301

## Test plan
- [x] Existing tests pass (76/77, 1 pre-existing failure in heartbeat-engine)
- [ ] Manual: run `zylos init` normally — no warning shown (PM2 in correct cgroup)
- [ ] Manual: run `zylos init` from a systemd service — warning shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)