### PR TITLE
fix(activity-monitor): reduce periodic probe interval 5min → 3min

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -159,7 +159,7 @@ const RATE_LIMIT_DEFAULT_COOLDOWN = 3600;  // 1 hour default when reset time can
 const USER_MESSAGE_RECOVERY_COOLDOWN = 60; // 1 min between user-message-triggered recoveries
 
 // Periodic probe config (replaces stuck detection)
-const PERIODIC_PROBE_INTERVAL = 300; // 5 min fixed-interval probe when agent is idle
+const PERIODIC_PROBE_INTERVAL = 180; // 3 min fixed-interval probe when agent is idle
 
 // Health check config
 const HEALTH_CHECK_INTERVAL = 21600; // 6 hours


### PR DESCRIPTION
## Summary

- Reduces `PERIODIC_PROBE_INTERVAL` from 300s to 180s
- Total stuck/menu-blocked agent recovery time: ~7min → ~5min

## Why it's safe

The probe fires only when `active_tools === 0` (agent is idle). During active tool use, the probe is skipped entirely — no risk of interrupting work in progress. When idle, the probe just gets ACKd and health stays OK.

## Note on installed version

The running v0.4.0 npm package predates PR #332 and still uses the old `STUCK_THRESHOLD` constant. This PR targets the new periodic probe architecture from #332. Will take effect after next upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)