### PR TITLE
fix(codex): backfill config via installed sync script

### DIFF
--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const {
+  shouldSyncCodexConfig,
+  syncCodexConfig,
+} = await import('../sync-settings-hooks.js');
+
+describe('shouldSyncCodexConfig', () => {
+  it('skips when runtime is not codex and no codex state exists', () => {
+    const result = shouldSyncCodexConfig({
+      cfg: { runtime: 'claude' },
+      homeDir: '/tmp/no-codex',
+      existsSync: () => false,
+    });
+
+    assert.equal(result.shouldSync, false);
+  });
+});
+
+describe('syncCodexConfig', () => {
+  it('refreshes stale codex config when codex state exists outside codex runtime', () => {
+    const writes = [];
+    const logs = [];
+    const configPath = '/tmp/home/.codex/config.toml';
+
+    const result = syncCodexConfig({
+      cfg: { runtime: 'claude' },
+      homeDir: '/tmp/home',
+      projectDir: '/tmp/zylos',
+      existsSync: (filePath) => filePath === configPath,
+      readFileSync: () => 'model = "gpt-5.3-codex"\n',
+      renderConfig: () => 'model = "gpt-5.3-codex"\n[features]\nmulti_agent = true\n',
+      writeConfig: (projectDir) => {
+        writes.push(projectDir);
+        return true;
+      },
+      log: (line) => logs.push(line),
+    });
+
+    assert.equal(result.changed, true);
+    assert.deepEqual(writes, ['/tmp/zylos']);
+    assert.ok(logs.some(line => line.includes('codex config')));
+  });
+
+  it('treats refresh failures as fatal only in codex runtime', () => {
+    const result = syncCodexConfig({
+      cfg: { runtime: 'codex' },
+      homeDir: '/tmp/home',
+      projectDir: '/tmp/zylos',
+      existsSync: () => true,
+      readFileSync: () => 'model = "gpt-5.3-codex"\n',
+      renderConfig: () => 'model = "gpt-5.3-codex"\n[features]\nmulti_agent = true\n',
+      writeConfig: () => false,
+      log: () => {},
+    });
+
+    assert.equal(result.fatal, true);
+    assert.match(result.error, /Failed to refresh/);
+  });
+});

--- a/cli/lib/runtime-setup.js
+++ b/cli/lib/runtime-setup.js
@@ -235,6 +235,65 @@ export function saveSetupTokenToEnv(token) {
 // ── Codex credential helpers ───────────────────────────────────────────────
 
 /**
+ * Render ~/.codex/config.toml with the required headless configuration.
+ *
+ * Existing [projects.*] trust entries in the file are preserved; top-level
+ * settings and the zylos project trust entry are always regenerated.
+ *
+ * @param {string} projectDir - The zylos working directory to pre-trust
+ * @param {string} existingContent - Existing config.toml contents (optional)
+ * @returns {string}
+ */
+export function renderCodexConfig(projectDir, existingContent = '') {
+  const absProject = path.resolve(projectDir);
+
+  let preservedProjects = '';
+  const projectMatches = existingContent.match(/^\[projects\.[^\]]+\][^\[]+/gm);
+  if (projectMatches) {
+    const toKeep = projectMatches.filter(
+      (s) => !s.includes(`"${absProject}"`) && !s.includes(`'${absProject}'`)
+    );
+    if (toKeep.length) preservedProjects = '\n' + toKeep.join('\n').trimEnd() + '\n';
+  }
+
+  const config = [
+    '# Codex headless config — written by zylos, do not edit manually.',
+    '# Re-generated on each `zylos init` / `zylos runtime codex`.',
+    '',
+    '# Disable startup checks and telemetry',
+    'check_for_update_on_startup = false',
+    '# analytics: Codex v0.114.0 expects a struct here, not a boolean.',
+    '# Omitting this field leaves analytics at default (no crash on startup).',
+    '',
+    '# Acknowledge the latest model NUX so the "Introducing GPT-X" dialog',
+    '# is not shown on startup.  Update this when Codex ships a new default model.',
+    'model_availability_nux = "gpt-5.4"',
+    '',
+    '# Enable Codex features required by Zylos runtime workflows.',
+    '[features]',
+    'multi_agent = true',
+    '',
+    '# Suppress all known interactive notice dialogs',
+    '[notice]',
+    'hide_full_access_warning = true',
+    'hide_world_writable_warning = true',
+    'hide_rate_limit_model_nudge = true',
+    'hide_gpt5_1_migration_prompt = true',
+    '"hide_gpt-5.1-codex-max_migration_prompt" = true',
+    '',
+    '# Acknowledge known model migrations so no migration prompt appears',
+    '[notice.model_migrations]',
+    '"gpt-5.3-codex" = "gpt-5.4"',
+    '',
+    '# Trust the zylos project directory',
+    `[projects."${absProject}"]`,
+    'trust_level = "trusted"',
+  ].join('\n') + '\n';
+
+  return config + preservedProjects;
+}
+
+/**
  * Write ~/.codex/config.toml with a comprehensive headless configuration that
  * suppresses all known interactive prompts (trust dialogs, model upgrade notices,
  * update checks, telemetry prompts, etc.).
@@ -242,69 +301,20 @@ export function saveSetupTokenToEnv(token) {
  * Called by both `zylos init` (Codex runtime) and `zylos runtime codex` so the
  * config is always present when switching to Codex.
  *
- * Existing [projects.*] trust entries in the file are preserved; top-level settings
- * and [notice] section are always written/overwritten for freshness.
- *
  * @param {string} projectDir - The zylos working directory to pre-trust
  * @returns {boolean} true on success
  */
 export function writeCodexConfig(projectDir) {
   const codexDir = path.join(os.homedir(), '.codex');
   const configPath = path.join(codexDir, 'config.toml');
-  const absProject = path.resolve(projectDir);
   try {
-    // Preserve existing [projects.*] sections (other directories may already be trusted).
-    let preservedProjects = '';
+    let existing = '';
     try {
-      const existing = fs.readFileSync(configPath, 'utf8');
-      const projectMatches = existing.match(/^\[projects\.[^\]]+\][^\[]+/gm);
-      if (projectMatches) {
-        // Keep sections that are NOT the one we're about to write.
-        const toKeep = projectMatches.filter(
-          (s) => !s.includes(`"${absProject}"`) && !s.includes(`'${absProject}'`)
-        );
-        if (toKeep.length) preservedProjects = '\n' + toKeep.join('\n').trimEnd() + '\n';
-      }
+      existing = fs.readFileSync(configPath, 'utf8');
     } catch { /* new file — nothing to preserve */ }
 
-    // Build the complete headless config.
-    // All fields are verified against the installed Codex binary (v0.114.0).
-    const config = [
-      '# Codex headless config — written by zylos, do not edit manually.',
-      '# Re-generated on each `zylos init` / `zylos runtime codex`.',
-      '',
-      '# Disable startup checks and telemetry',
-      'check_for_update_on_startup = false',
-      '# analytics: Codex v0.114.0 expects a struct here, not a boolean.',
-      '# Omitting this field leaves analytics at default (no crash on startup).',
-      '',
-      '# Acknowledge the latest model NUX so the "Introducing GPT-X" dialog',
-      '# is not shown on startup.  Update this when Codex ships a new default model.',
-      'model_availability_nux = "gpt-5.4"',
-      '',
-      '# Enable Codex features required by Zylos runtime workflows.',
-      '[features]',
-      'multi_agent = true',
-      '',
-      '# Suppress all known interactive notice dialogs',
-      '[notice]',
-      'hide_full_access_warning = true',
-      'hide_world_writable_warning = true',
-      'hide_rate_limit_model_nudge = true',
-      'hide_gpt5_1_migration_prompt = true',
-      '"hide_gpt-5.1-codex-max_migration_prompt" = true',
-      '',
-      '# Acknowledge known model migrations so no migration prompt appears',
-      '[notice.model_migrations]',
-      '"gpt-5.3-codex" = "gpt-5.4"',
-      '',
-      `# Trust the zylos project directory`,
-      `[projects."${absProject}"]`,
-      'trust_level = "trusted"',
-    ].join('\n') + '\n';
-
     fs.mkdirSync(codexDir, { recursive: true });
-    fs.writeFileSync(configPath, config + preservedProjects, 'utf8');
+    fs.writeFileSync(configPath, renderCodexConfig(projectDir, existing), 'utf8');
     return true;
   } catch {
     return false;

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -997,11 +997,13 @@ function step8_migrateStateMd() {
 }
 
 /**
- * Step 9: sync settings.json hooks from template.
+ * Step 9: sync settings.json hooks from template and refresh upgrade-safe
+ * config backfills via the newly installed package.
  *
  * Shells out to the NEWLY INSTALLED sync-settings-hooks.js instead of using
  * the in-memory generateMigrationHints(). This avoids bootstrap problems where
- * the old version's sync logic misses new config fields (e.g. statusLine).
+ * the old version's sync logic misses new config fields or backfills
+ * (e.g. statusLine, Codex config refreshes).
  */
 function step9_syncSettingsHooks(ctx) {
   const startTime = Date.now();

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -21,14 +21,79 @@ import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
 import { extractScriptPath, extractSkillName, getCommandHooks } from './hook-utils.js';
+import { getZylosConfig } from './config.js';
+import { renderCodexConfig, writeCodexConfig } from './runtime-setup.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ZYLOS_DIR = path.resolve(process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
 const TEMPLATE_SETTINGS = path.join(__dirname, '..', '..', 'templates', '.claude', 'settings.json');
 const INSTALLED_SETTINGS = path.join(ZYLOS_DIR, '.claude', 'settings.json');
 
-function main() {
-  const dryRun = process.argv.includes('--dry-run');
+export function shouldSyncCodexConfig({
+  cfg = getZylosConfig(),
+  homeDir = os.homedir(),
+  existsSync = fs.existsSync,
+} = {}) {
+  const codexDir = path.join(homeDir, '.codex');
+  const configPath = path.join(codexDir, 'config.toml');
+  const hasCodexState = existsSync(configPath) || existsSync(path.join(codexDir, 'auth.json'));
+  return {
+    cfg,
+    configPath,
+    shouldSync: cfg.runtime === 'codex' || hasCodexState,
+  };
+}
+
+export function syncCodexConfig({
+  dryRun = false,
+  cfg = getZylosConfig(),
+  projectDir = ZYLOS_DIR,
+  homeDir = os.homedir(),
+  existsSync = fs.existsSync,
+  readFileSync = fs.readFileSync,
+  renderConfig = renderCodexConfig,
+  writeConfig = writeCodexConfig,
+  log = console.log,
+} = {}) {
+  const state = shouldSyncCodexConfig({ cfg, homeDir, existsSync });
+  if (!state.shouldSync) {
+    return { attempted: false, changed: false, fatal: false };
+  }
+
+  let existing = '';
+  try {
+    existing = readFileSync(state.configPath, 'utf8');
+  } catch {}
+
+  const desired = renderConfig(projectDir, existing);
+  if (existing === desired) {
+    return { attempted: true, changed: false, fatal: false };
+  }
+
+  if (dryRun) {
+    log(`  ~ codex config: ${state.configPath}`);
+    return { attempted: true, changed: true, fatal: false };
+  }
+
+  if (!writeConfig(projectDir)) {
+    if (cfg.runtime !== 'codex') {
+      log('  Warning: failed to refresh ~/.codex/config.toml outside codex runtime.');
+      return { attempted: true, changed: false, fatal: false, warning: true };
+    }
+    return {
+      attempted: true,
+      changed: false,
+      fatal: true,
+      error: 'Failed to refresh ~/.codex/config.toml.',
+    };
+  }
+
+  log(`  ~ codex config: ${state.configPath}`);
+  return { attempted: true, changed: true, fatal: false };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const dryRun = argv.includes('--dry-run');
 
   if (!fs.existsSync(TEMPLATE_SETTINGS)) {
     console.log('Settings hooks: template not found, skipping.');
@@ -193,13 +258,19 @@ function main() {
     console.log(`  - statusLine: (removed)`);
   }
 
-  if (added === 0 && updated === 0 && removed === 0 && !statusLineChanged) {
+  const codexSync = syncCodexConfig({ dryRun });
+  if (codexSync.fatal) {
+    console.error(codexSync.error);
+    process.exit(1);
+  }
+
+  if (added === 0 && updated === 0 && removed === 0 && !statusLineChanged && !codexSync.changed) {
     console.log('Settings hooks: all up to date (no changes).');
     return;
   }
 
   if (dryRun) {
-    console.log(`Settings hooks (dry run): ${added} to add, ${updated} to update, ${removed} to remove${statusLineChanged ? ', statusLine to update' : ''}.`);
+    console.log(`Settings hooks (dry run): ${added} to add, ${updated} to update, ${removed} to remove${statusLineChanged ? ', statusLine to update' : ''}${codexSync.changed ? ', codex config to refresh' : ''}.`);
     return;
   }
 
@@ -207,7 +278,14 @@ function main() {
   const dir = path.dirname(INSTALLED_SETTINGS);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(INSTALLED_SETTINGS, JSON.stringify(installedSettings, null, 2) + '\n');
-  console.log(`Settings hooks: ${added} added, ${updated} updated, ${removed} removed${statusLineChanged ? ', statusLine updated' : ''}.`);
+  if (added === 0 && updated === 0 && removed === 0 && !statusLineChanged) {
+    console.log(`Settings hooks: all up to date; Codex config ${codexSync.changed ? 'refreshed' : 'unchanged'}.`);
+    return;
+  }
+
+  console.log(`Settings hooks: ${added} added, ${updated} updated, ${removed} removed${statusLineChanged ? ', statusLine updated' : ''}${codexSync.changed ? ', Codex config refreshed' : ''}.`);
 }
 
-main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "node scripts/postinstall.js || true",
     "test": "npm run test:jest && npm run test:node",
     "test:jest": "node --experimental-vm-modules node_modules/.bin/jest",
-    "test:node": "node --test cli/lib/__tests__/codex.test.js cli/lib/__tests__/fs-utils.test.js cli/lib/__tests__/runtime-setup.test.js cli/lib/__tests__/self-upgrade.test.js"
+    "test:node": "node --test cli/lib/__tests__/codex.test.js cli/lib/__tests__/fs-utils.test.js cli/lib/__tests__/runtime-setup.test.js cli/lib/__tests__/self-upgrade.test.js cli/lib/__tests__/sync-settings-hooks.test.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,12 +3,13 @@
  *
  * Two responsibilities:
  * 1. Sync Core Skills (skipped during self-upgrade — step 5 handles it)
- * 2. Sync settings.json hooks/statusLine (ALWAYS runs when zylos is initialized)
+ * 2. Sync settings.json hooks/statusLine and refresh Codex config backfills
+ *    (ALWAYS runs when zylos is initialized)
  *
  * Settings sync runs even when ZYLOS_SKIP_POSTINSTALL is set because this is
  * the only reliable hook where the NEWLY INSTALLED code executes during
- * self-upgrade. The old version's step 8 may not know about new config fields
- * (e.g. statusLine added in v0.2.1), so this postinstall catches them.
+ * self-upgrade. The old version's in-memory upgrader may not know about new
+ * config fields or backfills, so this postinstall catches them.
  */
 
 import fs from 'node:fs';


### PR DESCRIPTION
## Summary
- refresh stale `~/.codex/config.toml` from `sync-settings-hooks.js`, which already runs from the newly installed package during postinstall/self-upgrade
- reuse a shared Codex config renderer so the sync script can diff the desired config before rewriting it
- add node tests covering the postinstall/self-upgrade backfill path for non-Codex runtimes with existing Codex state

## Why
Upgrading from 0.4.3 to 0.4.4 can skip the new `ensure_codex_config` step because self-upgrade keeps running inside the old in-memory upgrader after `npm install -g`. The installed `sync-settings-hooks.js` path is the compatibility seam that old versions already execute, so backfilling Codex config there fixes the missed `multi_agent = true` case.