### PR TITLE
fix: remove /console/ path from web console URL without Caddy

### DIFF
--- a/cli/commands/doctor.js
+++ b/cli/commands/doctor.js
@@ -516,9 +516,9 @@ function discoverChannels(pm2Procs, env, tmuxSession, components) {
       action = `${protocol}://${domain}/console/`;
       if (!hasPassword) warning = 'no password set';
     } else {
-      action = `http://localhost:${port}/console/`;
+      action = `http://localhost:${port}/`;
       const ip = getNetworkIP();
-      if (ip) secondaryAction = `http://${ip}:${port}/console/`;
+      if (ip) secondaryAction = `http://${ip}:${port}/`;
       hint = `Tip: ${bold('zylos init')} can set up a custom domain for remote access.`;
     }
 

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -1074,10 +1074,10 @@ function printWebConsoleInfo() {
     console.log(`    URL:      ${bold(url)}`);
   } else {
     const port = process.env.WEB_CONSOLE_PORT || '3456';
-    console.log(`    Local:    ${bold(`http://localhost:${port}/console/`)}`);
+    console.log(`    Local:    ${bold(`http://localhost:${port}/`)}`);
     const ip = getNetworkIP();
     if (ip) {
-      console.log(`    Network:  ${bold(`http://${ip}:${port}/console/`)}`);
+      console.log(`    Network:  ${bold(`http://${ip}:${port}/`)}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove `/console/` from web console URL in `zylos init` and `zylos doctor` when Caddy is not configured
- The `/console` path is a Caddy reverse proxy prefix (stripped before reaching the server). Without Caddy, the web console serves at root, so `/console/` returns 404.

Closes #307

## Changes
- `cli/commands/init.js` — `printWebConsoleInfo()`: `http://localhost:3456/console/` → `http://localhost:3456/`
- `cli/commands/doctor.js` — `discoverChannels()`: same fix

## Test plan
- [ ] Run `zylos init` without Caddy — URL should be `http://localhost:3456/`
- [ ] Run `zylos doctor` without Caddy — URL should be `http://localhost:3456/`
- [ ] With Caddy + domain — URL should still be `https://domain/console/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)