### PR TITLE
chore: bump version to 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2026-03-11
+
+### Added
+- **Comprehensive onboarding flow**: guided first-run experience with step-by-step setup wizard covering auth, channels, and Caddy configuration (#291)
+- **Interactive security consent**: users must explicitly accept autonomous mode permissions during installation, replacing silent opt-in (#306)
+
+### Fixed
+- **API key exposed in process command line**: replaced `execSync` string interpolation with `execFileSync` + temp env file pattern — secrets no longer visible in `ps aux` or `/proc/cmdline` (#289)
+- **Web console URL shows /console/ without Caddy**: `zylos init` and `zylos doctor` now show direct `ip:port` URL when Caddy is not configured, instead of the Caddy-only `/console/` path (#307)
+- **Context rotation delivery deadlock**: fixed deadlock where context rotation and message delivery could block each other, causing session restart failures (#274)
+- **PM2 daemon foreign cgroup warning**: detect and warn when PM2 daemon runs in a different cgroup (e.g., after system upgrade), which can cause silent service failures (#302)
+- **Local address detection for Caddy**: automatically detect localhost/private IPs and configure HTTP on a high port instead of requesting HTTPS certificates (#298)
+- **Recovery notification dedup failure**: fix dedup key parsing when message contains `|req:xxx` suffix, preventing duplicate recovery notifications (#270)
+- **Docker entrypoint working directory**: fix Claude starting in wrong directory inside Docker container (#292)
+
 ## [0.3.6] - 2026-03-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.2.7",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.2.7",
+      "version": "0.3.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
Version bump to 0.3.7 — includes 2 new features and 7 bug fixes since v0.3.6.

### Added
- Comprehensive onboarding flow (#291)
- Interactive security consent during installation (#306)

### Fixed
- API key exposed in process command line (#289)
- Web console URL shows /console/ without Caddy (#307)
- Context rotation delivery deadlock (#274)
- PM2 daemon foreign cgroup warning (#302)
- Local address detection for Caddy (#298)
- Recovery notification dedup failure (#270)
- Docker entrypoint working directory (#292)

## Changes
- `package.json` — version 0.3.6 → 0.3.7
- `package-lock.json` — synced
- `CHANGELOG.md` — added 0.3.7 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)