### PR TITLE
fix: unify Codex heartbeat to use C4 control queue

### DIFF
--- a/cli/lib/heartbeat/codex-probe.js
+++ b/cli/lib/heartbeat/codex-probe.js
@@ -26,7 +26,7 @@
  *   avoiding unnecessary interruption.
  *
  * Usage:
- *   const probe = createCodexProbe({ pendingFile, tmuxSession });
+ *   const probe = createCodexProbe({ pendingFile });
  */
 
 import { execFileSync } from 'node:child_process';
@@ -42,14 +42,12 @@ const C4_CONTROL = path.join(ZYLOS_DIR, '.claude/skills/comm-bridge/scripts/c4-c
  *
  * @param {object} opts
  * @param {string}  opts.pendingFile       - Path to codex-heartbeat-pending.json
- * @param {string}  [opts.tmuxSession='codex-main']
  * @param {number}  [opts.ackDeadline=300]      - ACK deadline for normal heartbeats (seconds)
  * @param {number}  [opts.stuckAckDeadline=120] - ACK deadline for stuck-phase heartbeats
  * @returns {object} Partial HeartbeatEngine deps
  */
 export function createCodexProbe({
   pendingFile,
-  tmuxSession = 'codex-main',
   ackDeadline = 300,
   stuckAckDeadline = 120,
 }) {

--- a/templates/codex-addon.md
+++ b/templates/codex-addon.md
@@ -67,11 +67,11 @@ You are running with `--dangerously-bypass-approvals-and-sandbox` (all Codex-int
 
 ### Heartbeat
 
-When you receive a message containing `Heartbeat check`, respond with a short acknowledgment:
+When you receive a message containing `Heartbeat check`, acknowledge it immediately by running the ack command:
+```bash
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js ack --id <id>
 ```
-ok
-```
-Include the `ack via:` command if present in the message.
+The `ack via:` path and ID are included in the message.
 
 ### Memory Sync
 


### PR DESCRIPTION
## Summary
- Replace tmux stdin injection + dual-signal passive probe with C4 control queue delivery
- Codex heartbeat now uses the same architecture as Claude: `c4-control enqueue` → `c4-dispatcher` → tmux delivery → Codex ack
- With hooks (Codex >= 0.116.0): dispatcher auto-acks when busy via `api-activity.json`
- Without hooks: heartbeat delivered every time, Codex acks explicitly — still reliable
- Eliminates kill-restart loops caused by `rollout_path` null after activity-monitor restart
- Net: -163 lines removed, +60 added (codex-probe.js now mirrors claude-probe.js)

## Root Cause (what this fixes)
1. **Kill-restart loop**: After activity-monitor restart, `_startTime` filter → `rollout_path = null` → passive signals fail → false timeout → kill → restart → repeat
2. **User disruption**: Tmux stdin injection treated as new user prompt by Codex, disrupting conversations

## Supersedes
- Closes #375 (passive-only probe — replaced by unified C4 approach per team discussion)

## Test plan
- [ ] Deploy to Codex test environment
- [ ] Verify heartbeat flows through C4 control queue (check `control_queue` table)
- [ ] Verify Codex session receives heartbeat via c4-dispatcher and acks
- [ ] Verify no kill-restart loops during normal operation
- [ ] Verify idle Codex sessions are NOT falsely killed
- [ ] Verify dead Codex sessions ARE recovered after ack deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)