### PR TITLE
docs: add version query instructions for IM channels

### DIFF
--- a/skills/component-management/SKILL.md
+++ b/skills/component-management/SKILL.md
@@ -31,7 +31,10 @@ Detailed step-by-step workflows for each operation (Session + C4 modes):
 ## Quick Commands
 
 ```bash
-# List installed components
+# Check zylos-core version
+zylos --version
+
+# List installed components (with versions)
 zylos list
 
 # Search available components
@@ -39,6 +42,9 @@ zylos search <keyword>
 
 # Component status
 zylos status
+
+# Check for zylos-core updates
+zylos upgrade --self --check
 
 # Check all components for updates
 zylos upgrade --all --check

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -25,6 +25,25 @@ This is a Zylos-managed workspace for an autonomous AI agent. You have full cont
 
 Be resourceful: when a user makes a request, don't give up easily. If you can do it yourself, do it — save the user's effort. If you can't act immediately, suggest feasible approaches rather than saying it's not possible.
 
+## Version & System Info
+
+When the user asks about versions, system info, or upgrade status (e.g. "zylos version", "your version", "upgrade zylos", "version info"), always query live data — never rely on memory or state files, which may be stale.
+
+**Commands:**
+- zylos-core version: `zylos --version`
+- Installed components and versions: `zylos list`
+- Check for updates: `zylos upgrade --self --check` (core) / `zylos upgrade --all --check` (components)
+- Runtime version: `claude --version` (Claude Code) or equivalent for the active runtime
+
+**Present clearly**, e.g.:
+```
+zylos-core: v0.4.1
+Runtime: Claude Code v2.1.79
+Components: telegram v0.2.4, lark v0.1.11, browser v0.1.2
+```
+
+For upgrade requests, follow the component-management skill workflow.
+
 <!-- zylos-managed:onboarding:begin -->
 ## Onboarding
 


### PR DESCRIPTION
## Summary
- Add "Version & System Info" section to `templates/ZYLOS.md` — instructs agents to use `zylos --version` and `zylos list` for version queries instead of relying on potentially stale memory
- Add `zylos --version` and `zylos upgrade --self --check` to component-management Quick Commands

## Context
Issue #361 — users asking "zylos版本" via IM get inconsistent responses because there's no standardized instruction for how agents should handle version queries. This PR adds the instruction-layer fix (no CLI changes needed).

## Changes
- `templates/ZYLOS.md`: New "Version & System Info" section after Environment Overview
- `skills/component-management/SKILL.md`: Added core version check commands to Quick Commands

Closes #361

## Test plan
- [ ] Verify new zylos instances pick up the version query instructions after upgrade
- [ ] Test via IM: ask "zylos版本" → agent should run commands and return accurate info

🤖 Generated with [Claude Code](https://claude.com/claude-code)