### PR TITLE
feat: add runtime-specific base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Automatically when no TTY is available — e.g. Docker containers (without `-it`
 | `--setup-token <token>` | Claude [setup token](https://code.claude.com/docs/en/authentication) (starts with `sk-ant-oat`) | — |
 | `--api-key <key>` | Anthropic API key (starts with `sk-ant-`) | — |
 | `--codex-api-key <key>` | OpenAI API key for Codex runtime (starts with `sk-`) | — |
+| `--base-url <url>` | Custom API base URL for Claude Code | — |
+| `--codex-base-url <url>` | Custom API base URL for Codex | — |
 | `--timezone <tz>` | [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. `Asia/Shanghai`, `America/New_York`, `Europe/London` | System default |
 | `--domain <domain>` | Domain for Caddy reverse proxy, e.g. `agent.example.com` | None |
 | `--https` / `--no-https` | Enable or disable HTTPS | `--https` when domain is set |
@@ -79,14 +81,16 @@ Automatically when no TTY is available — e.g. Docker containers (without `-it`
 
 **Environment variables:**
 
-Flags can also be set via environment variables. Resolution order: CLI flag > env var > existing `.env` > interactive prompt.
+Flags can also be set via environment variables during `zylos init`. Resolution order: CLI flag > env var > existing `.env` > interactive prompt.
 
 | Environment Variable | Equivalent Flag |
 |---------------------|-----------------|
 | `ZYLOS_RUNTIME` | `--runtime` |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `--setup-token` |
 | `ANTHROPIC_API_KEY` | `--api-key` |
-| `OPENAI_API_KEY` | `--codex-api-key` (stored in `~/.codex/auth.json`, not `.env`) |
+| `ANTHROPIC_BASE_URL` | `--base-url` |
+| `OPENAI_API_KEY` | `--codex-api-key` |
+| `OPENAI_BASE_URL` | `--codex-base-url` |
 | `ZYLOS_DOMAIN` | `--domain` |
 | `ZYLOS_PROTOCOL` (`https` or `http`) | `--https` / `--no-https` |
 | `ZYLOS_WEB_PASSWORD` | `--web-password` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,6 +70,8 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 | `--setup-token <token>` | Claude [setup token](https://code.claude.com/docs/en/authentication)（以 `sk-ant-oat` 开头） | — |
 | `--api-key <key>` | Anthropic API key（以 `sk-ant-` 开头） | — |
 | `--codex-api-key <key>` | Codex 运行时的 OpenAI API key（以 `sk-` 开头） | — |
+| `--base-url <url>` | 给 Claude Code 设置自定义 API 地址 | — |
+| `--codex-base-url <url>` | 给 Codex 设置自定义 API 地址 | — |
 | `--timezone <tz>` | [IANA 时区](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)，如 `Asia/Shanghai`、`America/New_York`、`Europe/London` | 系统默认 |
 | `--domain <domain>` | Caddy 反向代理域名，如 `agent.example.com` | 无 |
 | `--https` / `--no-https` | 启用或禁用 HTTPS | 设置域名时默认 `--https` |
@@ -78,14 +80,16 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 
 **环境变量：**
 
-参数也可通过环境变量设置。优先级：CLI 参数 > 环境变量 > 已有 `.env` > 交互式提示。
+参数也可在 `zylos init` 时通过环境变量设置。优先级：CLI 参数 > 环境变量 > 已有 `.env` > 交互式提示。
 
 | 环境变量 | 对应参数 |
 |---------|---------|
 | `ZYLOS_RUNTIME` | `--runtime` |
 | `CLAUDE_CODE_OAUTH_TOKEN` | `--setup-token` |
 | `ANTHROPIC_API_KEY` | `--api-key` |
-| `OPENAI_API_KEY` | `--codex-api-key`（存储在 `~/.codex/auth.json`，不在 `.env`） |
+| `ANTHROPIC_BASE_URL` | `--base-url` |
+| `OPENAI_API_KEY` | `--codex-api-key` |
+| `OPENAI_BASE_URL` | `--codex-base-url` |
 | `ZYLOS_DOMAIN` | `--domain` |
 | `ZYLOS_PROTOCOL`（`https` 或 `http`） | `--https` / `--no-https` |
 | `ZYLOS_WEB_PASSWORD` | `--web-password` |

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -25,12 +25,18 @@ import {
   installCodex,
   isClaudeAuthenticated,
   isCodexAuthenticated,
+  isValidBaseUrl,
   approveApiKey,
   saveApiKey,
   saveApiKeyToEnv,
+  saveClaudeBaseUrl,
+  saveClaudeBaseUrlToSettingsAndEnv,
   saveSetupToken,
   saveSetupTokenToEnv,
+  saveCodexBaseUrl,
   saveCodexApiKey,
+  saveCodexApiKeyToEnv,
+  saveCodexBaseUrlToEnv,
   writeCodexConfig,
 } from '../lib/runtime-setup.js';
 
@@ -1571,7 +1577,7 @@ async function setupCaddy(skipConfirm, opts = {}) {
  * @param {string[]} args - CLI arguments (after command name)
  * @returns {object} Parsed options
  */
-function parseInitFlags(args) {
+export function parseInitFlags(args) {
   const opts = {
     yes: false,
     quiet: false,
@@ -1582,6 +1588,8 @@ function parseInitFlags(args) {
     setupToken: null,
     apiKey: null,
     codexApiKey: null,
+    baseUrl: null,
+    codexBaseUrl: null,
     domain: null,
     https: null,   // null = not specified, true = --https, false = --no-https
     caddy: null,   // null = not specified, true = --caddy, false = --no-caddy
@@ -1610,6 +1618,8 @@ function parseInitFlags(args) {
       case '--setup-token':
       case '--api-key':
       case '--codex-api-key':
+      case '--base-url':
+      case '--codex-base-url':
       case '--domain':
       case '--web-password': {
         const val = args[++i];
@@ -1622,6 +1632,8 @@ function parseInitFlags(args) {
         else if (arg === '--setup-token') opts.setupToken = val;
         else if (arg === '--api-key') opts.apiKey = val;
         else if (arg === '--codex-api-key') opts.codexApiKey = val;
+        else if (arg === '--base-url') opts.baseUrl = val;
+        else if (arg === '--codex-base-url') opts.codexBaseUrl = val;
         else if (arg === '--domain') opts.domain = val;
         else if (arg === '--web-password') opts.webPassword = val;
         break;
@@ -1643,7 +1655,7 @@ function parseInitFlags(args) {
  *
  * @param {object} opts - Parsed CLI options (mutated in place)
  */
-function resolveFromEnv(opts) {
+export function resolveFromEnv(opts) {
   // Only promote auth tokens from env when:
   // 1. Not already authenticated (avoids redundant re-verification)
   // 2. No auth token was provided via CLI flag (avoids false mutual-exclusion
@@ -1673,19 +1685,19 @@ function resolveFromEnv(opts) {
   if (opts.codexApiKey === null && (process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY)) {
     opts.codexApiKey = process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY;
   }
+  if (opts.baseUrl === null && process.env.ANTHROPIC_BASE_URL) {
+    opts.baseUrl = process.env.ANTHROPIC_BASE_URL;
+  }
+  if (opts.codexBaseUrl === null && process.env.OPENAI_BASE_URL) {
+    opts.codexBaseUrl = process.env.OPENAI_BASE_URL;
+  }
   // TZ: do NOT pick up ambient TZ from the environment.
   // Docker containers often have TZ=UTC set by default, which would silently
   // overwrite user-configured timezones on re-init. Only --timezone flag applies.
   // The auto-detect in configureTimezone() will handle the default case.
 }
 
-/**
- * Validate resolved options. Returns error message or null if valid.
- *
- * @param {object} opts - Resolved options
- * @returns {string|null} Error message or null
- */
-function validateInitOptions(opts) {
+export function validateInitOptions(opts) {
   // Mutual exclusion: setup-token and api-key
   if (opts.setupToken && opts.apiKey) {
     return '--setup-token and --api-key are mutually exclusive.\n  Run zylos init and choose one during setup.';
@@ -1714,6 +1726,13 @@ function validateInitOptions(opts) {
     return `Invalid timezone: "${opts.timezone}".\n  Run: zylos init --timezone Asia/Shanghai`;
   }
 
+  if (opts.baseUrl && !isValidBaseUrl(opts.baseUrl)) {
+    return `Invalid base URL: "${opts.baseUrl}".\n  Run: zylos init --base-url https://example.com/v1`;
+  }
+  if (opts.codexBaseUrl && !isValidBaseUrl(opts.codexBaseUrl)) {
+    return `Invalid Codex base URL: "${opts.codexBaseUrl}".\n  Run: zylos init --codex-base-url https://example.com/v1`;
+  }
+
   // Domain validation (basic hostname check)
   if (opts.domain) {
     const domainPattern = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
@@ -1734,7 +1753,7 @@ function validateInitOptions(opts) {
 /**
  * Print help text for `zylos init`.
  */
-function printInitHelp() {
+export function printInitHelp() {
   console.log(`
 Usage: zylos init [options]
 
@@ -1746,6 +1765,8 @@ Options:
   --setup-token <token>      Authenticate with Claude setup token
   --api-key <key>            Authenticate with Anthropic API key
   --codex-api-key <key>      Authenticate Codex with OpenAI API key (sk-...)
+  --base-url <url>           Custom API base URL for Claude Code
+  --codex-base-url <url>     Custom API base URL for Codex
   --domain <domain>          Configure Caddy with this domain
   --https / --no-https       Enable/disable HTTPS (default: https when domain set)
   --caddy / --no-caddy       Install/skip Caddy web server (default: install)
@@ -1922,6 +1943,18 @@ export async function initCommand(args) {
   let codexAuthenticated = false;
   let pendingApiKey = null; // set if user enters API key, written to .env after templates
   let pendingSetupToken = null; // set if user enters setup-token, written to .env after templates
+  let pendingCodexApiKey = null; // set if codex api key provided, written to .env after templates
+  let pendingClaudeBaseUrl = null;
+  let pendingCodexBaseUrl = null;
+
+  if (opts.baseUrl) {
+    saveClaudeBaseUrl(opts.baseUrl);
+    pendingClaudeBaseUrl = opts.baseUrl;
+  }
+  if (opts.codexBaseUrl) {
+    saveCodexBaseUrl(opts.codexBaseUrl);
+    pendingCodexBaseUrl = opts.codexBaseUrl;
+  }
 
   if (selectedRuntime === 'codex') {
     // ── Step 5 (Codex): install ───────────────────────────────────────────
@@ -2035,7 +2068,7 @@ export async function initCommand(args) {
       }
 
       // Write ~/.codex/config.toml to suppress interactive prompts on first launch
-      if (writeCodexConfig(ZYLOS_DIR)) {
+      if (writeCodexConfig(ZYLOS_DIR, { openaiBaseUrl: pendingCodexBaseUrl || undefined })) {
         if (!quiet) console.log(`  ${success('Codex startup config written')}`);
       }
     }
@@ -2252,6 +2285,16 @@ export async function initCommand(args) {
     if (pendingSetupToken) {
       saveSetupTokenToEnv(pendingSetupToken);
     }
+    if (pendingCodexApiKey) {
+      saveCodexApiKeyToEnv(pendingCodexApiKey);
+    }
+    if (pendingClaudeBaseUrl) {
+      saveClaudeBaseUrlToSettingsAndEnv(pendingClaudeBaseUrl);
+    }
+    if (pendingCodexBaseUrl) {
+      saveCodexBaseUrlToEnv(pendingCodexBaseUrl);
+      writeCodexConfig(ZYLOS_DIR, { openaiBaseUrl: pendingCodexBaseUrl });
+    }
 
     // Timezone: use resolved value or show current
     if (!quiet) console.log(heading('Checking timezone...'));
@@ -2346,6 +2389,16 @@ export async function initCommand(args) {
   }
   if (pendingSetupToken) {
     saveSetupTokenToEnv(pendingSetupToken);
+  }
+  if (pendingCodexApiKey) {
+    saveCodexApiKeyToEnv(pendingCodexApiKey);
+  }
+  if (pendingClaudeBaseUrl) {
+    saveClaudeBaseUrlToSettingsAndEnv(pendingClaudeBaseUrl);
+  }
+  if (pendingCodexBaseUrl) {
+    saveCodexBaseUrlToEnv(pendingCodexBaseUrl);
+    writeCodexConfig(ZYLOS_DIR, { openaiBaseUrl: pendingCodexBaseUrl });
   }
   // Step 8: Configure timezone
   if (!quiet) console.log(`\n${heading('Timezone configuration...')}`);

--- a/cli/commands/runtime.js
+++ b/cli/commands/runtime.js
@@ -5,6 +5,7 @@
  *   zylos runtime <name>                        Switch to the specified runtime (claude|codex)
  *   zylos runtime status                        Show the currently configured runtime
  *   zylos runtime <name> --save-apikey <key>    Save API key and switch (all runtimes)
+ *   zylos runtime <name> --save-base-url <url>  Save base URL and switch
  *   zylos runtime claude --save-setup-token <t> Save Claude setup token and switch
  */
 
@@ -18,11 +19,15 @@ import { commandExists } from '../lib/shell-utils.js';
 import {
   installClaude,
   installCodex,
+  isValidBaseUrl,
   saveApiKey,
   saveApiKeyToEnv,
+  saveClaudeBaseUrlToSettingsAndEnv,
   saveSetupToken,
   saveSetupTokenToEnv,
   saveCodexApiKey,
+  saveCodexBaseUrlToEnv,
+  saveCodexApiKeyToEnv,
   writeCodexConfig,
 } from '../lib/runtime-setup.js';
 
@@ -102,34 +107,85 @@ function applyCredentials(target, creds) {
   return false;
 }
 
+export function applyBaseUrl(target, baseUrl) {
+  if (target === 'claude') {
+    return saveClaudeBaseUrlToSettingsAndEnv(baseUrl);
+  }
+  if (target === 'codex') {
+    if (!saveCodexBaseUrlToEnv(baseUrl)) return false;
+    return writeCodexConfig(ZYLOS_DIR, { openaiBaseUrl: baseUrl });
+  }
+  return false;
+}
+
+export function parseRuntimeFlags(flags) {
+  const apiKeyIdx = flags.indexOf('--save-apikey');
+  const setupTokenIdx = flags.indexOf('--save-setup-token');
+  const baseUrlIdx = flags.indexOf('--save-base-url');
+
+  return {
+    apiKey: apiKeyIdx >= 0 ? flags[apiKeyIdx + 1] : null,
+    setupToken: setupTokenIdx >= 0 ? flags[setupTokenIdx + 1] : null,
+    baseUrl: baseUrlIdx >= 0 ? flags[baseUrlIdx + 1] : null,
+    hasApiKey: apiKeyIdx >= 0,
+    hasSetupToken: setupTokenIdx >= 0,
+    hasBaseUrl: baseUrlIdx >= 0,
+  };
+}
+
+export function validateRuntimeFlags(target, parsed) {
+  if (parsed.hasApiKey && (!parsed.apiKey || parsed.apiKey.startsWith('--'))) {
+    return {
+      error: 'Missing value for --save-apikey.',
+      example: target === 'codex'
+        ? 'zylos runtime codex --save-apikey sk-proj-xxx'
+        : 'zylos runtime claude --save-apikey sk-ant-api-xxx',
+    };
+  }
+  if (parsed.hasSetupToken && (!parsed.setupToken || parsed.setupToken.startsWith('--'))) {
+    return {
+      error: 'Missing value for --save-setup-token.',
+      example: 'zylos runtime claude --save-setup-token sk-ant-oat-xxx',
+    };
+  }
+  if (parsed.hasBaseUrl && (!parsed.baseUrl || parsed.baseUrl.startsWith('--'))) {
+    return {
+      error: 'Missing value for --save-base-url.',
+      example: target === 'codex'
+        ? 'zylos runtime codex --save-base-url https://proxy.example.com/v1'
+        : 'zylos runtime claude --save-base-url https://claude-proxy.example.com',
+    };
+  }
+  if (parsed.baseUrl && !isValidBaseUrl(parsed.baseUrl)) {
+    return {
+      error: `Invalid base URL: "${parsed.baseUrl}".`,
+      example: target === 'codex'
+        ? 'zylos runtime codex --save-base-url https://proxy.example.com/v1'
+        : 'zylos runtime claude --save-base-url https://claude-proxy.example.com',
+    };
+  }
+  return null;
+}
+
 // ── Switch ────────────────────────────────────────────────────────────────
 
 async function switchRuntime(target, flags) {
   const cfg = getZylosConfig();
   const current = cfg.runtime ?? 'claude';
   const monitorDir = path.join(ZYLOS_DIR, 'activity-monitor');
+  const parsed = parseRuntimeFlags(flags);
+  const validationError = validateRuntimeFlags(target, parsed);
+  if (validationError) {
+    console.error(red(`\n${validationError.error}`));
+    console.error(dim(`  Example: ${validationError.example}`));
+    process.exit(1);
+  }
 
-  if (current === target) {
+  const { apiKey, setupToken, baseUrl } = parsed;
+
+  if (current === target && !apiKey && !setupToken && !baseUrl) {
     console.log(`Already on ${bold(target)} runtime.`);
     return;
-  }
-
-  // Parse credential flags
-  const apiKeyIdx = flags.indexOf('--save-apikey');
-  const setupTokenIdx = flags.indexOf('--save-setup-token');
-  const apiKey = apiKeyIdx >= 0 ? flags[apiKeyIdx + 1] : null;
-  const setupToken = setupTokenIdx >= 0 ? flags[setupTokenIdx + 1] : null;
-
-  // Validate that flag values were actually provided (not undefined / another flag).
-  if (apiKeyIdx >= 0 && (!apiKey || apiKey.startsWith('--'))) {
-    console.error(red(`\nMissing value for --save-apikey.`));
-    console.error(dim('  Example: zylos runtime codex --save-apikey sk-proj-xxx'));
-    process.exit(1);
-  }
-  if (setupTokenIdx >= 0 && (!setupToken || setupToken.startsWith('--'))) {
-    console.error(red(`\nMissing value for --save-setup-token.`));
-    console.error(dim('  Example: zylos runtime claude --save-setup-token sk-ant-oat-xxx'));
-    process.exit(1);
   }
 
   // Step 1: Ensure target runtime CLI is installed.
@@ -156,6 +212,15 @@ async function switchRuntime(target, flags) {
       process.exit(1);
     }
     console.log(`  ${green('✓')} credentials saved`);
+  }
+
+  if (baseUrl) {
+    console.log(`Saving base URL for ${bold(target)}...`);
+    if (!applyBaseUrl(target, baseUrl)) {
+      console.error(red(`\nFailed to save base URL.`));
+      process.exit(1);
+    }
+    console.log(`  ${green('✓')} base URL saved`);
   }
 
   // Step 2b: Write Codex headless config (trust dir, suppress all interactive prompts).
@@ -230,7 +295,7 @@ async function switchRuntime(target, flags) {
 
 // ── Help ──────────────────────────────────────────────────────────────────
 
-function showHelp() {
+export function showHelp() {
   console.log(`
 zylos runtime — switch agent runtime
 
@@ -238,6 +303,7 @@ Usage:
   zylos runtime <name>                        Switch to the specified runtime
   zylos runtime status                        Show currently configured runtime
   zylos runtime <name> --save-apikey <key>    Save API key and switch
+  zylos runtime <name> --save-base-url <url>  Save base URL and switch
   zylos runtime claude --save-setup-token <t> Save Claude setup token and switch
 
 Supported runtimes:
@@ -246,9 +312,11 @@ Supported runtimes:
 
 Authentication options (if not already authenticated):
   Claude:  --save-apikey <sk-ant-api...>   Anthropic API key
+           --save-base-url <url>           Claude base URL
            --save-setup-token <sk-ant-oat...>  Setup token
            claude auth login               Browser OAuth (then retry)
   Codex:   --save-apikey <sk-...>          OpenAI API key
+           --save-base-url <url>           Codex base URL
            codex login --device-auth       Device auth (headless)
            codex login                     Browser login (then retry)
 
@@ -261,7 +329,9 @@ Examples:
   zylos runtime status
   zylos runtime codex
   zylos runtime claude --save-apikey sk-ant-api-xxx
+  zylos runtime claude --save-base-url https://claude-proxy.example.com
   zylos runtime claude --save-setup-token sk-ant-oat-xxx
   zylos runtime codex --save-apikey sk-proj-xxx
+  zylos runtime codex --save-base-url https://proxy.example.com/v1
 `);
 }

--- a/cli/lib/__tests__/init-base-url.test.js
+++ b/cli/lib/__tests__/init-base-url.test.js
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+describe('base URL support', () => {
+  test('init command exports helpers for base-url parsing and validation', async () => {
+    const initModule = await import('../../commands/init.js');
+
+    assert.equal(typeof initModule.parseInitFlags, 'function');
+    assert.equal(typeof initModule.validateInitOptions, 'function');
+    assert.equal(typeof initModule.printInitHelp, 'function');
+  });
+
+  test('parseInitFlags accepts runtime-specific base URL flags and printInitHelp shows them', async () => {
+    const initModule = await import('../../commands/init.js');
+    const opts = initModule.parseInitFlags([
+      '--runtime', 'codex',
+      '--base-url', 'https://claude-proxy.example.com',
+      '--codex-base-url', 'https://proxy.example.com/v1',
+    ]);
+
+    assert.equal(opts.runtime, 'codex');
+    assert.equal(opts.baseUrl, 'https://claude-proxy.example.com');
+    assert.equal(opts.codexBaseUrl, 'https://proxy.example.com/v1');
+
+    const originalLog = console.log;
+    let output = '';
+    console.log = (line = '') => {
+      output += `${line}\n`;
+    };
+
+    try {
+      initModule.printInitHelp();
+    } finally {
+      console.log = originalLog;
+    }
+
+    assert.match(output, /--base-url <url>/);
+    assert.match(output, /--codex-base-url <url>/);
+  });
+
+  test('resolveFromEnv reads base URL env vars without overriding explicit flags', async () => {
+    const initModule = await import('../../commands/init.js');
+    const originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
+
+    process.env.ANTHROPIC_BASE_URL = 'https://claude-env.example.com';
+    process.env.OPENAI_BASE_URL = 'https://codex-env.example.com/v1';
+
+    try {
+      const envOnly = initModule.parseInitFlags([]);
+      initModule.resolveFromEnv(envOnly);
+      assert.equal(envOnly.baseUrl, 'https://claude-env.example.com');
+      assert.equal(envOnly.codexBaseUrl, 'https://codex-env.example.com/v1');
+
+      const explicitFlags = initModule.parseInitFlags([
+        '--base-url', 'https://claude-flag.example.com',
+        '--codex-base-url', 'https://codex-flag.example.com/v1',
+      ]);
+      initModule.resolveFromEnv(explicitFlags);
+      assert.equal(explicitFlags.baseUrl, 'https://claude-flag.example.com');
+      assert.equal(explicitFlags.codexBaseUrl, 'https://codex-flag.example.com/v1');
+    } finally {
+      if (originalAnthropicBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+      else process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
+
+      if (originalOpenAiBaseUrl === undefined) delete process.env.OPENAI_BASE_URL;
+      else process.env.OPENAI_BASE_URL = originalOpenAiBaseUrl;
+    }
+  });
+
+  test('writeCodexConfig writes openai_base_url when OPENAI_BASE_URL is set', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-base-url-'));
+    const originalHome = process.env.HOME;
+    const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
+
+    process.env.HOME = tmpRoot;
+    process.env.OPENAI_BASE_URL = 'https://openai-proxy.example.com/v1';
+
+    try {
+      const { writeCodexConfig } = await import('../runtime-setup.js');
+
+      assert.equal(writeCodexConfig('/tmp/zylos-project'), true);
+
+      const configPath = path.join(tmpRoot, '.codex', 'config.toml');
+      const config = fs.readFileSync(configPath, 'utf8');
+      assert.match(config, /openai_base_url = "https:\/\/openai-proxy\.example\.com\/v1"/);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+
+      if (originalOpenAiBaseUrl === undefined) delete process.env.OPENAI_BASE_URL;
+      else process.env.OPENAI_BASE_URL = originalOpenAiBaseUrl;
+
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('writeCodexConfig writes openai_base_url when explicit opts.openaiBaseUrl is provided', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-base-url-opt-'));
+    const originalHome = process.env.HOME;
+    const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
+
+    process.env.HOME = tmpRoot;
+    delete process.env.OPENAI_BASE_URL;
+
+    try {
+      const { writeCodexConfig } = await import('../runtime-setup.js');
+
+      assert.equal(
+        writeCodexConfig('/tmp/zylos-project', { openaiBaseUrl: 'https://explicit-proxy.example.com/v1' }),
+        true
+      );
+
+      const configPath = path.join(tmpRoot, '.codex', 'config.toml');
+      const config = fs.readFileSync(configPath, 'utf8');
+      assert.match(config, /openai_base_url = "https:\/\/explicit-proxy\.example\.com\/v1"/);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+
+      if (originalOpenAiBaseUrl === undefined) delete process.env.OPENAI_BASE_URL;
+      else process.env.OPENAI_BASE_URL = originalOpenAiBaseUrl;
+
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('validateInitOptions rejects invalid base URL values for both runtimes', async () => {
+    const { validateInitOptions } = await import('../../commands/init.js');
+
+    const claudeError = validateInitOptions({
+      setupToken: null,
+      apiKey: null,
+      runtime: 'claude',
+      timezone: null,
+      domain: null,
+      baseUrl: 'not-a-url',
+    });
+    const codexError = validateInitOptions({
+      setupToken: null,
+      apiKey: null,
+      runtime: 'codex',
+      timezone: null,
+      domain: null,
+      baseUrl: null,
+      codexBaseUrl: 'still-not-a-url',
+    });
+
+    assert.match(claudeError, /Invalid base URL/);
+    assert.match(codexError, /Invalid Codex base URL/);
+  });
+});

--- a/cli/lib/__tests__/runtime-base-url.test.js
+++ b/cli/lib/__tests__/runtime-base-url.test.js
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-runtime-base-url-'));
+process.env.HOME = tmpRoot;
+process.env.ZYLOS_DIR = path.join(tmpRoot, 'zylos-home');
+fs.mkdirSync(process.env.ZYLOS_DIR, { recursive: true });
+fs.writeFileSync(path.join(process.env.ZYLOS_DIR, '.env'), '', 'utf8');
+
+describe('runtime base URL support', () => {
+  test('runtime command exports helpers for base-url parsing and validation', async () => {
+    const runtimeModule = await import('../../commands/runtime.js');
+
+    assert.equal(typeof runtimeModule.parseRuntimeFlags, 'function');
+    assert.equal(typeof runtimeModule.validateRuntimeFlags, 'function');
+    assert.equal(typeof runtimeModule.showHelp, 'function');
+  });
+
+  test('parseRuntimeFlags accepts --save-base-url and showHelp shows it', async () => {
+    const runtimeModule = await import('../../commands/runtime.js');
+    const flags = runtimeModule.parseRuntimeFlags(['--save-apikey', 'sk-test', '--save-base-url', 'https://proxy.example.com/v1']);
+
+    assert.equal(flags.apiKey, 'sk-test');
+    assert.equal(flags.baseUrl, 'https://proxy.example.com/v1');
+
+    const originalLog = console.log;
+    let output = '';
+    console.log = (line = '') => {
+      output += `${line}\n`;
+    };
+
+    try {
+      runtimeModule.showHelp();
+    } finally {
+      console.log = originalLog;
+    }
+
+    assert.match(output, /--save-base-url <url>/);
+  });
+
+  test('validateRuntimeFlags rejects invalid saved base URL values', async () => {
+    const { validateRuntimeFlags } = await import('../../commands/runtime.js');
+
+    const error = validateRuntimeFlags('codex', {
+      apiKey: null,
+      setupToken: null,
+      baseUrl: 'not-a-url',
+    });
+
+    assert.match(error.error, /Invalid base URL/);
+  });
+
+  test('applyBaseUrl writes Claude and Codex base URLs to the expected config', async () => {
+    const runtimeModule = await import('../../commands/runtime.js');
+
+    assert.equal(runtimeModule.applyBaseUrl('claude', 'https://claude-proxy.example.com'), true);
+    assert.equal(runtimeModule.applyBaseUrl('codex', 'https://codex-proxy.example.com/v1'), true);
+
+    const envContent = fs.readFileSync(path.join(process.env.ZYLOS_DIR, '.env'), 'utf8');
+    assert.match(envContent, /ANTHROPIC_BASE_URL=https:\/\/claude-proxy\.example\.com/);
+    assert.match(envContent, /OPENAI_BASE_URL=https:\/\/codex-proxy\.example\.com\/v1/);
+
+    const claudeSettings = JSON.parse(fs.readFileSync(path.join(tmpRoot, '.claude', 'settings.json'), 'utf8'));
+    assert.equal(claudeSettings.env.ANTHROPIC_BASE_URL, 'https://claude-proxy.example.com');
+
+    const codexConfig = fs.readFileSync(path.join(tmpRoot, '.codex', 'config.toml'), 'utf8');
+    assert.match(codexConfig, /openai_base_url = "https:\/\/codex-proxy\.example\.com\/v1"/);
+  });
+});

--- a/cli/lib/runtime-setup.js
+++ b/cli/lib/runtime-setup.js
@@ -13,6 +13,24 @@ import { execSync, execFileSync, spawnSync } from 'node:child_process';
 import { ZYLOS_DIR } from './config.js';
 import { commandExists } from './shell-utils.js';
 
+function upsertEnvValue(content, key, value, comment = null) {
+  const line = `${key}=${value}`;
+  if (content.match(new RegExp(`^${key}=.*$`, 'm'))) {
+    return content.replace(new RegExp(`^${key}=.*$`, 'm'), line);
+  }
+  const prefix = comment ? `\n\n# ${comment}\n` : '\n';
+  return content.trimEnd() + `${prefix}${line}\n`;
+}
+
+export function isValidBaseUrl(value) {
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && !!url.host;
+  } catch {
+    return false;
+  }
+}
+
 // ── Install ────────────────────────────────────────────────────────────────
 
 /**
@@ -177,11 +195,7 @@ export function saveApiKeyToEnv(apiKey) {
   try {
     let content = '';
     try { content = fs.readFileSync(envPath, 'utf8'); } catch {}
-    if (content.match(/^\s*ANTHROPIC_API_KEY\s*=.*$/m)) {
-      content = content.replace(/^\s*ANTHROPIC_API_KEY\s*=.*$/m, `ANTHROPIC_API_KEY=${apiKey}`);
-    } else {
-      content = content.trimEnd() + `\n\n# Anthropic API key (set by zylos init)\nANTHROPIC_API_KEY=${apiKey}\n`;
-    }
+    content = upsertEnvValue(content, 'ANTHROPIC_API_KEY', apiKey, 'Anthropic API key (set by zylos init)');
     fs.writeFileSync(envPath, content);
   } catch {}
 }
@@ -221,15 +235,66 @@ export function saveSetupTokenToEnv(token) {
   try {
     let content = '';
     try { content = fs.readFileSync(envPath, 'utf8'); } catch {}
-    if (content.match(/^\s*CLAUDE_CODE_OAUTH_TOKEN\s*=.*$/m)) {
-      content = content.replace(/^\s*CLAUDE_CODE_OAUTH_TOKEN\s*=.*$/m, `CLAUDE_CODE_OAUTH_TOKEN=${token}`);
-    } else {
-      content = content.trimEnd() + `\n\n# Claude Code setup token (set by zylos init)\nCLAUDE_CODE_OAUTH_TOKEN=${token}\n`;
-    }
+    content = upsertEnvValue(content, 'CLAUDE_CODE_OAUTH_TOKEN', token, 'Claude Code setup token (set by zylos init)');
     content = content.replace(/^# Anthropic API key \(set by zylos init\)\n/m, '');
     content = content.replace(/^\s*ANTHROPIC_API_KEY\s*=.*\n?/m, '');
     fs.writeFileSync(envPath, content);
   } catch {}
+}
+
+/**
+ * Set ANTHROPIC_BASE_URL in process.env for the current process.
+ * @param {string} baseUrl
+ * @returns {boolean}
+ */
+export function saveClaudeBaseUrl(baseUrl) {
+  try {
+    process.env.ANTHROPIC_BASE_URL = baseUrl;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write ANTHROPIC_BASE_URL to Claude settings.json.
+ * @param {string} baseUrl
+ * @returns {boolean}
+ */
+function saveClaudeBaseUrlToSettings(baseUrl) {
+  const settingsDir = path.join(os.homedir(), '.claude');
+  const settingsPath = path.join(settingsDir, 'settings.json');
+  try {
+    fs.mkdirSync(settingsDir, { recursive: true });
+    let settings = {};
+    try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch {}
+    if (!settings.env) settings.env = {};
+    settings.env.ANTHROPIC_BASE_URL = baseUrl;
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write ANTHROPIC_BASE_URL to Claude settings.json and ~/zylos/.env.
+ * @param {string} baseUrl
+ * @returns {boolean}
+ */
+export function saveClaudeBaseUrlToSettingsAndEnv(baseUrl) {
+  const envPath = path.join(ZYLOS_DIR, '.env');
+  try {
+    if (!saveClaudeBaseUrlToSettings(baseUrl)) return false;
+    let content = '';
+    try { content = fs.readFileSync(envPath, 'utf8'); } catch {}
+    content = upsertEnvValue(content, 'ANTHROPIC_BASE_URL', baseUrl, 'Anthropic base URL for Claude Code (set by zylos init)');
+    fs.writeFileSync(envPath, content);
+    process.env.ANTHROPIC_BASE_URL = baseUrl;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // ── Codex credential helpers ───────────────────────────────────────────────
@@ -242,10 +307,12 @@ export function saveSetupTokenToEnv(token) {
  *
  * @param {string} projectDir - The zylos working directory to pre-trust
  * @param {string} existingContent - Existing config.toml contents (optional)
+ * @param {{ openaiBaseUrl?: string }} opts - Optional Codex config overrides
  * @returns {string}
  */
-export function renderCodexConfig(projectDir, existingContent = '') {
+export function renderCodexConfig(projectDir, existingContent = '', opts = {}) {
   const absProject = path.resolve(projectDir);
+  const openaiBaseUrl = opts.openaiBaseUrl || process.env.OPENAI_BASE_URL || '';
 
   let preservedProjects = '';
   const projectMatches = existingContent.match(/^\[projects\.[^\]]+\][^\[]+/gm);
@@ -268,6 +335,7 @@ export function renderCodexConfig(projectDir, existingContent = '') {
     '# Acknowledge the latest model NUX so the "Introducing GPT-X" dialog',
     '# is not shown on startup.  Update this when Codex ships a new default model.',
     'model_availability_nux = "gpt-5.4"',
+    ...(openaiBaseUrl ? ['', '# Use a custom OpenAI-compatible base URL', `openai_base_url = "${openaiBaseUrl.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`] : []),
     '',
     '# Enable Codex features required by Zylos runtime workflows.',
     '[features]',
@@ -304,7 +372,7 @@ export function renderCodexConfig(projectDir, existingContent = '') {
  * @param {string} projectDir - The zylos working directory to pre-trust
  * @returns {boolean} true on success
  */
-export function writeCodexConfig(projectDir) {
+export function writeCodexConfig(projectDir, opts = {}) {
   const codexDir = path.join(os.homedir(), '.codex');
   const configPath = path.join(codexDir, 'config.toml');
   try {
@@ -312,9 +380,8 @@ export function writeCodexConfig(projectDir) {
     try {
       existing = fs.readFileSync(configPath, 'utf8');
     } catch { /* new file — nothing to preserve */ }
-
     fs.mkdirSync(codexDir, { recursive: true });
-    fs.writeFileSync(configPath, renderCodexConfig(projectDir, existing), 'utf8');
+    fs.writeFileSync(configPath, renderCodexConfig(projectDir, existing, opts), 'utf8');
     return true;
   } catch {
     return false;
@@ -344,6 +411,58 @@ export function saveCodexApiKey(apiKey) {
     authContent.OPENAI_API_KEY = apiKey;
     fs.writeFileSync(authPath, JSON.stringify(authContent, null, 2) + '\n', { mode: 0o600 });
     process.env.OPENAI_API_KEY = apiKey;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write OPENAI_API_KEY to ~/zylos/.env for runtime processes that still read it there.
+ * @param {string} apiKey - The OpenAI API key (sk-...)
+ * @returns {boolean}
+ */
+export function saveCodexApiKeyToEnv(apiKey) {
+  const envPath = path.join(ZYLOS_DIR, '.env');
+  try {
+    let content = '';
+    try { content = fs.readFileSync(envPath, 'utf8'); } catch {}
+    content = upsertEnvValue(content, 'OPENAI_API_KEY', apiKey, 'OpenAI API key for Codex (set by zylos init)');
+    fs.writeFileSync(envPath, content);
+    process.env.OPENAI_API_KEY = apiKey;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Set OPENAI_BASE_URL in process.env for the current process.
+ * @param {string} baseUrl
+ * @returns {boolean}
+ */
+export function saveCodexBaseUrl(baseUrl) {
+  try {
+    process.env.OPENAI_BASE_URL = baseUrl;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write OPENAI_BASE_URL to ~/zylos/.env.
+ * @param {string} baseUrl
+ * @returns {boolean}
+ */
+export function saveCodexBaseUrlToEnv(baseUrl) {
+  const envPath = path.join(ZYLOS_DIR, '.env');
+  try {
+    let content = '';
+    try { content = fs.readFileSync(envPath, 'utf8'); } catch {}
+    content = upsertEnvValue(content, 'OPENAI_BASE_URL', baseUrl, 'OpenAI base URL for Codex (set by zylos init)');
+    fs.writeFileSync(envPath, content);
+    process.env.OPENAI_BASE_URL = baseUrl;
     return true;
   } catch {
     return false;

--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -230,6 +230,7 @@ export class ClaudeAdapter extends RuntimeAdapter {
     let hasNativeAuth = useCredentialsFile;
     let apiKeyValue = '';
     let oauthTokenValue = '';
+    let baseUrlValue = '';
 
     if (!hasNativeAuth) {
       // Check if user is logged in via `claude login`
@@ -250,6 +251,7 @@ export class ClaudeAdapter extends RuntimeAdapter {
         const envContent = fs.readFileSync(path.join(ZYLOS_DIR, '.env'), 'utf8');
         apiKeyValue = _parseEnvValue(envContent, 'ANTHROPIC_API_KEY');
         oauthTokenValue = _parseEnvValue(envContent, 'CLAUDE_CODE_OAUTH_TOKEN');
+        baseUrlValue = _parseEnvValue(envContent, 'ANTHROPIC_BASE_URL');
       } catch { }
 
       // Pre-approve API keys to skip interactive confirmation prompts
@@ -280,12 +282,13 @@ export class ClaudeAdapter extends RuntimeAdapter {
       let shellCmd;
       let tmpEnv = null;
 
-      if (!hasNativeAuth && (apiKeyValue || oauthTokenValue)) {
+      if (baseUrlValue || (!hasNativeAuth && (apiKeyValue || oauthTokenValue))) {
         // Write secrets to a temp file, source it, then delete it
         // Avoids exposing secrets in ps/proc/cmdline
         const envParts = [];
         if (apiKeyValue) envParts.push(`ANTHROPIC_API_KEY='${apiKeyValue}'`);
         if (oauthTokenValue) envParts.push(`CLAUDE_CODE_OAUTH_TOKEN='${oauthTokenValue}'`);
+        if (baseUrlValue) envParts.push(`ANTHROPIC_BASE_URL='${baseUrlValue}'`);
         tmpEnv = path.join(os.tmpdir(), `.zylos-env-${process.pid}-${Date.now()}`);
         fs.writeFileSync(tmpEnv, envParts.join('\n') + '\n', { mode: 0o600 });
         shellCmd = `set -a; . "${tmpEnv}"; set +a; rm -f "${tmpEnv}"; cd "${ZYLOS_DIR}" && ${claudeCmd}; ${exitLogSnippet}`;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,10 @@
 # Install with Codex runtime:
 #   curl -fsSL .../install.sh | bash -s -- -y --runtime codex --domain example.com --https
 #
+# Install with custom API base URLs:
+#   curl -fsSL .../install.sh | bash -s -- -y --base-url https://claude-proxy.example.com
+#   curl -fsSL .../install.sh | bash -s -- -y --runtime codex --codex-base-url https://proxy.example.com/v1
+#
 # Install environment only (no init):
 #   curl -fsSL .../install.sh | bash -s -- --no-init
 #
@@ -45,7 +49,7 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     # Flags that take a value — forward both flag and value to zylos init
-    --timezone|--setup-token|--api-key|--codex-api-key|--domain|--web-password|--runtime)
+    --timezone|--setup-token|--api-key|--codex-api-key|--base-url|--codex-base-url|--domain|--web-password|--runtime)
       if [ -z "${2:-}" ]; then
         echo "[zylos] Error: $1 requires a value" >&2
         exit 1

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -22,7 +22,13 @@ CLAUDE_BYPASS_PERMISSIONS=true
 # CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-xxx
 # Option 2: Anthropic API key (usage-based billing)
 # ANTHROPIC_API_KEY=sk-ant-xxx
+# Optional: custom Anthropic-compatible base URL for Claude Code
+# ANTHROPIC_BASE_URL=https://api.example.com
 
+# Codex (OpenAI) runtime authentication
+# OPENAI_API_KEY=sk-xxx
+# Optional: custom OpenAI-compatible base URL for Codex
+# OPENAI_BASE_URL=https://api.example.com/v1
 # Proxy (if needed for external API access)
 # HTTP_PROXY=http://proxy:port
 # HTTPS_PROXY=http://proxy:port


### PR DESCRIPTION
## Summary

This PR adds runtime-specific base URL configuration for Claude Code and Codex across the existing install/init/runtime flows.

Refs #399.

## What changed

- `install.sh` now forwards `--base-url` and `--codex-base-url`
- `zylos init` now supports runtime-specific base URL flags for Claude Code and Codex
- `zylos runtime <runtime> --save-base-url <url>` now saves the base URL for the selected runtime and switches runtime as usual
- Claude base URL is written to both Claude settings and `~/zylos/.env`
- Codex base URL is written to both `~/zylos/.env` and Codex config
- help text, docs, and regression coverage were updated for the new flow

## Reviewer note

The Codex base URL path in this PR intentionally preserves the current config generation/rewrite behavior.

That means Codex base URL is still applied through the existing config rewrite path rather than through a narrow patch-style update of a single field. In other words, this PR adds the new runtime-specific base URL capability on top of the current Codex config ownership model, and does not separately redesign Codex config merging behavior.

Please review this PR with that boundary in mind: the new capability is implemented, but the current overwrite-style Codex config path is still in place.

## Validation

- `npm test`
