### PR TITLE
fix: use x-api-key header for OAuth token HTTP validation

### DIFF
--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -133,7 +133,7 @@ export class ClaudeAdapter extends RuntimeAdapter {
       return await this._httpValidateCredentials({ 'x-api-key': envApiKey });
     }
     if (envOauthToken) {
-      return await this._httpValidateCredentials({ 'Authorization': `Bearer ${envOauthToken}` });
+      return await this._httpValidateCredentials({ 'x-api-key': envOauthToken });
     }
 
     // Stage 3: Live CLI probe — `claude -p ping --max-turns 1`.


### PR DESCRIPTION
## Summary
- `checkAuth()` Stage 2 sent `CLAUDE_CODE_OAUTH_TOKEN` as `Authorization: Bearer`, but the Anthropic `/v1/models` endpoint returns 401 for OAuth tokens (`sk-ant-oat01-...`) with Bearer auth
- The same token works correctly with `x-api-key` header (200 for valid, 401 for invalid)
- This caused `zylos status` / `zylos doctor` to falsely report "NOT AUTHENTICATED" even when Claude Code was running and fully authenticated

## Test results (on zylos0)
| Header | Token | Result |
|--------|-------|--------|
| `x-api-key` | valid `sk-ant-oat01-...` | 200 |
| `Authorization: Bearer` | valid `sk-ant-oat01-...` | 401 |
| `x-api-key` | fake token | 401 |

## Change
One-line change in `cli/lib/runtime/claude.js:136`:
```diff
- return await this._httpValidateCredentials({ 'Authorization': `Bearer ${envOauthToken}` });
+ return await this._httpValidateCredentials({ 'x-api-key': envOauthToken });
```

## Test plan
- [x] HTTP validation tested with valid token: 200
- [x] HTTP validation tested with fake token: 401
- [ ] `zylos status` shows correct auth state after upgrade
- [ ] `zylos doctor` shows correct auth state after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)