### PR TITLE
fix(init): pre-accept Claude terms regardless of auth state

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -2198,8 +2198,9 @@ export async function initCommand(args) {
     } // end if (commandExists('claude')) — Step 6
   } // end else (Claude runtime branch)
 
-  // Pre-accept Claude Code terms (skips manual prompts on first launch)
-  if (claudeAuthenticated) {
+  // Pre-accept Claude Code terms (skips manual prompts on first launch).
+  // Called regardless of auth state — user may configure credentials after init.
+  if (selectedRuntime === 'claude') {
     if (preAcceptClaudeTerms()) {
       if (!quiet) console.log(`  ${success('Claude Code terms pre-accepted')}`);
     }


### PR DESCRIPTION
## Summary
- `preAcceptClaudeTerms()` was gated on `claudeAuthenticated`, so `~/.claude/settings.json` was never created when `zylos init` ran without credentials in `.env`
- Users who configured tokens after init saw "NOT READY — autonomous mode not yet accepted" and had to wait up to 3 minutes (Guardian auth backoff) before Claude auto-started
- Fix: gate on `selectedRuntime === 'claude'` instead — terms pre-acceptance and authentication are independent concerns

## Test plan
- [ ] Run `zylos init` in a fresh Docker container without any token in `.env`
- [ ] Verify `~/.claude/settings.json` exists with `skipDangerousModePermissionPrompt: true`
- [ ] Add token to `.env`, verify `zylos status` shows correct state (not "NOT READY")
- [ ] Run `zylos init` with token already in `.env`, verify no regression

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)