### PR TITLE
feat: boot-time service discovery for component PM2 services

### DIFF
--- a/templates/pm2/ecosystem.config.cjs
+++ b/templates/pm2/ecosystem.config.cjs
@@ -98,6 +98,9 @@ function loadComponentServices() {
 
     for (const [name, meta] of Object.entries(components)) {
       try {
+        // Skip components that haven't finished setup (AI-mode install in progress)
+        if (meta && meta.setupComplete === false) continue;
+
         const skillDir = (meta && meta.skillDir) || path.join(SKILLS_DIR, name);
 
         // Try loading the component's own ecosystem.config.cjs


### PR DESCRIPTION
Closes #312

## Summary
- ecosystem.config.cjs now reads `.zylos/components.json` at startup and dynamically includes component PM2 services
- Components with their own `ecosystem.config.cjs` are loaded directly
- Fallback: line-by-line YAML parser for SKILL.md `service` block
- `CORE_SERVICE_NAMES` prevents components from shadowing core services
- `console.warn` on failures instead of silent catch
- Handles `service: null` / `~` / `false` correctly
- If `components.json` missing or malformed, core services still start

## Test plan (16 Docker scenarios, all passing)
- Fresh install / normal components / service:null / malformed JSON / SKILL.md fallback / comments in YAML / empty components / empty apps / no files / missing name or entry / duplicate names / no apps property / multi-app collision / non-object value / broken ecosystem fallback / core name collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)