### PR TITLE
fix: disable startup fallback control for Codex runtime

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -529,9 +529,12 @@ async function startAgent() {
     log(`Guardian: Failed to start ${adapter.displayName}: ${err.message}`);
   });
 
-  // Enqueue startup prompt (fires with --available-in 3 delay — no need to
-  // wait for launch to complete before enqueueing).
-  if (!hasStartupHook()) {
+  // Enqueue startup prompt only when runtime cannot self-inject it.
+  // Codex already injects the startup trigger in runtime/codex.js launch();
+  // adding fallback control here would duplicate triggers and cause repeated
+  // autonomous "continue work" runs.
+  const needsStartupFallback = adapter.runtimeId === 'claude' && !hasStartupHook();
+  if (needsStartupFallback) {
     enqueueStartupControl();
   }
   } finally {


### PR DESCRIPTION
## Summary
- avoid enqueueing `startup fallback` control for Codex in activity-monitor
- keep fallback behavior for Claude when SessionStart hook is missing
- document why Codex must skip fallback (Codex runtime already injects startup trigger in launch)

## Root Cause
Codex launch path already injects the active startup trigger (`reply to your human partner...`).
activity-monitor also enqueued the same fallback control for non-Claude runtimes.
During frequent session rotation/restarts this duplicated trigger caused repeated autonomous task execution.

## Validation
- `node --check skills/activity-monitor/scripts/activity-monitor.js`
- hotfix applied on running machine and activity-monitor restarted
- verified recent `control_queue` entries after restart only contain heartbeat controls, no new startup fallback controls
