### PR TITLE
fix: context rotation delivery deadlock

### DIFF
--- a/skills/activity-monitor/scripts/context-monitor.js
+++ b/skills/activity-monitor/scripts/context-monitor.js
@@ -79,24 +79,34 @@ function main(raw) {
   const state = loadState();
   if (state && (now - state.last_trigger_at) < COOLDOWN_SECONDS) return;
 
-  // Save state FIRST to prevent re-triggering
-  saveState({
-    ...state,
-    last_trigger_at: now,
-    used_percentage: usedPct,
-  });
+  // Enqueue new-session control message with bypass_state so dispatcher
+  // delivers it even when health !== 'ok' (fixes #274: context rotation deadlock)
+  const MAX_RETRIES = 3;
+  let enqueued = false;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      execFileSync('node', [C4_CONTROL, 'enqueue',
+        '--content', `Context usage at ${usedPct}%, exceeding 70% threshold. Use the new-session skill to start a fresh session.`,
+        '--priority', '1',
+        '--bypass-state',
+        '--ack-deadline', '300'
+      ], { encoding: 'utf8', stdio: 'pipe' });
 
-  // Enqueue new-session control message
-  try {
-    execFileSync('node', [C4_CONTROL, 'enqueue',
-      '--content', `Context usage at ${usedPct}%, exceeding 70% threshold. Use the new-session skill to start a fresh session.`,
-      '--priority', '1',
-      '--ack-deadline', '300'
-    ], { encoding: 'utf8', stdio: 'pipe' });
+      enqueued = true;
+      log(`Triggered new-session: context at ${usedPct}%`);
+      break;
+    } catch (err) {
+      log(`Failed to enqueue new-session (attempt ${attempt}/${MAX_RETRIES}): ${err.message}`);
+    }
+  }
 
-    log(`Triggered new-session: context at ${usedPct}%`);
-  } catch (err) {
-    log(`Failed to enqueue new-session: ${err.message}`);
+  // Only update cooldown after successful enqueue to avoid silent 5-min gap on failure
+  if (enqueued) {
+    saveState({
+      ...state,
+      last_trigger_at: now,
+      used_percentage: usedPct,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #274 — new session fails to start after context rotation.

**Root cause:** When context exceeds 70%, `context-monitor` enqueues a `new-session` control message. But if Claude's health state is not `ok` (e.g. `recovering` due to the high context causing slow responses), `c4-dispatcher` blocks delivery. The recovery mechanism is blocked by the unhealthy state it's trying to fix — a deadlock.

**Changes:**
- Add `--bypass-state` flag to the `new-session` enqueue call, so dispatcher delivers it regardless of health state. The bypass mechanism already existed in dispatcher (`isBypassState()`), it just wasn't being used by context-monitor.
- Move cooldown state (`last_trigger_at`) write to after successful enqueue. Previously written before enqueue, so a failed enqueue silently consumed the 5-minute cooldown window.
- Add retry (up to 3 attempts) on enqueue failure (e.g. DB lock).

**One file changed:** `skills/activity-monitor/scripts/context-monitor.js`

## Test plan

- [ ] Verify `c4-control.js enqueue --bypass-state` sets `bypass_state=1` in the control queue
- [ ] Verify dispatcher delivers control messages with `bypass_state=1` when `health !== 'ok'`
- [ ] Verify failed enqueue no longer blocks the 5-min cooldown
- [ ] Verify normal context rotation flow still works (context > 70% → new-session triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)