### PR TITLE
fix: guard /usage check against active prompts using in_prompt signal

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -986,7 +986,7 @@ function sendUsageNotification(message) {
  * Usage check state machine — called from monitorLoop every second.
  * Only progresses when Claude is idle with no pending work.
  */
-function maybeCheckUsage(claudeState, idleSeconds, currentTime) {
+function maybeCheckUsage(claudeState, idleSeconds, currentTime, apiActivity) {
   // /usage is a Claude Code-only slash command — skip for other runtimes
   if (adapter.runtimeId !== 'claude') return;
 
@@ -1080,6 +1080,15 @@ function maybeCheckUsage(claudeState, idleSeconds, currentTime) {
   if (claudeState !== 'idle') return;
   if (idleSeconds < USAGE_IDLE_GATE) return;
   if ((currentTime - lastUsageCheckAt) < USAGE_CHECK_INTERVAL) return;
+
+  // Don't interrupt an active prompt (text generation between tool calls).
+  // Guard against stale in_prompt after a hard crash: ignore if the hook
+  // activity file hasn't been updated in 10 minutes (600s).
+  if (apiActivity?.in_prompt) {
+    const updatedAt = apiActivity?.updated_at
+      ? Math.floor(apiActivity.updated_at / 1000) : 0;
+    if ((currentTime - updatedAt) < 600) return;
+  }
 
   // Only check during active hours
   const hour = getLocalHour();
@@ -1321,7 +1330,7 @@ async function monitorLoop() {
   }
   memoryCommitScheduler.maybeTrigger();
   if (engine.health === 'ok') {
-    maybeCheckUsage(state, idleSeconds, currentTime);
+    maybeCheckUsage(state, idleSeconds, currentTime, apiActivity);
   }
   lastState = state;
 }

--- a/skills/activity-monitor/scripts/hook-activity.js
+++ b/skills/activity-monitor/scripts/hook-activity.js
@@ -132,6 +132,7 @@ process.stdin.on('end', () => {
           eventType = 'prompt';
           active = true;
           state.active_tools = 0;
+          state.in_prompt = true;
           break;
         case 'PreToolUse':
           eventType = 'pre_tool';
@@ -148,11 +149,13 @@ process.stdin.on('end', () => {
         case 'Stop':
           eventType = 'stop';
           state.active_tools = 0;
+          state.in_prompt = false;
           active = false;
           break;
         case 'Notification':
           eventType = 'idle';
           state.active_tools = 0;
+          state.in_prompt = false;
           active = false;
           break;
         default:
@@ -168,6 +171,7 @@ process.stdin.on('end', () => {
         tool,
         active,
         active_tools: state.active_tools,
+        in_prompt: state.in_prompt ?? false,
         updated_at: Date.now()
       });
 


### PR DESCRIPTION
## Summary

- `/usage` slash command was firing mid-task and interrupting Claude's active work
- Root cause: `IDLE_THRESHOLD=3s` — between tool calls, the monitor falsely sees idle state (no hook fires during text generation). After 30s of false-idle, `/usage` gets sent via `tmux send-keys`
- Fix: track prompt lifecycle via `in_prompt` flag; `/usage` only fires after `Stop`/`Notification` confirms the prompt is complete

## Changes

**`hook-activity.js`** — track prompt lifecycle:
- `UserPromptSubmit` → `state.in_prompt = true`
- `Stop` / `Notification` → `state.in_prompt = false`
- Written to `api-activity.json` alongside existing fields

**`activity-monitor.js`** — guard in `maybeCheckUsage()`:
- Skip `/usage` check while `apiActivity.in_prompt === true`
- 600s staleness guard: if last hook update was >10 min ago, ignore `in_prompt` (handles hard crash where `Stop` never fired)

## Test plan
- [ ] Start a long multi-tool task (>30s between tool calls) — `/usage` should NOT fire mid-task
- [ ] After task completes (`Stop` fires) — `/usage` should fire normally after 30s idle
- [ ] Simulate hard crash (kill Claude without Stop hook) — after 10+ minutes idle, `/usage` should fire again

Reviewed by: local Codex v0.114.0 (non-interactive mode) — no regressions found

🤖 Generated with [Claude Code](https://claude.com/claude-code)