### PR TITLE
Refine onboarding security copy for cloud deployments

### DIFF
--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -44,7 +44,7 @@ When the user sends their first message, deliver the following security notice t
 > • Make sure you're using me in a trusted environment — if others can access your account, device, or communication channels, they may be able to trigger actions through me
 > • Conversations and files may be processed by AI models — avoid storing sensitive credentials (private keys, long-lived tokens, etc.) here
 > • Third-party skills, external tools, or system integrations can act directly based on how they are configured — check the source and permissions before enabling them
-> • I may make mistakes — keep an eye on the results of important operations, especially anything involving production systems, sensitive data, or spending
+> • I may make mistakes — keep an eye on the results of important operations
 >
 > Ready? Let's get started.
 

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -43,7 +43,7 @@ When the user sends their first message (via C4, with a `reply via:` path), deli
 > • Make sure you're using me in a trusted environment — if others can access your account, device, or communication channels, they may be able to trigger actions through me
 > • Conversations and files may be processed by AI models — avoid storing sensitive credentials (private keys, long-lived tokens, etc.) here
 > • Third-party skills, external tools, or system integrations can act directly based on how they are configured — check the source and permissions before enabling them
-> • I may make mistakes — keep an eye on the results of important operations, especially anything involving production systems, sensitive data, or spending
+> • I may make mistakes — keep an eye on the results of important operations
 >
 > Ready? Let's get started.
 


### PR DESCRIPTION
## Summary
- replace the onboarding line that implies full host access with wording based on actions within the current runtime environment
- update the risk bullets so they apply to both self-hosted and cloud deployments
- keep the existing onboarding flow unchanged

## Testing
- not run (copy-only change)