### PR TITLE
feat: API error fast-detection for heartbeat recovery

### DIFF
--- a/cli/lib/heartbeat/claude-probe.js
+++ b/cli/lib/heartbeat/claude-probe.js
@@ -2,7 +2,7 @@
  * claude-probe.js — HeartbeatEngine probe for Claude Code runtime.
  *
  * Implements the runtime-specific deps subset for HeartbeatEngine:
- *   enqueueHeartbeat, getHeartbeatStatus, detectRateLimit,
+ *   enqueueHeartbeat, getHeartbeatStatus, detectRateLimit, detectApiError,
  *   readHeartbeatPending, clearHeartbeatPending
  *
  * Mechanism:
@@ -10,6 +10,8 @@
  *     Claude Code's ACK (via c4-control.js ack --id <id>) marks it done.
  *   - getHeartbeatStatus: queries C4 control for the message status.
  *   - detectRateLimit: captures the tmux pane and matches Anthropic usage-limit UI patterns.
+ *   - detectApiError: captures the tmux pane and matches Anthropic API error patterns (e.g. 400).
+ *     Used for fast recovery when API errors cause the session to become unresponsive.
  *
  * Usage:
  *   const probe = createClaudeProbe({ pendingFile, tmuxSession });
@@ -29,6 +31,17 @@ const RATE_LIMIT_PATTERNS = [
   /you['']re out of .* usage/i,
   /usage limit reached/i,
   /you['']ve hit your limit/i,
+];
+
+// Anthropic API error patterns — matched against tmux pane content to detect
+// fatal API errors (e.g. 400 from a corrupted image) that leave Claude Code
+// unresponsive. These patterns are specific to Claude Code's error display
+// to avoid false positives from conversation content containing "400".
+const API_ERROR_PATTERNS = [
+  /APIError:\s*\d{3}/,                                    // "APIError: 400 ..."
+  /\b(400|422)\b.*(?:bad request|invalid request)/i,      // "400 Bad Request"
+  /invalid_request_error/,                                 // Anthropic error type
+  /overloaded_error/,                                      // Anthropic overloaded
 ];
 
 /**
@@ -126,6 +139,27 @@ export function createClaudeProbe({
       }
 
       return { detected: true, cooldownUntil, resetTime };
+    },
+
+    /**
+     * Detect Anthropic API errors (e.g. 400 from corrupted image) in the tmux pane.
+     * Used for fast recovery: when a heartbeat is pending and the session appears
+     * stuck, this check can trigger immediate recovery instead of waiting for the
+     * full ack_deadline timeout.
+     *
+     * @returns {{ detected: boolean, pattern?: string }}
+     */
+    detectApiError() {
+      const pane = _captureTmuxPane(tmuxSession);
+      if (!pane) return { detected: false };
+
+      for (const p of API_ERROR_PATTERNS) {
+        const match = pane.match(p);
+        if (match) {
+          return { detected: true, pattern: match[0] };
+        }
+      }
+      return { detected: false };
     },
 
     // ── Pending state management ─────────────────────────────────────────────

--- a/skills/activity-monitor/scripts/__tests__/heartbeat-engine.test.js
+++ b/skills/activity-monitor/scripts/__tests__/heartbeat-engine.test.js
@@ -914,4 +914,86 @@ describe('HeartbeatEngine', () => {
       assert.equal(engine.health, 'down');
     });
   });
+
+  describe('API error fast-detection', () => {
+    it('triggers recovery when API error detected and pending age > 30s', () => {
+      const { deps, calls } = createMockDeps();
+      const now = Math.floor(Date.now() / 1000);
+      deps._pending = { control_id: 1, phase: 'stuck', created_at: now - 40 };
+      deps._heartbeatStatus = 'pending';
+      deps.detectApiError = () => ({ detected: true, pattern: 'APIError: 400' });
+      const engine = new HeartbeatEngine(deps);
+
+      engine.processHeartbeat(true, now);
+
+      assert.equal(calls.killTmuxSession, 1);
+      assert.equal(engine.health, 'recovering');
+      assert.ok(calls.log.some(m => m.includes('API error detected') && m.includes('APIError: 400')));
+    });
+
+    it('does not scan when pending age < 30s', () => {
+      let scanCalled = false;
+      const { deps, calls } = createMockDeps();
+      const now = Math.floor(Date.now() / 1000);
+      deps._pending = { control_id: 1, phase: 'stuck', created_at: now - 10 };
+      deps._heartbeatStatus = 'pending';
+      deps.detectApiError = () => { scanCalled = true; return { detected: false }; };
+      const engine = new HeartbeatEngine(deps);
+
+      engine.processHeartbeat(true, now);
+
+      assert.equal(scanCalled, false);
+      assert.equal(calls.killTmuxSession, 0);
+    });
+
+    it('throttles scans to once per 15 seconds', () => {
+      let scanCount = 0;
+      const { deps } = createMockDeps();
+      const now = Math.floor(Date.now() / 1000);
+      deps._pending = { control_id: 1, phase: 'stuck', created_at: now - 50 };
+      deps._heartbeatStatus = 'pending';
+      deps.detectApiError = () => { scanCount++; return { detected: false }; };
+      const engine = new HeartbeatEngine(deps);
+
+      // First call: should scan
+      engine.processHeartbeat(true, now);
+      assert.equal(scanCount, 1);
+
+      // Second call 5 seconds later: should NOT scan (throttled)
+      engine.processHeartbeat(true, now + 5);
+      assert.equal(scanCount, 1);
+
+      // Third call 16 seconds later: should scan again
+      engine.processHeartbeat(true, now + 16);
+      assert.equal(scanCount, 2);
+    });
+
+    it('does not scan when detectApiError dep is absent', () => {
+      const { deps, calls } = createMockDeps();
+      const now = Math.floor(Date.now() / 1000);
+      deps._pending = { control_id: 1, phase: 'stuck', created_at: now - 40 };
+      deps._heartbeatStatus = 'pending';
+      // No detectApiError dep
+      const engine = new HeartbeatEngine(deps);
+
+      engine.processHeartbeat(true, now);
+
+      assert.equal(calls.killTmuxSession, 0);
+      assert.equal(engine.health, 'ok');
+    });
+
+    it('does not trigger when no API error detected', () => {
+      const { deps, calls } = createMockDeps();
+      const now = Math.floor(Date.now() / 1000);
+      deps._pending = { control_id: 1, phase: 'stuck', created_at: now - 40 };
+      deps._heartbeatStatus = 'pending';
+      deps.detectApiError = () => ({ detected: false });
+      const engine = new HeartbeatEngine(deps);
+
+      engine.processHeartbeat(true, now);
+
+      assert.equal(calls.killTmuxSession, 0);
+      assert.equal(engine.health, 'ok');
+    });
+  });
 });

--- a/skills/activity-monitor/scripts/heartbeat-engine.js
+++ b/skills/activity-monitor/scripts/heartbeat-engine.js
@@ -39,6 +39,7 @@ export class HeartbeatEngine {
    * @param {() => void} deps.notifyPendingChannels
    * @param {(message: string) => void} deps.log
    * @param {() => {detected: boolean, cooldownUntil?: number, resetTime?: string}} [deps.detectRateLimit]
+   * @param {() => {detected: boolean, pattern?: string}} [deps.detectApiError]
    * @param {object} [options]
    * @param {number} [options.heartbeatInterval=1800]
    * @param {number} [options.downDegradeThreshold=3600] - Seconds of continuous failure before entering DOWN
@@ -75,6 +76,9 @@ export class HeartbeatEngine {
     this.cooldownUntil = 0; // Epoch seconds when rate limit cooldown expires
     this.rateLimitResetTime = ''; // Human-readable reset time for display
     this.lastUserMessageRecoveryAt = 0; // Last time user message triggered early recovery
+
+    // API error detection throttle
+    this._lastApiErrorScanAt = 0; // Last time tmux pane was scanned for API errors
   }
 
   get health() {
@@ -192,6 +196,20 @@ export class HeartbeatEngine {
       const pendingAge = currentTime - (pending.created_at || 0);
       const maxPendingAge = 600; // 10 min absolute ceiling
       if ((status === 'pending' || status === 'running' || status === 'error') && pendingAge < maxPendingAge) {
+        // API error fast-detection: when a heartbeat has been pending for >30s,
+        // periodically scan the tmux pane for fatal API errors (e.g. 400 from
+        // corrupted image). Triggers immediate recovery instead of waiting for
+        // the full ack_deadline timeout (120s). Scans at most once per 15s.
+        if (pendingAge > 30 && this.deps.detectApiError
+            && (currentTime - this._lastApiErrorScanAt) >= 15) {
+          this._lastApiErrorScanAt = currentTime;
+          const apiError = this.deps.detectApiError();
+          if (apiError.detected) {
+            this.deps.log(`API error detected in tmux pane: ${apiError.pattern}. Triggering immediate recovery.`);
+            this.onHeartbeatFailure(pending, 'api_error');
+            return;
+          }
+        }
         return;
       }
       if (pendingAge >= maxPendingAge && status !== 'done') {


### PR DESCRIPTION
## Summary
- When Anthropic API returns 400 (e.g. corrupted image), Claude Code becomes unresponsive but the tmux session stays alive. Previously, recovery waited for the full 120s ack_deadline timeout.
- New: when a heartbeat has been pending >30s, the tmux pane is scanned every 15s for API error patterns (`APIError: 400`, `invalid_request_error`, `overloaded_error`, etc). If detected, recovery triggers immediately.
- Recovery time reduced from ~120s to ~30-45s for API error scenarios.
- Dual-signal protection (heartbeat stuck + error pattern) prevents false positives from conversation content.

## Changes
- `cli/lib/heartbeat/claude-probe.js`: Added `detectApiError()` dep + `API_ERROR_PATTERNS`
- `skills/activity-monitor/scripts/heartbeat-engine.js`: API error scanning in `processHeartbeat()` with 15s throttle
- 5 new test cases (all passing)

## Test plan
- [x] Unit tests: 75/76 pass (1 pre-existing failure unrelated)
- [ ] Integration test: send corrupted image via Lark → verify recovery triggers within ~45s instead of ~120s
- [ ] Verify no false positives during normal conversation containing "400" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)