### PR TITLE
fix: replace hardcoded Chinese rotation message with English

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -1590,7 +1590,7 @@ function init() {
           if (lastChannel) {
             try {
               execFileSync('node', [C4_SEND_PATH, lastChannel.channel, lastChannel.endpoint,
-                '上下文快满了，正在切换新 session，记忆完整保留，稍等片刻…'], { stdio: 'pipe', timeout: 15000 });
+                'Context is almost full — switching to a new session. Memory is fully preserved, back in a moment.'], { stdio: 'pipe', timeout: 15000 });
               log(`Rotation notice sent to ${lastChannel.channel}:${lastChannel.endpoint}`);
             } catch (notifyErr) {
               log(`Rotation notice failed (non-fatal): ${notifyErr.message}`);


### PR DESCRIPTION
## Summary
- Replace hardcoded Chinese context rotation notification with English
- `'上下文快满了，正在切换新 session，记忆完整保留，稍等片刻…'` → `'Context is almost full — switching to a new session. Memory is fully preserved, back in a moment.'`

zylos-core is an open-source project — infrastructure-level user-facing strings should be in English. The agent translates to the user's language before delivering via C4.

## Test plan
- [ ] Trigger context rotation → verify English message is sent
- [ ] Verify agent translates to user's language when delivering

🤖 Generated with [Claude Code](https://claude.com/claude-code)