### PR TITLE
fix: auto-restart service after successful upgrade

### DIFF
--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -458,7 +458,13 @@ function step7_startService(ctx) {
     execSync(`pm2 restart ${serviceName} 2>/dev/null`, { stdio: 'pipe' });
     return { step: 7, name: 'start_service', status: 'done', message: serviceName, duration: Date.now() - startTime };
   } catch {
-    return { step: 7, name: 'start_service', status: 'failed', error: `Failed to restart ${serviceName}`, duration: Date.now() - startTime };
+    // restart fails if process was deleted from PM2 between step1 and step7; fall back to start
+    try {
+      execSync(`pm2 start ${serviceName} 2>/dev/null`, { stdio: 'pipe' });
+      return { step: 7, name: 'start_service', status: 'done', message: `${serviceName} (started)`, duration: Date.now() - startTime };
+    } catch {
+      return { step: 7, name: 'start_service', status: 'failed', error: `Failed to restart ${serviceName}`, duration: Date.now() - startTime };
+    }
   }
 }
 
@@ -504,7 +510,7 @@ export function rollback(ctx) {
     const parsed = parseSkillMd(ctx.skillDir);
     const serviceName = parsed?.frontmatter?.lifecycle?.service?.name || `zylos-${ctx.component}`;
     try {
-      execSync(`pm2 restart ${serviceName} 2>/dev/null || true`, { stdio: 'pipe' });
+      execSync(`pm2 restart ${serviceName} 2>/dev/null`, { stdio: 'pipe' });
       results.push({ action: 'restart_service', success: true });
     } catch (err) {
       results.push({ action: 'restart_service', success: false, error: err.message });


### PR DESCRIPTION
## Summary
- After step 1 stops the service during upgrade, the success path never restarts it (only rollback has restart)
- This leaves the service in stopped state after every upgrade, requiring manual `pm2 restart`
- Add step7_startService: automatically restart the PM2 service after successful upgrade (only if it was running before)

## Change
Upgrade pipeline expanded from 6 steps to 7: stop → backup → merge → npm install → manifest → caddy → **start**

step7 logic:
- If `ctx.serviceWasRunning` is false (not running before upgrade) → skip
- Read service name from the updated SKILL.md → `pm2 restart`
- On failure, mark as `failed` (triggers rollback)

## Test plan
- [ ] Upgrade a component with a PM2 service (e.g. telegram) → service auto-restarts
- [ ] Upgrade a component without a PM2 service (e.g. browser) → step7 skipped
- [ ] Upgrade a component whose service was already stopped → step7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)