### PR TITLE
fix: clear stale heartbeat pending on new session launch

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -491,6 +491,13 @@ async function startAgent() {
   log(`Guardian: Starting ${adapter.displayName}...`);
   lastLaunchAt = Math.floor(Date.now() / 1000);
 
+  // Clear stale heartbeat pending from previous session — prevents a race where
+  // the old heartbeat times out AFTER the new session starts, pushing health to
+  // "recovering" when the process signal (false→true) was already consumed while
+  // health was still "ok". Without this, health gets stuck in "recovering" with
+  // no signal to trigger acceleration.
+  try { engine.deps.clearHeartbeatPending(); } catch { }
+
   // Clear stale context temp files from a previous session
   try { fs.unlinkSync('/tmp/context-alert-cooldown'); } catch { }
   try { fs.unlinkSync('/tmp/context-compact-scheduled'); } catch { }


### PR DESCRIPTION
## Summary
- Clear `heartbeat-pending.json` in `startAgent()` before launching a new session, preventing a stale heartbeat timeout from pushing health to "recovering" after the new session is already running.

## Root Cause
When a session crashes with a pending heartbeat probe:

```
t+0s    Old session sends heartbeat probe
t+33s   Old session crashes (e.g. 400 API error), heartbeat still pending
t+68s   Guardian starts new session, health="ok" (pending not yet timed out)
t+69s   Process signal: false→true recorded, but health="ok" → signal NOT stored
t+120s  Old heartbeat times out → health="ok" → "recovering"
        Agent already running, no new false→true transition → no acceleration
        → health stuck in "recovering" forever → user messages blocked
```

## Fix
One line: `engine.deps.clearHeartbeatPending()` in `startAgent()`, right before `adapter.launch()`. The stale pending heartbeat is cleared, so it can't time out and cause a late health transition.

## Test plan
- [x] All 77 tests pass
- [ ] Deploy to coco-voya-test, trigger 400 error with corrupt image, verify session recovers and health returns to "ok"

🤖 Generated with [Claude Code](https://claude.com/claude-code)