### PR TITLE
fix(upgrade): handle symlinked skills root in backups

### DIFF
--- a/cli/lib/__tests__/fs-utils.test.js
+++ b/cli/lib/__tests__/fs-utils.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+const tmpDirs = [];
+
+const { copyTree } = await import('../fs-utils.js');
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function makeTmpDir() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-fs-utils-test-'));
+  tmpDirs.push(tmpDir);
+  return tmpDir;
+}
+
+describe('copyTree', () => {
+  it('backs up a symlink root without precreating dest as a directory', () => {
+    const tmpDir = makeTmpDir();
+    const realSkillsDir = path.join(tmpDir, 'real-skills');
+    const symlinkSkillsDir = path.join(tmpDir, 'skills');
+    const backupTarget = path.join(tmpDir, 'backup', 'skills');
+
+    fs.mkdirSync(realSkillsDir, { recursive: true });
+    fs.writeFileSync(path.join(realSkillsDir, 'manifest.json'), '{}', 'utf8');
+    fs.symlinkSync(realSkillsDir, symlinkSkillsDir);
+
+    copyTree(symlinkSkillsDir, backupTarget, { excludes: ['node_modules'] });
+
+    const stat = fs.lstatSync(backupTarget);
+    assert.equal(stat.isSymbolicLink(), true);
+    assert.equal(fs.readlinkSync(backupTarget), realSkillsDir);
+  });
+});

--- a/cli/lib/fs-utils.js
+++ b/cli/lib/fs-utils.js
@@ -50,7 +50,9 @@ function cpSyncFiltered(src, dest, excludes) {
  * @param {string[]} [opts.excludes=[]] - Top-level names to exclude
  */
 export function copyTree(src, dest, { excludes = [] } = {}) {
-  fs.mkdirSync(dest, { recursive: true });
+  const srcStat = fs.lstatSync(src);
+  const destParent = srcStat.isSymbolicLink() ? path.dirname(dest) : dest;
+  fs.mkdirSync(destParent, { recursive: true });
 
   const resolvedSrc = path.resolve(src);
   const resolvedDest = path.resolve(dest);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "node scripts/postinstall.js || true",
     "test": "npm run test:jest && npm run test:node",
     "test:jest": "node --experimental-vm-modules node_modules/.bin/jest",
-    "test:node": "node --test cli/lib/__tests__/codex.test.js cli/lib/__tests__/runtime-setup.test.js cli/lib/__tests__/self-upgrade.test.js"
+    "test:node": "node --test cli/lib/__tests__/codex.test.js cli/lib/__tests__/fs-utils.test.js cli/lib/__tests__/runtime-setup.test.js cli/lib/__tests__/self-upgrade.test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- fix `copyTree` so symlink roots create only the parent destination directory before copy
- cover the regression with a focused `copyTree` test for symlink-root backups
- include the new regression test in the root `test:node` target set

## Testing
- npm test
- reproduced the original `EEXIST` failure shape with a symlinked `skills` root, then verified the patched copy succeeds
