### PR TITLE
fix(activity-monitor): align startup control prompt with bootstrap context

### DIFF
--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -426,14 +426,14 @@ function hasStartupHook() {
 }
 
 function enqueueStartupControl() {
-  const content = 'reply to your human partner if they are waiting your reply, and continue your work if you have ongoing task according to the previous conversations.';
+  const content = 'reply to your human partner if they are waiting for your reply, then continue your ongoing tasks using the startup memory and C4 context already injected in this session, and do not query c4.db for recent conversations unless explicitly required.';
   const result = runC4Control([
     'enqueue',
     '--content', content,
     '--priority', '3',
     '--require-idle',
     '--available-in', '3',
-    '--ack-deadline', '600'
+    '--no-ack-suffix'
   ]);
   if (result.ok) {
     const match = result.output.match(/control\s+(\d+)/i);

--- a/skills/activity-monitor/scripts/session-start-prompt.js
+++ b/skills/activity-monitor/scripts/session-start-prompt.js
@@ -37,8 +37,9 @@ async function logHookTimingSafe(name, durationMs) {
 }
 
 const prompt = [
-  'reply to your human partner if they are waiting your reply,',
-  'and continue your work if you have ongoing task according to the previous conversations.'
+  'reply to your human partner if they are waiting for your reply,',
+  'then continue your ongoing tasks using the startup memory and C4 context already injected in this session,',
+  'and do not query c4.db for recent conversations unless explicitly required.'
 ].join(' ');
 
 async function main() {
@@ -47,7 +48,7 @@ async function main() {
       C4_CONTROL, 'enqueue',
       '--content', prompt,
       '--priority', '2',
-      '--ack-deadline', '120'
+      '--no-ack-suffix'
     ], { stdio: 'pipe' });
   } catch {
     // Silently fail — session still starts even if enqueue fails


### PR DESCRIPTION
## Summary
- update startup control prompt text to use injected startup memory/C4 context
- explicitly instruct to avoid querying c4.db recent conversations unless required
- remove ack suffix from startup control enqueue (`--no-ack-suffix`) in both hook and fallback paths

## Files
- skills/activity-monitor/scripts/session-start-prompt.js
- skills/activity-monitor/scripts/activity-monitor.js

## Validation
- node --check skills/activity-monitor/scripts/session-start-prompt.js
- node --check skills/activity-monitor/scripts/activity-monitor.js