### PR TITLE
feat(c4): rename external require-idle flag

### DIFF
--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -1107,7 +1107,7 @@ async function upgradeSelfCore({ providedTempDir, branch, beta = false, mode = '
           if (activeRuntime === 'claude') {
             const c4ControlPath = path.join(ZYLOS_DIR, '.claude', 'skills', 'comm-bridge', 'scripts', 'c4-control.js');
             const { spawnSync } = await import('child_process');
-            spawnSync('node', [c4ControlPath, 'enqueue', '--content', '/exit', '--priority', '1', '--require-idle'], { stdio: 'pipe' });
+            spawnSync('node', [c4ControlPath, 'enqueue', '--content', '/exit', '--priority', '1', '--block-queue-until-idle'], { stdio: 'pipe' });
           }
         } catch { /* non-fatal */ }
       }

--- a/skills/activity-monitor/SKILL.md
+++ b/skills/activity-monitor/SKILL.md
@@ -169,7 +169,7 @@ Event-driven context monitoring via Claude Code's statusLine feature, replacing 
   - **Early memory sync** at `64%` (80% of 80%): Enqueues a prompt for Claude to run memory sync as a background task, so it completes well before the session switch. Priority 2, 10-minute cooldown.
   - **New-session handoff** at `80%`: Enqueues the new-session trigger. Priority 1, 5-minute cooldown.
 - **Delivery**: Enqueues via C4 control queue with bypass_state — ensures the trigger reaches Claude even during long tasks
-- **Two-stage design**: The trigger message instructs Claude to start the new-session handoff flow; the actual `/clear` is gated by require-idle in the new-session skill's final step
+- **Two-stage design**: The trigger message instructs Claude to start the new-session handoff flow; the actual `/clear` is gated by block-queue-until-idle in the new-session skill's final step
 - **Log**: `~/zylos/activity-monitor/context-monitor.log`
 
 The early memory sync decouples memory sync from the session switch. Memory sync is also triggered by the new session's startup hook if unsummarized conversations exceed the threshold, so data is never lost.

--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -472,7 +472,7 @@ function enqueueStartupControl() {
     'enqueue',
     '--content', content,
     '--priority', '3',
-    '--require-idle',
+    '--block-queue-until-idle',
     '--available-in', '3',
     '--no-ack-suffix'
   ]);
@@ -1107,7 +1107,7 @@ function sendUsageNotification(message) {
     'enqueue',
     '--content', content,
     '--priority', '1',
-    '--require-idle',
+    '--block-queue-until-idle',
     '--available-in', '5',
     '--no-ack-suffix'
   ]);

--- a/skills/comm-bridge/init-db.sql
+++ b/skills/comm-bridge/init-db.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS conversations (
     content TEXT NOT NULL,          -- message content (large messages: preview + file path)
     status TEXT DEFAULT 'pending',  -- 'pending' | 'delivered' | 'failed' (for direction='in' queue)
     priority INTEGER DEFAULT 3,     -- 1=urgent, 2=high, 3=normal
-    require_idle INTEGER DEFAULT 0, -- 1=wait for Claude idle state, 0=deliver immediately
+    require_idle INTEGER DEFAULT 0, -- legacy/internal name for block_queue_until_idle behavior
     retry_count INTEGER DEFAULT 0   -- delivery retries for incoming queue
 );
 
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS control_queue (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     content TEXT NOT NULL,
     priority INTEGER DEFAULT 3,
-    require_idle INTEGER DEFAULT 0,
+    require_idle INTEGER DEFAULT 0, -- legacy/internal name for block_queue_until_idle behavior
     bypass_state INTEGER DEFAULT 0,
     ack_deadline_at INTEGER,
     status TEXT DEFAULT 'pending',

--- a/skills/comm-bridge/references/c4-control.md
+++ b/skills/comm-bridge/references/c4-control.md
@@ -17,14 +17,14 @@ Control messages are stored in the `control_queue` table in `~/zylos/comm-bridge
 Insert a new control message into the queue.
 
 ```bash
-c4-control.js enqueue --content "<text>" [--priority 3] [--require-idle] [--bypass-state] [--ack-deadline <seconds>] [--available-in <seconds>] [--no-ack-suffix]
+c4-control.js enqueue --content "<text>" [--priority 3] [--block-queue-until-idle] [--bypass-state] [--ack-deadline <seconds>] [--available-in <seconds>] [--no-ack-suffix]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--content <text>` | Instruction content (required) |
 | `--priority <n>` | Priority level (see Priority Levels below, default: 3 = normal) |
-| `--require-idle` | Only deliver when Claude is idle |
+| `--block-queue-until-idle` | Wait for sustained idle, then block later dispatch until execution settles |
 | `--bypass-state` | Deliver regardless of current state |
 | `--ack-deadline <seconds>` | Seconds from now until the control times out if unacknowledged |
 | `--available-in <seconds>` | Delay before the control becomes eligible for delivery |
@@ -132,10 +132,10 @@ pending ──► timeout  (ack deadline exceeded)
 # Delayed maintenance command (available in 60s, idle-only)
 ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js \
     enqueue --content "Run log rotation" \
-    --require-idle --available-in 60
+    --block-queue-until-idle --available-in 60
 
 # Enqueue clean slash command (no ack suffix)
 ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js \
     enqueue --content "/clear" \
-    --priority 1 --require-idle --no-ack-suffix
+    --priority 1 --block-queue-until-idle --no-ack-suffix
 ```

--- a/skills/comm-bridge/references/c4-receive.md
+++ b/skills/comm-bridge/references/c4-receive.md
@@ -20,7 +20,7 @@ Messages are written to DB with `status='pending'`. The c4-dispatcher daemon han
 | `--content <text>` | Message content (required) |
 | `--priority <1-3>` | Priority level (default: 3) |
 | `--no-reply` | Omit `reply via` suffix; defaults channel to `system` |
-| `--require-idle` | Only deliver when Claude is idle |
+| `--block-queue-until-idle` | Wait for sustained idle, then block later dispatch until execution settles |
 | `--json` | Output structured JSON instead of plain text |
 
 ## Priority Levels
@@ -46,7 +46,7 @@ Messages are written to DB with `status='pending'`. The c4-dispatcher daemon han
 
 # Idle-only delivery
 ~/zylos/.claude/skills/comm-bridge/scripts/c4-receive.js \
-    --channel scheduler --require-idle \
+    --channel scheduler --block-queue-until-idle \
     --content 'Run daily report'
 
 # Lark topic (endpoint with multiple parts)

--- a/skills/comm-bridge/scripts/__tests__/c4-control-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-control-cli.test.js
@@ -80,7 +80,17 @@ describe('c4-control enqueue', () => {
     });
   });
 
-  it('enqueue with --require-idle', () => {
+  it('enqueue with --block-queue-until-idle', () => {
+    withTmpDir(({ env }) => {
+      const { stdout, status } = cliRaw(
+        ['enqueue', '--content', 'idle test', '--block-queue-until-idle'], env
+      );
+      assert.equal(status, 0);
+      assert.match(stdout, /OK: enqueued control \d+/);
+    });
+  });
+
+  it('enqueue still accepts legacy --require-idle', () => {
     withTmpDir(({ env }) => {
       const { stdout, status } = cliRaw(
         ['enqueue', '--content', 'idle test', '--require-idle'], env

--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -101,6 +101,34 @@ describe('c4-receive basic intake', () => {
       assert.equal(row.channel, 'test-channel');
     });
   });
+
+  it('accepts --block-queue-until-idle', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      const r = cliRaw(['--no-reply', '--json', '--block-queue-until-idle', '--content', 'idle flag'], env);
+      assert.equal(r.status, 0);
+      const out = parseJsonStdout(r.stdout);
+
+      const db = openDb(tmpDir);
+      const row = db.prepare('SELECT require_idle FROM conversations WHERE id = ?').get(Number(out.id));
+      db.close();
+
+      assert.equal(row.require_idle, 1);
+    });
+  });
+
+  it('still accepts legacy --require-idle', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      const r = cliRaw(['--no-reply', '--json', '--require-idle', '--content', 'legacy idle flag'], env);
+      assert.equal(r.status, 0);
+      const out = parseJsonStdout(r.stdout);
+
+      const db = openDb(tmpDir);
+      const row = db.prepare('SELECT require_idle FROM conversations WHERE id = ?').get(Number(out.id));
+      db.close();
+
+      assert.equal(row.require_idle, 1);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/skills/comm-bridge/scripts/c4-config.js
+++ b/skills/comm-bridge/scripts/c4-config.js
@@ -18,9 +18,11 @@ export const CONTROL_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 export const ENTER_VERIFY_MAX_RETRIES = 3;
 export const ENTER_VERIFY_WAIT_MS = 500;
 
-// For require_idle messages: minimum sustained idle seconds before delivery.
+// For legacy require_idle / external block_queue_until_idle messages:
+// minimum sustained idle seconds before delivery.
 export const REQUIRE_IDLE_MIN_SECONDS = 3;
-// For require_idle messages: allow execution time before dispatching the next message.
+// For legacy require_idle / external block_queue_until_idle messages:
+// allow execution time before dispatching the next message.
 export const REQUIRE_IDLE_POST_SEND_HOLD_MS = 5000;
 export const REQUIRE_IDLE_EXECUTION_MAX_WAIT_MS = 120000;
 export const REQUIRE_IDLE_EXECUTION_POLL_MS = 1000;

--- a/skills/comm-bridge/scripts/c4-control.js
+++ b/skills/comm-bridge/scripts/c4-control.js
@@ -3,7 +3,7 @@
  * C4 Communication Bridge - Control Queue Interface
  *
  * Commands:
- *   enqueue --content "<text>" [--priority 3] [--require-idle] [--bypass-state] [--ack-deadline <seconds>] [--available-in <seconds>] [--no-ack-suffix]
+ *   enqueue --content "<text>" [--priority 3] [--block-queue-until-idle] [--bypass-state] [--ack-deadline <seconds>] [--available-in <seconds>] [--no-ack-suffix]
  *   get --id <control_id>
  *   ack --id <control_id>
  */
@@ -18,7 +18,8 @@ import {
 
 function usage() {
   console.error('Usage: c4-control.js <enqueue|get|ack> [options]');
-  console.error('  enqueue --content "<text>" [--priority 3] [--require-idle] [--bypass-state] [--ack-deadline <seconds>] [--available-in <seconds>] [--no-ack-suffix]');
+  console.error('  enqueue --content "<text>" [--priority 3] [--block-queue-until-idle] [--bypass-state] [--ack-deadline <seconds>] [--available-in <seconds>] [--no-ack-suffix]');
+  console.error('           Legacy alias: --require-idle');
   console.error('  get --id <control_id>');
   console.error('  ack --id <control_id>');
 }
@@ -88,10 +89,11 @@ function handleEnqueue(args) {
   const now = nowSeconds();
   const ackDeadlineAt = ackDeadlineSeconds !== null ? now + ackDeadlineSeconds : null;
   const availableAt = availableInSeconds !== null ? now + availableInSeconds : null;
+  const requireIdle = hasFlag(args, '--block-queue-until-idle') || hasFlag(args, '--require-idle');
 
   const record = insertControl(content, {
     priority: priority ?? 3,
-    requireIdle: hasFlag(args, '--require-idle'),
+    requireIdle,
     bypassState: hasFlag(args, '--bypass-state'),
     appendAckSuffix: !hasFlag(args, '--no-ack-suffix'),
     ackDeadlineAt,

--- a/skills/comm-bridge/scripts/c4-dispatcher.js
+++ b/skills/comm-bridge/scripts/c4-dispatcher.js
@@ -426,17 +426,17 @@ async function handleControlDeliveryFailure(control, reason) {
 }
 
 async function waitForRequireIdleSettlement(msgId) {
-  log(`require_idle item id=${msgId}: hold ${REQUIRE_IDLE_POST_SEND_HOLD_MS}ms before next dispatch`);
+  log(`block_queue_until_idle item id=${msgId}: hold ${REQUIRE_IDLE_POST_SEND_HOLD_MS}ms before next dispatch`);
   await sleep(REQUIRE_IDLE_POST_SEND_HOLD_MS);
 
   let state = getAgentState().state;
   if (state === 'offline' || state === 'stopped') {
-    log(`require_idle item id=${msgId}: agent state=${state}, continuing`);
+    log(`block_queue_until_idle item id=${msgId}: agent state=${state}, continuing`);
     return;
   }
 
   if (state === 'idle') {
-    log(`require_idle item id=${msgId}: agent remained idle after hold, continuing`);
+    log(`block_queue_until_idle item id=${msgId}: agent remained idle after hold, continuing`);
     return;
   }
 
@@ -445,12 +445,12 @@ async function waitForRequireIdleSettlement(msgId) {
     await sleep(REQUIRE_IDLE_EXECUTION_POLL_MS);
     state = getAgentState().state;
     if (state === 'idle' || state === 'offline' || state === 'stopped') {
-      log(`require_idle item id=${msgId}: settled with agent state=${state}`);
+      log(`block_queue_until_idle item id=${msgId}: settled with agent state=${state}`);
       return;
     }
   }
 
-  log(`require_idle item id=${msgId}: timeout after ${REQUIRE_IDLE_EXECUTION_MAX_WAIT_MS}ms, continuing`);
+  log(`block_queue_until_idle item id=${msgId}: timeout after ${REQUIRE_IDLE_EXECUTION_MAX_WAIT_MS}ms, continuing`);
 }
 
 function claimNextItem() {

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -23,11 +23,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function printUsage() {
-  console.log('Usage: node c4-receive.js --channel <channel> [--endpoint <endpoint_id>] [--priority <1-3>] [--no-reply] [--require-idle] [--json] --content "<message>"');
+  console.log('Usage: node c4-receive.js --channel <channel> [--endpoint <endpoint_id>] [--priority <1-3>] [--no-reply] [--block-queue-until-idle] [--json] --content "<message>"');
   console.log('');
   console.log('Options:');
   console.log('  --no-reply       Do not append "reply via" suffix (use for system messages)');
-  console.log('  --require-idle   Only deliver when Claude is idle');
+  console.log('  --block-queue-until-idle');
+  console.log('                   Wait for sustained idle, then block subsequent dispatch until execution settles');
+  console.log('                   Legacy alias: --require-idle');
   console.log('  --json           Output structured JSON');
   console.log('');
   console.log('Priority levels:');
@@ -62,6 +64,7 @@ function parseArgs(args) {
         result.noReply = true;
         break;
       case '--require-idle':
+      case '--block-queue-until-idle':
         result.requireIdle = true;
         break;
       case '--json':

--- a/skills/new-session/SKILL.md
+++ b/skills/new-session/SKILL.md
@@ -55,12 +55,12 @@ The goal is twofold: (a) the user knows what's happening, and (b) the handoff su
 
 For Codex:
 ```bash
-node ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js enqueue --content "/exit" --priority 1 --require-idle --no-ack-suffix
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js enqueue --content "/exit" --priority 1 --block-queue-until-idle --no-ack-suffix
 ```
 
 For Claude:
 ```bash
-node ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js enqueue --content "/clear" --priority 1 --require-idle --no-ack-suffix
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js enqueue --content "/clear" --priority 1 --block-queue-until-idle --no-ack-suffix
 ```
 
 ## How It Works

--- a/skills/restart-claude/SKILL.md
+++ b/skills/restart-claude/SKILL.md
@@ -44,12 +44,12 @@ The goal is twofold: (a) the user knows what's happening, and (b) the handoff su
 ### 5. Enqueue /exit
 
 ```bash
-node ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js enqueue --content "/exit" --priority 1 --require-idle
+node ~/zylos/.claude/skills/comm-bridge/scripts/c4-control.js enqueue --content "/exit" --priority 1 --block-queue-until-idle
 ```
 
 ## How It Works
 
-1. **Enqueue /exit**: Puts `/exit` into the control queue (priority=1, require_idle)
-2. **Block subsequent messages**: require_idle prevents other messages from being dispatched
+1. **Enqueue /exit**: Puts `/exit` into the control queue (priority=1, block_queue_until_idle)
+2. **Block subsequent messages**: block_queue_until_idle prevents other messages from being dispatched
 3. **Deliver when idle**: Dispatcher delivers `/exit` to tmux when Claude is idle
 4. **Daemon restart**: activity-monitor detects exit and restarts Claude

--- a/skills/scheduler/references/add.md
+++ b/skills/scheduler/references/add.md
@@ -25,7 +25,7 @@ Creates a new scheduled task. Exactly one timing option is required.
 |--------|-------------|---------|
 | `--priority <1-3>` | 1=urgent, 2=high, 3=normal | 3 |
 | `--name "<name>"` | Task display name | Truncated prompt |
-| `--require-idle` | Wait for Claude to be idle | off |
+| `--block-queue-until-idle` | Wait for sustained idle, then block later dispatch until execution settles | off |
 | `--miss-threshold <seconds>` | Skip if overdue by more than this | 300 |
 | `--reply-channel "<source>"` | Reply channel (e.g., "telegram", "lark") | none |
 | `--reply-endpoint "<endpoint>"` | Reply endpoint (e.g., user ID) | none |
@@ -47,7 +47,7 @@ cli.js add "Check updates" --every "2 hours"
 cli.js add "Check updates" --every "90 minutes"
 
 # Maintenance (wait for idle)
-cli.js add "Compact session" --cron "0 2 * * *" --require-idle
+cli.js add "Compact session" --cron "0 2 * * *" --block-queue-until-idle
 
 # With reply
 cli.js add "Daily report" --at "9am" --reply-channel "telegram" --reply-endpoint "8101553026"
@@ -59,7 +59,7 @@ cli.js add "Backup data" --cron "0 2 * * *" --miss-threshold 86400
 
 ## Best Practices
 
-### --require-idle
+### --block-queue-until-idle
 
 Use for: session compaction, data cleanup, health checks needing full attention.
 Don't use for: user notifications, time-sensitive tasks, high-priority alerts.

--- a/skills/scheduler/references/config.md
+++ b/skills/scheduler/references/config.md
@@ -49,7 +49,7 @@ SQLite at `~/zylos/scheduler/scheduler.db`
 | 2 | High | Important tasks, execute soon |
 | 3 | Normal | Default priority, standard execution |
 
-Priority only affects dispatch order, not idle waiting. Use `--require-idle` for idle control.
+Priority only affects dispatch order, not idle waiting. Use `--block-queue-until-idle` for this queue-blocking idle gate.
 
 ## Retry / Missed Task Behavior
 

--- a/skills/scheduler/references/update.md
+++ b/skills/scheduler/references/update.md
@@ -13,8 +13,8 @@ All `add` timing options (`--in`, `--at`, `--cron`, `--every`) plus:
 | `--name "<name>"` | Update task name |
 | `--prompt "<prompt>"` | Update task content |
 | `--priority <1-3>` | Update priority |
-| `--require-idle` | Enable idle requirement |
-| `--no-require-idle` | Disable idle requirement |
+| `--block-queue-until-idle` | Enable block-queue-until-idle behavior |
+| `--no-block-queue-until-idle` | Disable block-queue-until-idle behavior |
 | `--reply-channel "<source>"` | Update reply channel |
 | `--reply-endpoint "<endpoint>"` | Update reply endpoint |
 | `--clear-reply` | Clear reply configuration |
@@ -32,7 +32,7 @@ cli.js update task-abc --priority 1
 cli.js update task-abc --cron "0 10 * * *"
 
 # Enable idle requirement
-cli.js update task-abc --require-idle
+cli.js update task-abc --block-queue-until-idle
 
 # Update reply
 cli.js update task-abc --reply-channel "telegram" --reply-endpoint "new_id"

--- a/skills/scheduler/scripts/__tests__/cli.test.js
+++ b/skills/scheduler/scripts/__tests__/cli.test.js
@@ -110,9 +110,9 @@ describe('cli add', () => {
     });
   });
 
-  it('sets require_idle and reply fields', () => {
+  it('sets require_idle and reply fields via --block-queue-until-idle', () => {
     withTmpDir(({ dbPath, env }) => {
-      cli(['add', 'idle task', '--cron', '0 2 * * *', '--require-idle',
+      cli(['add', 'idle task', '--cron', '0 2 * * *', '--block-queue-until-idle',
            '--reply-channel', 'telegram', '--reply-endpoint', '12345'], env);
       const db = new Database(dbPath);
       try {
@@ -120,6 +120,19 @@ describe('cli add', () => {
         assert.equal(task.require_idle, 1);
         assert.equal(task.reply_channel, 'telegram');
         assert.equal(task.reply_endpoint, '12345');
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it('still accepts legacy --require-idle', () => {
+    withTmpDir(({ dbPath, env }) => {
+      cli(['add', 'legacy idle task', '--cron', '0 2 * * *', '--require-idle'], env);
+      const db = new Database(dbPath);
+      try {
+        const task = db.prepare('SELECT require_idle FROM tasks LIMIT 1').get();
+        assert.equal(task.require_idle, 1);
       } finally {
         db.close();
       }
@@ -314,6 +327,36 @@ describe('cli update', () => {
         assert.equal(updated.type, 'interval');
         assert.ok(updated.interval_seconds >= 7190 && updated.interval_seconds <= 7210);
         assert.equal(updated.cron_expression, null);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it('disables require_idle via --no-block-queue-until-idle', () => {
+    withTmpDir(({ dbPath, env }) => {
+      cli(['add', 'idle task', '--cron', '0 9 * * *', '--block-queue-until-idle'], env);
+      const db = new Database(dbPath);
+      try {
+        const task = db.prepare('SELECT id FROM tasks LIMIT 1').get();
+        cli(['update', task.id, '--no-block-queue-until-idle'], env);
+        const updated = db.prepare('SELECT require_idle FROM tasks WHERE id = ?').get(task.id);
+        assert.equal(updated.require_idle, 0);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it('still accepts legacy --no-require-idle', () => {
+    withTmpDir(({ dbPath, env }) => {
+      cli(['add', 'idle task', '--cron', '0 9 * * *', '--require-idle'], env);
+      const db = new Database(dbPath);
+      try {
+        const task = db.prepare('SELECT id FROM tasks LIMIT 1').get();
+        cli(['update', task.id, '--no-require-idle'], env);
+        const updated = db.prepare('SELECT require_idle FROM tasks WHERE id = ?').get(task.id);
+        assert.equal(updated.require_idle, 0);
       } finally {
         db.close();
       }

--- a/skills/scheduler/scripts/cli.js
+++ b/skills/scheduler/scripts/cli.js
@@ -45,14 +45,18 @@ Add Options:
   --every "<interval>"    Interval: repeat every X time (e.g., "2 hours")
   --priority <1-3>        Priority level (1=urgent, 2=high, 3=normal, default=3)
   --name "<name>"         Task name (optional)
-  --require-idle          Wait for Claude to be idle before executing
+  --block-queue-until-idle
+                          Wait for sustained idle, then block subsequent dispatch until execution settles
+                          Legacy alias: --require-idle
   --reply-channel "<source>"      Reply channel (e.g., "telegram", "lark")
   --reply-endpoint "<endpoint>"  Reply endpoint (e.g., "8101553026", "chat_id topic_id")
   --miss-threshold <seconds>  Skip if overdue by more than this (default=300)
 
 Update Options (same as Add, plus):
   --prompt "<prompt>"     Update task content
-  --no-require-idle       Disable idle requirement
+  --no-block-queue-until-idle
+                          Disable block-queue-until-idle behavior
+                          Legacy alias: --no-require-idle
   --clear-reply           Clear reply configuration
 
 Examples:
@@ -60,7 +64,7 @@ Examples:
   ~/zylos/.claude/skills/scheduler/scripts/cli.js add "Health check" --cron "0 8 * * *"
   ~/zylos/.claude/skills/scheduler/scripts/cli.js add "Check updates" --every "1 hour"
   ~/zylos/.claude/skills/scheduler/scripts/cli.js update task-abc --priority 1
-  ~/zylos/.claude/skills/scheduler/scripts/cli.js update task-abc --require-idle
+  ~/zylos/.claude/skills/scheduler/scripts/cli.js update task-abc --block-queue-until-idle
   ~/zylos/.claude/skills/scheduler/scripts/cli.js done task-abc123
 `;
 
@@ -75,6 +79,8 @@ function parseArgs(args) {
 
   // Boolean flags (no value required)
   const booleanFlags = new Set([
+    'block-queue-until-idle',
+    'no-block-queue-until-idle',
     'require-idle',
     'no-require-idle',
     'clear-reply'
@@ -198,8 +204,8 @@ function cmdAdd(args, options) {
     return;
   }
 
-  // Parse require-idle flag
-  const requireIdle = options['require-idle'] ? 1 : 0;
+  // Parse block-queue-until-idle flag (legacy alias: require-idle)
+  const requireIdle = (options['block-queue-until-idle'] || options['require-idle']) ? 1 : 0;
 
   // Parse reply-channel and reply-endpoint
   const replyChannel = options['reply-channel'] || null;
@@ -546,11 +552,11 @@ function cmdUpdate(taskId, options) {
     updatedFields.push('priority');
   }
 
-  // Update require_idle
-  if (options['require-idle']) {
+  // Update require_idle (external flag renamed to block-queue-until-idle)
+  if (options['block-queue-until-idle'] || options['require-idle']) {
     updates.require_idle = 1;
     updatedFields.push('require_idle');
-  } else if (options['no-require-idle']) {
+  } else if (options['no-block-queue-until-idle'] || options['no-require-idle']) {
     updates.require_idle = 0;
     updatedFields.push('require_idle');
   }

--- a/skills/scheduler/scripts/runtime.js
+++ b/skills/scheduler/scripts/runtime.js
@@ -57,7 +57,9 @@ function findC4ReceivePath() {
  * @param {string} message - Message to send
  * @param {object} options - Dispatch options
  * @param {number} options.priority - Message priority 1-3 (default: 3)
- * @param {boolean} options.requireIdle - Whether to wait for idle state (default: false)
+ * @param {boolean} options.blockQueueUntilIdle - Whether to wait for sustained idle
+ *   and hold subsequent dispatch until execution settles (default: false)
+ * @param {boolean} options.requireIdle - Legacy alias for blockQueueUntilIdle
  * @param {string} options.replyChannel - Reply channel (e.g., 'telegram')
  * @param {string} options.replyEndpoint - Reply endpoint (e.g., user ID)
  * @returns {boolean} True if successful
@@ -65,6 +67,7 @@ function findC4ReceivePath() {
 export function sendViaC4(message, options = {}) {
   const {
     priority = 3,
+    blockQueueUntilIdle = false,
     requireIdle = false,
     replyChannel = null,
     replyEndpoint = null
@@ -86,8 +89,8 @@ export function sendViaC4(message, options = {}) {
       args.push('--no-reply');
     }
 
-    if (requireIdle) {
-      args.push('--require-idle');
+    if (blockQueueUntilIdle || requireIdle) {
+      args.push('--block-queue-until-idle');
     }
 
     args.push('--priority', String(priority), '--content', message);

--- a/skills/upgrade-claude/SKILL.md
+++ b/skills/upgrade-claude/SKILL.md
@@ -50,7 +50,7 @@ nohup node ~/zylos/.claude/skills/upgrade-claude/scripts/upgrade.js >> ~/zylos/l
 
 ## How It Works
 
-1. **Enqueue /exit**: Puts `/exit` into the control queue (priority=1, require_idle) — dispatcher handles idle detection and message blocking
+1. **Enqueue /exit**: Puts `/exit` into the control queue (priority=1, block_queue_until_idle) — dispatcher handles idle detection and message blocking
 2. **Wait for exit**: Monitors Claude process until it exits (up to 120s); aborts if timeout
 3. **Upgrade**: Runs native installer (`curl -fsSL https://claude.ai/install.sh | bash`)
 4. **Daemon restart**: activity-monitor detects exit and restarts Claude automatically

--- a/skills/upgrade-claude/scripts/upgrade.js
+++ b/skills/upgrade-claude/scripts/upgrade.js
@@ -36,7 +36,7 @@ function enqueueExit() {
   try {
     const output = execFileSync(
       'node',
-      [C4_CONTROL, 'enqueue', '--content', '/exit', '--priority', '1', '--require-idle', '--no-ack-suffix'],
+      [C4_CONTROL, 'enqueue', '--content', '/exit', '--priority', '1', '--block-queue-until-idle', '--no-ack-suffix'],
       { encoding: 'utf8', stdio: 'pipe' }
     );
     const match = output.match(/control\s+(\d+)/);


### PR DESCRIPTION
## Summary
- rename the external queue-blocking flag from `require-idle` / `require_idle` to `block-queue-until-idle` / `block_queue_until_idle`
- keep legacy CLI aliases and internal DB column names for backward compatibility
- update docs and add coverage for new and legacy spellings across control, receive, and scheduler paths

## Testing
- `node --test skills/comm-bridge/scripts/__tests__/c4-control-cli.test.js`
- `node --test skills/comm-bridge/scripts/__tests__/c4-receive.test.js`
- `node --test skills/scheduler/scripts/__tests__/cli.test.js`