### PR TITLE
fix(heartbeat): use normal control priority

### DIFF
--- a/cli/lib/heartbeat/claude-probe.js
+++ b/cli/lib/heartbeat/claude-probe.js
@@ -74,7 +74,7 @@ export function createClaudeProbe({
       try {
         const out = execFileSync('node', [C4_CONTROL, 'enqueue',
           '--content', 'Heartbeat check.',
-          '--priority', '0',
+          '--priority', '3',
           '--bypass-state',
           '--ack-deadline', String(deadline),
         ], { encoding: 'utf8', stdio: 'pipe', timeout: 15_000 });

--- a/cli/lib/heartbeat/codex-probe.js
+++ b/cli/lib/heartbeat/codex-probe.js
@@ -65,7 +65,7 @@ export function createCodexProbe({
       try {
         const out = execFileSync('node', [C4_CONTROL, 'enqueue',
           '--content', 'Heartbeat check.',
-          '--priority', '0',
+          '--priority', '3',
           '--bypass-state',
           '--ack-deadline', String(deadline),
         ], { encoding: 'utf8', stdio: 'pipe', timeout: 15_000 });


### PR DESCRIPTION
## Summary
- change Claude and Codex heartbeat control enqueue priority from `0` to `3`
- keep heartbeat delivery on the existing bypass-state path without using `require_idle`
- confirm Codex still inherits the shared `IDLE_THRESHOLD = 3` idle gating for normal periodic probes

## Notes
- This does not change recovery heartbeat behavior
- This does not switch heartbeat to dispatcher-level `require_idle`
