### PR TITLE
fix: checkAuth() false-positive when Claude has no credentials

### DIFF
--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -106,11 +106,9 @@ export class ClaudeAdapter extends RuntimeAdapter {
       // a structured field from the API, not free-form text, so it's stable across CLI versions.
       // Rate limits produce "rate_limit_error", server errors produce "api_error" — no overlap.
       //
-      // "Not logged in" — Claude CLI has no credentials at all (no API key, no OAuth token).
-      // Observed output: "Not logged in · Please run /login". This is not a transient error
-      // and must not be treated as "uncertain" — returning ok:true here causes zylos status
-      // and zylos doctor to falsely report "authorized" on a fresh install where the user
-      // skipped authentication.
+      // Any other non-zero exit (e.g. "Not logged in · Please run /login" when the user has
+      // no credentials) must not be treated as "uncertain" — returning ok:true would cause
+      // zylos status/doctor to falsely report "authorized" on a fresh install.
       const output = (err.stdout ?? '') + (err.stderr ?? '');
       if (output.includes('authentication_error')) {
         return { ok: false, reason: 'cli_probe_authentication_error' };


### PR DESCRIPTION
## Problem

On a fresh install where the user skips authentication (presses Enter without entering a token), `zylos status` showed **Claude: IDLE** and `zylos doctor` showed **authorized** — both wrong.

**Root cause:** `checkAuth()` runs `claude -p ping`. When there are no credentials, Claude CLI outputs `Not logged in · Please run /login` (exit 1). This output doesn't contain `authentication_error` (an API-level JSON error type), so the catch block fell through to `{ ok: true, reason: 'cli_probe_uncertain' }` — a false positive.

Verified in the Docker container on zylos-voya-test:
```
$ claude -p ping --max-turns 1
Not logged in · Please run /login
exit: 1
```

## Fix

Add `"Not logged in"` pattern check to the catch block. This text appears when there are no credentials at all (no API key, no OAuth token). If this text changes in a future CLI version, the fallback remains `cli_probe_uncertain` (existing behavior — degrades gracefully, no regression).

## Test plan

- [ ] Fresh install, skip auth → `zylos doctor` shows "not authorized"
- [ ] Valid auth → `zylos doctor` still shows "authorized"
- [ ] Network down → still reports uncertain (ok: true, no false negative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)