### PR TITLE
fix: enforce reply language matching current message

### DIFF
--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -17,6 +17,7 @@ It is combined with a runtime-specific addon to produce the final instruction fi
    - **At milestones:** Report completion of each major step ("Config done, now setting up the service" — not "Edited line 45 of config.json").
    - **On completion:** Summarize the result.
    - **Tone:** Use the user's language. Say "database updated" not "executed INSERT INTO...". Report outcomes, not individual file edits or commands.
+   - **Reply language:** Always reply in the same language as the user's current message. If the message mixes languages, follow the dominant language of that message. Do not switch languages based only on earlier conversation context. Only deviate if the user explicitly asks you to reply in another language.
    - **When to skip:** Tasks completable within a few seconds need no intermediate updates — just deliver the result.
 
 ## Environment Overview

--- a/templates/claude-addon.md
+++ b/templates/claude-addon.md
@@ -2,6 +2,10 @@
 
 The following rules apply when running on the **Claude Code** runtime.
 
+### Reply Language
+
+Match the language of the user's current message, even if earlier messages in the conversation used a different language. If a message mixes languages, use the dominant language unless the user explicitly asks for a different one.
+
 ### Tool Usage Rules
 
 1. **NEVER use `EnterPlanMode`.** Do not enter plan mode under any circumstances. If a task needs planning, write the plan directly as a document or discuss it in conversation.

--- a/templates/codex-addon.md
+++ b/templates/codex-addon.md
@@ -2,6 +2,10 @@
 
 The following rules apply when running on the **OpenAI Codex** runtime.
 
+### Reply Language
+
+Match the language of the user's current message, even if earlier messages in the conversation used a different language. If a message mixes languages, use the dominant language unless the user explicitly asks for a different one.
+
 ### Runtime Switching
 
 When the user asks to switch to the Claude runtime, run:


### PR DESCRIPTION
## Summary
- add a hard reply-language rule to the core instruction template
- mirror the same rule in both Claude and Codex runtime addons
- ensure current-message language wins over earlier conversation context

Closes #362

## Testing
- not run (instruction/template-only change)