### PR TITLE
fix: auth check failure 3-min backoff in Guardian

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -408,6 +408,26 @@ function enqueueStartupControl() {
 }
 
 /**
+ * Check for a user-message signal file and clear auth suppression if found.
+ * Called from offline/stopped branches (which return early before the main
+ * signal-check code) so that user messages can trigger immediate auth retry.
+ */
+function maybeConsumeUserMessageSignal(currentTime) {
+  try {
+    if (!fs.existsSync(USER_MESSAGE_SIGNAL_FILE)) return;
+    const signal = JSON.parse(fs.readFileSync(USER_MESSAGE_SIGNAL_FILE, 'utf8'));
+    fs.unlinkSync(USER_MESSAGE_SIGNAL_FILE);
+    if (signal.timestamp && (currentTime - signal.timestamp) < 60) {
+      if (authRetrySuppressedUntil > 0) {
+        log('Guardian: user message received, clearing auth retry suppression');
+        authRetrySuppressedUntil = 0;
+      }
+      engine.notifyUserMessage(currentTime);
+    }
+  } catch { /* best-effort */ }
+}
+
+/**
  * Start the active runtime agent.
  * Clears stale state files, delegates launch to the RuntimeAdapter,
  * then enqueues the startup control prompt if no session-start hook is installed.
@@ -1160,6 +1180,9 @@ async function monitorLoop() {
       log('State: OFFLINE (tmux session not found)');
     }
 
+    // Check for user message signal — clears auth suppression for immediate retry.
+    maybeConsumeUserMessageSignal(currentTime);
+
     // Delegate restart permission to HeartbeatEngine (e.g. won't restart during rate_limited).
     // Counter mutations (consecutiveRestarts, startupGrace, notRunningCount) are handled
     // inside startAgent() after auth check passes — not here.
@@ -1211,6 +1234,9 @@ async function monitorLoop() {
     if (state !== lastState) {
       log(`State: STOPPED (${adapter.displayName} not running in tmux session)`);
     }
+
+    // Check for user message signal — clears auth suppression for immediate retry.
+    maybeConsumeUserMessageSignal(currentTime);
 
     // Delegate restart permission to HeartbeatEngine (e.g. won't restart during rate_limited).
     // Counter mutations (consecutiveRestarts, startupGrace, notRunningCount) are handled
@@ -1318,19 +1344,7 @@ async function monitorLoop() {
   // User message triggered recovery: when a user sends a message while unavailable,
   // c4-receive writes a signal file. Read and consume it to trigger/accelerate recovery.
   if (engine.health !== 'ok') {
-    try {
-      if (fs.existsSync(USER_MESSAGE_SIGNAL_FILE)) {
-        const signal = JSON.parse(fs.readFileSync(USER_MESSAGE_SIGNAL_FILE, 'utf8'));
-        fs.unlinkSync(USER_MESSAGE_SIGNAL_FILE);
-        if (signal.timestamp && (currentTime - signal.timestamp) < 60) {
-          if (authRetrySuppressedUntil > 0) {
-            log('Guardian: user message received, clearing auth retry suppression');
-            authRetrySuppressedUntil = 0;
-          }
-          engine.notifyUserMessage(currentTime);
-        }
-      }
-    } catch { /* best-effort */ }
+    maybeConsumeUserMessageSignal(currentTime);
   }
 
   // Periodic probe: fixed 5-min interval, skipped when agent is busy (active_tools > 0).


### PR DESCRIPTION
## Summary
- Auth check failure in Guardian now suppresses restart attempts for 3 minutes instead of retrying every ~1 second
- User message signal clears the suppression for immediate retry
- Suppression status logged once per 60s to avoid log spam

## Root Cause
During the 2026-03-17 outage, `checkAuth()` returned 401 for 18 minutes. After the initial `restartDelay` (5s) was exceeded, `notRunningCount` kept growing and satisfied `notRunningCount >= restartDelay` every tick (~1s), triggering `startAgent()` → `checkAuth()` every second. Auth failures returned early without resetting `notRunningCount`, so the condition was true on every subsequent tick.

Result: ~647 HTTP requests to api.anthropic.com in 18 minutes.

## Fix
New `authRetrySuppressedUntil` timestamp:
1. `checkAuth()` fails → `authRetrySuppressedUntil = Date.now() + 180_000` (3 min)
2. Guardian restart condition adds: `if (Date.now() < authRetrySuppressedUntil) skip`
3. User message signal → `authRetrySuppressedUntil = 0` (immediate retry)
4. Auth success → `authRetrySuppressedUntil = 0`

18 min scenario: 647 requests → ~6 requests.

## Test plan
- [ ] Verify auth failure logs show "Next retry in 3 min" and suppression message once per 60s
- [ ] Verify auth success after suppression proceeds normally
- [ ] Verify user message signal during suppression triggers immediate retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)