### PR TITLE
Harden multi-instance startup and PM2 persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ This works from Windows, ChromeOS, or any platform that can run Claude Code loca
 3. Create the `~/zylos/` directory with memory, skills, and services
 4. Start all background services and launch your AI agent in a tmux session
 
+Notes:
+- PM2 boot auto-start is installed with a stable systemd unit by default (`pm2-<user>.service`, `Type=simple`, `pm2 resurrect --no-daemon`).
+- Canonical web console port key is `WEB_CONSOLE_PORT`. Legacy `ZYLOS_WEB_PORT` is still recognized and normalized automatically.
+
 **Talk to your agent:**
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -172,6 +172,10 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 3. 创建 `~/zylos/` 目录，包含记忆、技能和服务
 4. 启动所有后台服务，并在 tmux 会话中启动 AI 智能体
 
+说明：
+- 默认会安装更稳定的 PM2 开机自启 systemd 单元（`pm2-<user>.service`，`Type=simple`，`pm2 resurrect --no-daemon`）。
+- Web 控制台的规范端口键为 `WEB_CONSOLE_PORT`。历史键 `ZYLOS_WEB_PORT` 仍可识别，并会被自动归一化。
+
 **与你的智能体对话：**
 
 ```bash

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -13,6 +13,7 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { execSync, execFileSync, spawnSync, spawn } from 'node:child_process';
 import { ZYLOS_DIR, SKILLS_DIR, CONFIG_DIR, COMPONENTS_DIR, LOCKS_DIR, COMPONENTS_FILE, BIN_DIR, HTTP_DIR, CADDYFILE, CADDY_BIN, getZylosConfig, updateZylosConfig } from '../lib/config.js';
+import { normalizeLegacyEnvAliases, upsertEnvEntries } from '../lib/env.js';
 import { generateManifest, saveManifest } from '../lib/manifest.js';
 import { prompt, promptYesNo, promptChoice, promptSecret } from '../lib/prompts.js';
 import { bold, dim, green, red, yellow, cyan, bgGreen, success, error, warn, heading } from '../lib/colors.js';
@@ -20,6 +21,13 @@ import { commandExists } from '../lib/shell-utils.js';
 import { getActiveAdapter } from '../lib/runtime/index.js';
 import { buildInstructionFile } from '../lib/runtime/instruction-builder.js';
 import { runMigrations } from '../lib/migrate.js';
+import {
+  buildManagedPath,
+  buildStablePm2SystemdUnit,
+  findPm2Binary,
+  getPm2Home,
+  getWebConsolePort,
+} from '../lib/service-runtime.js';
 import {
   installGlobalPackage,
   installCodex,
@@ -148,21 +156,15 @@ function ensureLocalBinInProfile() {
  * Updates SYSTEM_PATH= line if exists, appends if not.
  */
 function saveSystemPath(envPath) {
-  const currentPath = process.env.PATH || '';
-  let content = '';
   try {
-    content = fs.readFileSync(envPath, 'utf8');
+    if (!fs.existsSync(envPath)) return;
+    process.env.PATH = buildManagedPath();
+    upsertEnvEntries({
+      SYSTEM_PATH: process.env.PATH,
+    }, { comment: 'System PATH captured by zylos init (used by PM2 services)' });
   } catch {
-    return; // .env doesn't exist yet
+    // Best effort only
   }
-
-  const line = `SYSTEM_PATH=${currentPath}`;
-  if (content.includes('SYSTEM_PATH=')) {
-    content = content.replace(/^SYSTEM_PATH=.*$/m, line);
-  } else {
-    content = content.trimEnd() + '\n\n# System PATH captured by zylos init (used by PM2 services)\n' + line + '\n';
-  }
-  fs.writeFileSync(envPath, content);
 }
 
 // ── Timezone configuration ───────────────────────────────────
@@ -747,6 +749,7 @@ function deployTemplates() {
 
   // Always save current shell PATH to .env (for PM2 services)
   saveSystemPath(envDest);
+  normalizeLegacyEnvAliases();
 
   // ZYLOS.md — user-editable runtime-agnostic core; only create if missing
   const zylosMdSrc = path.join(TEMPLATES_SRC, 'ZYLOS.md');
@@ -977,7 +980,7 @@ function printWebConsoleInfo() {
     const url = `${proto}://${config.domain}/console/`;
     console.log(`    URL:      ${bold(url)}`);
   } else {
-    const port = process.env.WEB_CONSOLE_PORT || '3456';
+    const port = getWebConsolePort();
     console.log(`    Local:    ${bold(`http://localhost:${port}/`)}`);
     const ip = getNetworkIP();
     if (ip) {
@@ -1025,6 +1028,7 @@ function startCoreServices(webPassword = null) {
   installSkillDependencies();
   ensureWebConsolePassword(webPassword);
   initializeDatabases();
+  process.env.PATH = buildManagedPath();
 
   const ecosystemPath = path.join(ZYLOS_DIR, 'pm2', 'ecosystem.config.cjs');
   if (!fs.existsSync(ecosystemPath)) {
@@ -1070,58 +1074,58 @@ function startCoreServices(webPassword = null) {
 // ── PM2 boot auto-start ──────────────────────────────────────────
 
 /**
- * Configure PM2 to auto-start on system boot.
- * Runs `pm2 startup` which generates a systemd service command,
- * then executes it. Idempotent — safe to run multiple times.
+ * Configure a stable PM2 systemd unit for reboot persistence.
  */
 function setupPm2Startup() {
-  // pm2 startup exits non-zero when it needs a sudo command to be run,
-  // so we use spawnSync to always capture output regardless of exit code.
-  const result = spawnSync('pm2', ['startup'], {
-    encoding: 'utf8',
-    stdio: 'pipe',
-    timeout: 15000,
-  });
+  if (process.platform !== 'linux') {
+    console.log(`  ${dim('PM2 boot auto-start is only configured automatically on Linux/systemd hosts.')}`);
+    return;
+  }
+  if (!commandExists('systemctl')) {
+    console.log(`  ${dim('systemd not detected; skipping PM2 boot auto-start setup.')}`);
+    return;
+  }
 
-  const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
-
-  // Extract the sudo command from output
-  // Typical: "sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u howard --hp /home/howard"
-  const sudoMatch = output.match(/^(sudo .+)$/m);
-  if (sudoMatch) {
-    // Use stdio: 'inherit' so sudo can prompt interactively
-    // (sudo retries up to 3 times by default)
-    const sudoResult = spawnSync('sh', ['-c', sudoMatch[1]], {
-      stdio: 'inherit',
-      timeout: 60000,
+  const user = os.userInfo().username;
+  const home = os.homedir();
+  const unitName = `pm2-${user}.service`;
+  const unitPath = `/etc/systemd/system/${unitName}`;
+  const tempUnitPath = path.join(ZYLOS_DIR, `${unitName}.tmp`);
+  try {
+    process.env.PATH = buildManagedPath();
+    const unitContent = buildStablePm2SystemdUnit({
+      user,
+      home,
+      pm2Path: findPm2Binary(),
+      pathValue: process.env.PATH,
+      pm2Home: getPm2Home(home),
     });
-    if (sudoResult.status === 0) {
-      console.log(`  ${success('PM2 boot auto-start configured')}`);
-      warnIfForeignCgroup();
-    } else {
-      console.log(`  ${warn('PM2 boot auto-start: sudo password incorrect')}`);
-      console.log(`    This is optional — Zylos works fine without it.`);
-      console.log(`    ${cyan('To enable auto-start later, run:')}`);
-      console.log(`      ${bold(sudoMatch[1])}`);
+    fs.writeFileSync(tempUnitPath, unitContent, 'utf8');
+
+    for (const args of [
+      ['install', '-m', '0644', tempUnitPath, unitPath],
+      ['systemctl', 'daemon-reload'],
+      ['systemctl', 'enable', unitName],
+    ]) {
+      const result = spawnSync('sudo', args, {
+        stdio: 'inherit',
+        timeout: 60000,
+      });
+      if (result.status !== 0) {
+        console.log(`  ${warn('PM2 boot auto-start setup skipped (sudo did not complete).')}`);
+        console.log(`    ${dim(`Stable unit left at ${tempUnitPath}`)}`);
+        return;
+      }
     }
-    return;
+
+    console.log(`  ${success(`PM2 boot auto-start configured via ${unitName}`)}`);
+    console.log(`    ${dim(`Unit: ${unitPath}`)}`);
+  } catch (err) {
+    console.log(`  ${warn(`PM2 boot auto-start setup failed: ${err.message}`)}`);
+  } finally {
+    try { fs.unlinkSync(tempUnitPath); } catch { /* ignore */ }
   }
 
-  // No sudo command found — may already be configured or failed
-  if (result.status === 0) {
-    console.log(`  ${success('PM2 boot auto-start configured')}`);
-  } else {
-    const msg = output.trim().split('\n')[0] || 'unknown error';
-    console.log(`  ${warn(`PM2 boot auto-start setup failed: ${msg}`)}`);
-    console.log(`    ${dim('Fix manually: pm2 startup (then run the sudo command it outputs)')}`);
-    return;
-  }
-
-  // Check if PM2 daemon is running in a foreign cgroup (Linux only).
-  // When zylos init runs inside a systemd service (e.g., a bootstrap service),
-  // the PM2 daemon inherits that service's cgroup. If that service is later
-  // restarted, systemd kills all processes in its cgroup — including PM2.
-  // The pm2 startup unit only takes effect on the next boot, so warn the user.
   warnIfForeignCgroup();
 }
 

--- a/cli/commands/service.js
+++ b/cli/commands/service.js
@@ -163,11 +163,24 @@ export function showLogs(args) {
 export function startServices() {
   console.log(heading('Starting Zylos services...'));
 
+  const ecosystemPath = path.join(ZYLOS_DIR, 'pm2', 'ecosystem.config.cjs');
+  if (fs.existsSync(ecosystemPath)) {
+    try {
+      execSync(`pm2 start "${ecosystemPath}"`, { stdio: 'pipe' });
+      execSync('pm2 save 2>/dev/null', { stdio: 'pipe' });
+      console.log(`  ${success('Started core services from ecosystem.config.cjs')}`);
+      console.log(`\n${green('Core services started.')} Run ${dim('"zylos status"')} to check.`);
+      return;
+    } catch (e) {
+      console.log(`  ${warn(`Ecosystem start failed, falling back to direct PM2 starts: ${e.message}`)}`);
+    }
+  }
+
   const services = [
     { name: 'activity-monitor', script: path.join(SKILLS_DIR, 'self-maintenance', 'activity-monitor.js') },
     { name: 'scheduler', script: path.join(SKILLS_DIR, 'scheduler', 'scheduler.js'), env: `NODE_ENV=production ZYLOS_DIR=${ZYLOS_DIR}` },
     { name: 'c4-dispatcher', script: path.join(SKILLS_DIR, 'comm-bridge', 'scripts', 'c4-dispatcher.js') },
-    { name: 'web-console', script: path.join(SKILLS_DIR, 'web-console', 'server.js'), env: `WEB_CONSOLE_PORT=3456 ZYLOS_DIR=${ZYLOS_DIR}` },
+    { name: 'web-console', script: path.join(SKILLS_DIR, 'web-console', 'server.js'), env: `ZYLOS_DIR=${ZYLOS_DIR}` },
   ];
 
   let started = 0;

--- a/cli/lib/env.js
+++ b/cli/lib/env.js
@@ -37,6 +37,70 @@ export function readEnvFile() {
 }
 
 /**
+ * Upsert environment entries in .env.
+ * Unlike writeEnvEntries(), this updates existing keys in place.
+ *
+ * @param {Map<string, string> | Record<string, string>} entries
+ * @param {{ comment?: string }} [opts]
+ * @returns {{ written: string[], updated: string[] }}
+ */
+export function upsertEnvEntries(entries, opts = {}) {
+  const pairs = entries instanceof Map ? entries : new Map(Object.entries(entries));
+  const existingContent = fs.existsSync(ENV_FILE) ? fs.readFileSync(ENV_FILE, 'utf8') : '';
+  let content = existingContent;
+  const written = [];
+  const updated = [];
+
+  for (const [key, rawValue] of pairs) {
+    const cleanValue = String(rawValue).replace(/[\r\n]/g, '').trim();
+    const needsQuote = /[\s#"'$`\\]/.test(cleanValue);
+    const escaped = cleanValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$');
+    const line = `${key}=${needsQuote ? `"${escaped}"` : cleanValue}`;
+    const rx = new RegExp(`^${key}=.*$`, 'm');
+    if (rx.test(content)) {
+      content = content.replace(rx, line);
+      updated.push(key);
+    } else {
+      if (!content.endsWith('\n') && content.length) content += '\n';
+      if (opts.comment && !content.includes(`# ${opts.comment}`)) {
+        content += `\n# ${opts.comment}\n`;
+      }
+      content += `${line}\n`;
+      written.push(key);
+    }
+  }
+
+  fs.mkdirSync(path.dirname(ENV_FILE), { recursive: true });
+  fs.writeFileSync(ENV_FILE, content);
+  return { written, updated };
+}
+
+/**
+ * Normalize legacy env aliases to canonical keys.
+ * Returns true if any change was applied.
+ */
+export function normalizeLegacyEnvAliases() {
+  const env = readEnvFile();
+  let changed = false;
+
+  const aliases = [
+    ['ZYLOS_WEB_PORT', 'WEB_CONSOLE_PORT'],
+    ['WEB_CONSOLE_PASSWORD', 'ZYLOS_WEB_PASSWORD'],
+  ];
+
+  for (const [legacyKey, canonicalKey] of aliases) {
+    if (env.has(legacyKey) && !env.has(canonicalKey)) {
+      env.set(canonicalKey, env.get(legacyKey));
+      changed = true;
+    }
+  }
+
+  if (!changed) return false;
+  upsertEnvEntries(Object.fromEntries(env), { comment: 'Normalized by zylos' });
+  return true;
+}
+
+/**
  * Append environment entries to .env file.
  * Skips keys that already exist (append-only, never overwrites).
  *

--- a/cli/lib/migrate.js
+++ b/cli/lib/migrate.js
@@ -10,7 +10,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { ZYLOS_DIR } from './config.js';
+import { COMPONENTS_DIR, ENV_FILE, SKILLS_DIR, ZYLOS_DIR } from './config.js';
+import { parsePortNumber } from './service-runtime.js';
 
 const CLAUDE_MD = path.join(ZYLOS_DIR, 'CLAUDE.md');
 const AGENTS_MD = path.join(ZYLOS_DIR, 'AGENTS.md');
@@ -29,7 +30,132 @@ export function runMigrations() {
     migrated.push('v0.4.0/claude-md-to-zylos-md');
   }
 
+  if (migrateLegacyPortKeys()) {
+    migrated.push('v0.4.0/legacy-port-keys');
+  }
+
   return { migrated };
+}
+
+function migrateLegacyPortKeys() {
+  let changed = false;
+
+  if (migrateWebConsoleEnvKey()) {
+    changed = true;
+  }
+
+  if (migrateComponentPortConfig('telegram')) {
+    changed = true;
+  }
+
+  if (migrateComponentPortConfig('hxa')) {
+    changed = true;
+  }
+
+  return changed;
+}
+
+function migrateWebConsoleEnvKey() {
+  if (!fs.existsSync(ENV_FILE)) return false;
+
+  const content = fs.readFileSync(ENV_FILE, 'utf8');
+  if (/^WEB_CONSOLE_PORT=/m.test(content)) return false;
+
+  const legacyMatch = content.match(/^ZYLOS_WEB_PORT=(.+)$/m);
+  const legacyPort = parsePortNumber(legacyMatch?.[1] ?? null);
+  if (!legacyPort) return false;
+
+  const nextContent = content.trimEnd()
+    + '\n\n# Canonicalized by zylos init\n'
+    + `WEB_CONSOLE_PORT=${legacyPort}\n`;
+  fs.writeFileSync(ENV_FILE, nextContent, 'utf8');
+  return true;
+}
+
+function migrateComponentPortConfig(componentName) {
+  const roots = [
+    path.join(COMPONENTS_DIR, componentName),
+    path.join(SKILLS_DIR, componentName),
+  ];
+
+  let changed = false;
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    for (const file of walkJsonFiles(root)) {
+      if (normalizePortJsonFile(file)) {
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
+function *walkJsonFiles(root) {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      yield *walkJsonFiles(fullPath);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.json')) {
+      yield fullPath;
+    }
+  }
+}
+
+function normalizePortJsonFile(filePath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return false;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return false;
+  if (!normalizePortKeysInObject(parsed)) return false;
+
+  fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf8');
+  return true;
+}
+
+function normalizePortKeysInObject(value) {
+  let changed = false;
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (item && typeof item === 'object' && normalizePortKeysInObject(item)) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  if (!value || typeof value !== 'object') return false;
+
+  if (Object.hasOwn(value, 'internalPort') || Object.hasOwn(value, 'internal_port')) {
+    const camelPort = parsePortNumber(value.internalPort);
+    const snakePort = parsePortNumber(value.internal_port);
+    const canonical = camelPort || snakePort;
+
+    if (canonical && value.internalPort !== canonical) {
+      value.internalPort = canonical;
+      changed = true;
+    }
+    if (Object.hasOwn(value, 'internal_port')) {
+      delete value.internal_port;
+      changed = true;
+    }
+  }
+
+  for (const nested of Object.values(value)) {
+    if (nested && typeof nested === 'object' && normalizePortKeysInObject(nested)) {
+      changed = true;
+    }
+  }
+
+  return changed;
 }
 
 /**

--- a/cli/lib/service-runtime.js
+++ b/cli/lib/service-runtime.js
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { BIN_DIR } from './config.js';
+
+const PATH_FALLBACKS = [
+  '/usr/local/sbin',
+  '/usr/local/bin',
+  '/usr/sbin',
+  '/usr/bin',
+  '/sbin',
+  '/bin',
+];
+
+export function splitPathEntries(value) {
+  if (!value) return [];
+  return String(value)
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function dedupePathEntries(entries) {
+  const seen = new Set();
+  const result = [];
+  for (const entry of entries.flatMap(splitPathEntries)) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    result.push(entry);
+  }
+  return result;
+}
+
+export function buildManagedPath(envMap = null) {
+  const home = os.homedir();
+  const nodeBin = path.dirname(process.execPath);
+  return dedupePathEntries([
+    BIN_DIR,
+    path.join(home, '.local', 'bin'),
+    path.join(home, '.claude', 'bin'),
+    process.env.NVM_BIN,
+    nodeBin,
+    envMap?.get?.('SYSTEM_PATH'),
+    process.env.SYSTEM_PATH,
+    process.env.PATH,
+    PATH_FALLBACKS,
+  ]).join(path.delimiter);
+}
+
+export function parsePortNumber(value) {
+  if (value == null || value === '') return null;
+  const str = String(value).trim();
+  if (!/^\d+$/.test(str)) return null;
+  const port = Number.parseInt(str, 10);
+  if (port < 1 || port > 65535) return null;
+  return String(port);
+}
+
+export function resolvePort({ primaryKey, legacyKeys = [], envMap = null, envObject = process.env, defaultPort }) {
+  const candidates = [primaryKey, ...legacyKeys];
+  for (const key of candidates) {
+    const fromProcess = parsePortNumber(envObject?.[key]);
+    if (fromProcess) return fromProcess;
+    const fromEnv = parsePortNumber(envMap?.get?.(key));
+    if (fromEnv) return fromEnv;
+  }
+  return String(defaultPort);
+}
+
+export function getWebConsolePort(envMap = null, envObject = process.env) {
+  return resolvePort({
+    primaryKey: 'WEB_CONSOLE_PORT',
+    legacyKeys: ['ZYLOS_WEB_PORT'],
+    envMap,
+    envObject,
+    defaultPort: 3456,
+  });
+}
+
+export function getPm2Home(home = os.homedir()) {
+  return path.join(home, '.pm2');
+}
+
+export function findBinaryInPath(binaryName, searchPath) {
+  for (const dir of splitPathEntries(searchPath)) {
+    const candidate = path.join(dir, binaryName);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep searching.
+    }
+  }
+  return null;
+}
+
+export function findPm2Binary(envMap = null) {
+  const managedPath = buildManagedPath(envMap);
+  const explicit = findBinaryInPath('pm2', managedPath);
+  if (explicit) return explicit;
+
+  const adjacentToNode = path.join(path.dirname(process.execPath), 'pm2');
+  try {
+    fs.accessSync(adjacentToNode, fs.constants.X_OK);
+    return adjacentToNode;
+  } catch {
+    return 'pm2';
+  }
+}
+
+export function buildStablePm2SystemdUnit({ user, home, pm2Path, pathValue, pm2Home }) {
+  return `[Unit]
+Description=PM2 process manager for ${user}
+Documentation=https://pm2.keymetrics.io/
+After=network.target
+
+[Service]
+Type=simple
+User=${user}
+Environment=PATH=${pathValue}
+Environment=PM2_HOME=${pm2Home}
+Environment=HOME=${home}
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+ExecStart=${pm2Path} resurrect --no-daemon
+ExecReload=${pm2Path} reload all
+ExecStop=${pm2Path} kill
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`;
+}

--- a/templates/pm2/ecosystem.config.cjs
+++ b/templates/pm2/ecosystem.config.cjs
@@ -17,12 +17,14 @@ const SKILLS_DIR = path.join(HOME, 'zylos', '.claude', 'skills');
 const BIN_DIR = path.join(ZYLOS_DIR, 'bin');
 const HTTP_DIR = path.join(ZYLOS_DIR, 'http');
 
-// Read a value from .env file
-function readEnvValue(key, defaultValue = '') {
+// Read a value from .env file, with optional legacy aliases
+function readEnvValue(key, defaultValue = '', aliases = []) {
   try {
     const content = fs.readFileSync(path.join(ZYLOS_DIR, '.env'), 'utf8');
-    const match = content.match(new RegExp(`^${key}=(.+)$`, 'm'));
-    if (match) return match[1];
+    for (const candidate of [key, ...aliases]) {
+      const match = content.match(new RegExp(`^${candidate}=(.+)$`, 'm'));
+      if (match) return match[1];
+    }
   } catch {}
   return defaultValue;
 }
@@ -88,7 +90,8 @@ module.exports = {
       cwd: HOME,
       env: {
         PATH: ENHANCED_PATH,
-        NODE_ENV: 'production'
+        NODE_ENV: 'production',
+        WEB_CONSOLE_PORT: readEnvValue('WEB_CONSOLE_PORT', '3456', ['ZYLOS_WEB_PORT'])
       },
       autorestart: true,
       max_restarts: 10,


### PR DESCRIPTION
## Summary

This PR hardens multi-instance deployment and reboot persistence for zylos-core based on real-world failures observed during multi-agent deployment.

## What this fixes

### 1. More stable PM2 systemd startup
- generate a more robust systemd unit by default
- use `Type=simple`
- use `pm2 resurrect --no-daemon`
- reduce reliance on the fragile default `pm2 startup` output

### 2. Less dependence on interactive shell init
- reduce runtime dependence on `.bashrc` / interactive shell behavior
- make service startup rely more on explicit managed PATH construction

### 3. Canonicalize port/env handling
- treat `WEB_CONSOLE_PORT` as the canonical key
- retain backward compatibility with legacy `ZYLOS_WEB_PORT`
- normalize legacy config/env values during init/migration
- normalize JSON `internal_port` -> `internalPort`

### 4. More consistent service startup behavior
- make `zylos start` prefer the PM2 ecosystem config as the single source of truth
- reduce drift between manual start logic and persisted PM2 startup config

## Why

In real deployments with multiple instances (for example, parallel agents on the same host), we hit several issues:
- non-interactive shell PATH/NVM problems
- PM2 systemd units that were not stable enough after reboot
- web/telegram internal port collisions
- config key mismatch causing expected port overrides not to take effect

This PR addresses those issues in a backward-compatible way.

## Notes

- legacy env/config keys are still recognized
- canonical behavior now favors `WEB_CONSOLE_PORT`
- this PR focuses on stability and persistence, not feature expansion
