### PR TITLE
docs: add OpenClaw ecosystem compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ Zylos is fully compatible with the [OpenClaw](https://github.com/openclaw/opencl
 | Context compression | Auto memory save + infinite context | ✅ Available |
 | Browser automation | [zylos-browser](https://github.com/zylos-ai/zylos-browser) | ✅ Available |
 | Cron / webhooks | Scheduler (cron, NL input, idle-gating) | ✅ Available |
-| Voice pipeline | Telegram / Lark voice transcription | ✅ Available |
 
 > **Architecture note:** OpenClaw supports multi-session routing to isolated workspaces. Zylos takes a different approach — unified session (one AI, one consciousness across all channels). This is a deliberate design choice, not a missing feature.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -301,7 +301,6 @@ Zylos 已全面兼容 [OpenClaw](https://github.com/openclaw/openclaw) 生态。
 | 上下文压缩 | 自动记忆保存 + 无限上下文 | ✅ 已有 |
 | 浏览器自动化 | [zylos-browser](https://github.com/zylos-ai/zylos-browser) | ✅ 已有 |
 | 定时任务 / Webhooks | 调度器（Cron、自然语言输入、空闲门控） | ✅ 已有 |
-| 语音管道 | Telegram / 飞书语音转文字 | ✅ 已有 |
 
 > **架构差异说明：** OpenClaw 支持多会话路由到隔离工作区。Zylos 采用不同方案——统一会话（一个 AI、一个意识、跨所有通道）。这是刻意的架构选择，而非功能缺失。
 


### PR DESCRIPTION
## Summary
- Add "OpenClaw Compatibility" section to both EN and ZH READMEs
- Add capability mapping table (Skills, multi-agent routing, session management, browser automation, cron/webhooks, voice pipeline, search)
- Add integration guides for both OpenClaw users and Zylos users
- Add compatibility mention in intro paragraph

Based on Kevin's request to announce full Claw ecosystem compatibility. Collaborated with Jinglever and Eva in HXA thread.

## Changes
- `README.md`: +41 lines (EN)
- `README.zh-CN.md`: +41 lines (ZH, symmetric)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Check all links point to correct repos
- [ ] Verify EN/ZH content is symmetric

🤖 Generated with [Claude Code](https://claude.com/claude-code)