### PR TITLE
fix: add missing spawnSync import in CodexAdapter launch()

### DIFF
--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -15,7 +15,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execSync, execFileSync, execFile } from 'node:child_process';
+import { execSync, execFileSync, execFile, spawnSync } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);


### PR DESCRIPTION
## Summary

- `launch()` calls `spawnSync()` to run `session-start-inject.js` and `c4-session-init.js` when building the initial Codex prompt
- `spawnSync` was not included in the `child_process` import statement, causing a `ReferenceError` at runtime on every Codex launch attempt
- One-line fix: add `spawnSync` to the named imports on line 18

## Root Cause

The function was added to `launch()` but the import line was not updated to include it.

## Test plan

- [x] Codex E2E test: 26/26 passing (checkAuth → buildInstructionFile → launch → isRunning → heartbeat → stop)
- [x] Verified fix in global npm install (v0.4.2 patched) — applied same fix to source

🤖 Generated with [Claude Code](https://claude.com/claude-code)