### PR TITLE
feat: add runtime-work shared lifecycle ledger

### DIFF
--- a/skills/runtime-work/SKILL.md
+++ b/skills/runtime-work/SKILL.md
@@ -1,0 +1,19 @@
+# runtime-work
+
+Shared runtime ledger module for unified work lifecycle tracking.
+
+## Purpose
+
+This module provides:
+
+1. `runtime_work` table for top-level work records
+2. `runtime_work_event` append-only event table
+3. Minimal APIs to create, transition, append events, and close out work
+4. Minimal CLI for inspection (`list`, `show`)
+
+## Scripts
+
+- `scripts/db.js`: database bootstrap and path handling
+- `scripts/api.js`: runtime work APIs
+- `scripts/cli.js`: list/show CLI
+- `init-db.sql`: table and index schema

--- a/skills/runtime-work/init-db.sql
+++ b/skills/runtime-work/init-db.sql
@@ -1,0 +1,88 @@
+CREATE TABLE IF NOT EXISTS runtime_work (
+  work_id TEXT PRIMARY KEY,
+
+  source_system TEXT NOT NULL
+    CHECK (source_system IN ('conversation', 'control', 'scheduler', 'component', 'memory')),
+  source_id TEXT NOT NULL,
+  source_run_id TEXT,
+
+  kind TEXT NOT NULL
+    CHECK (kind IN (
+      'human_message',
+      'control_message',
+      'scheduled_task',
+      'component_op',
+      'memory_sync'
+    )),
+
+  state TEXT NOT NULL
+    CHECK (state IN (
+      'queued',
+      'running',
+      'waiting_user',
+      'waiting_external',
+      'done',
+      'failed',
+      'timeout',
+      'cancelled'
+    )),
+
+  priority INTEGER NOT NULL DEFAULT 3
+    CHECK (priority BETWEEN 1 AND 3),
+
+  summary TEXT,
+  subject TEXT,
+
+  channel TEXT,
+  endpoint_id TEXT,
+  reply_channel TEXT,
+  reply_endpoint TEXT,
+
+  require_idle INTEGER NOT NULL DEFAULT 0,
+  parent_work_id TEXT,
+
+  lease_owner TEXT,
+  lease_acquired_at INTEGER,
+  lease_expires_at INTEGER,
+  active_session TEXT,
+
+  waiting_reason TEXT,
+  waiting_on TEXT,
+
+  closeout_status TEXT,
+  closeout_summary TEXT,
+  closeout_json TEXT,
+  artifact_refs TEXT NOT NULL DEFAULT '[]',
+
+  error_code TEXT,
+  error_detail TEXT,
+
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  finished_at INTEGER,
+
+  FOREIGN KEY (parent_work_id) REFERENCES runtime_work(work_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_work_state_priority
+  ON runtime_work(state, priority, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_work_source
+  ON runtime_work(source_system, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_work_lease
+  ON runtime_work(state, lease_expires_at);
+
+CREATE TABLE IF NOT EXISTS runtime_work_event (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  work_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_json TEXT,
+  created_at INTEGER NOT NULL,
+
+  FOREIGN KEY (work_id) REFERENCES runtime_work(work_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_work_event_work
+  ON runtime_work_event(work_id, created_at);

--- a/skills/runtime-work/package-lock.json
+++ b/skills/runtime-work/package-lock.json
@@ -1,0 +1,470 @@
+{
+  "name": "runtime-work",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "runtime-work",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^12.6.2"
+      },
+      "bin": {
+        "runtime-work-cli": "scripts/cli.js"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/skills/runtime-work/package.json
+++ b/skills/runtime-work/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "runtime-work",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Shared runtime work ledger module",
+  "main": "scripts/api.js",
+  "bin": {
+    "runtime-work-cli": "./scripts/cli.js"
+  },
+  "scripts": {
+    "cli": "node scripts/cli.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.6.2"
+  }
+}

--- a/skills/runtime-work/scripts/api.js
+++ b/skills/runtime-work/scripts/api.js
@@ -1,0 +1,356 @@
+import { getDb, generateWorkId, nowSeconds } from './db.js';
+
+const VALID_SOURCE_SYSTEMS = new Set(['conversation', 'control', 'scheduler', 'component', 'memory']);
+const VALID_KINDS = new Set(['human_message', 'control_message', 'scheduled_task', 'component_op', 'memory_sync']);
+const VALID_STATES = new Set([
+  'queued',
+  'running',
+  'waiting_user',
+  'waiting_external',
+  'done',
+  'failed',
+  'timeout',
+  'cancelled'
+]);
+
+const TERMINAL_STATES = new Set(['done', 'failed', 'timeout', 'cancelled']);
+
+const ALLOWED_TRANSITIONS = {
+  queued: new Set(['running', 'cancelled']),
+  running: new Set(['waiting_user', 'waiting_external', 'done', 'failed', 'timeout', 'cancelled']),
+  waiting_user: new Set(['running', 'cancelled', 'timeout']),
+  waiting_external: new Set(['running', 'cancelled', 'timeout']),
+  done: new Set(),
+  failed: new Set(),
+  timeout: new Set(),
+  cancelled: new Set()
+};
+
+function ensureWorkExists(workId) {
+  const work = getWork(workId);
+  if (!work) {
+    throw new Error(`Work not found: ${workId}`);
+  }
+  return work;
+}
+
+function parseJsonSafe(raw, fallback) {
+  if (raw === null || raw === undefined || raw === '') {
+    return fallback;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizeJsonText(value, fallbackText) {
+  if (value === undefined || value === null) {
+    return fallbackText;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function parseWorkRow(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...row,
+    artifact_refs: parseJsonSafe(row.artifact_refs, []),
+    closeout_json: parseJsonSafe(row.closeout_json, null)
+  };
+}
+
+function parseEventRow(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...row,
+    event_json: parseJsonSafe(row.event_json, null)
+  };
+}
+
+export function createWork(input) {
+  const sourceSystem = input?.sourceSystem;
+  const sourceId = input?.sourceId;
+  const kind = input?.kind;
+
+  if (!VALID_SOURCE_SYSTEMS.has(sourceSystem)) {
+    throw new Error(`Invalid sourceSystem: ${sourceSystem}`);
+  }
+  if (!sourceId) {
+    throw new Error('sourceId is required');
+  }
+  if (!VALID_KINDS.has(kind)) {
+    throw new Error(`Invalid kind: ${kind}`);
+  }
+
+  const state = input?.state || 'queued';
+  if (!VALID_STATES.has(state)) {
+    throw new Error(`Invalid state: ${state}`);
+  }
+
+  const priority = input?.priority ?? 3;
+  if (!Number.isInteger(priority) || priority < 1 || priority > 3) {
+    throw new Error(`Invalid priority: ${priority}`);
+  }
+
+  const timestamp = nowSeconds();
+  const workId = input?.workId || generateWorkId();
+  const artifactRefsText = normalizeJsonText(input?.artifactRefs, '[]');
+
+  const db = getDb();
+  db.prepare(`
+    INSERT INTO runtime_work (
+      work_id, source_system, source_id, source_run_id, kind, state, priority, summary, subject,
+      channel, endpoint_id, reply_channel, reply_endpoint, require_idle, parent_work_id,
+      lease_owner, lease_acquired_at, lease_expires_at, active_session,
+      waiting_reason, waiting_on, closeout_status, closeout_summary, closeout_json, artifact_refs,
+      error_code, error_detail, created_at, updated_at, started_at, finished_at
+    ) VALUES (
+      @workId, @sourceSystem, @sourceId, @sourceRunId, @kind, @state, @priority, @summary, @subject,
+      @channel, @endpointId, @replyChannel, @replyEndpoint, @requireIdle, @parentWorkId,
+      @leaseOwner, @leaseAcquiredAt, @leaseExpiresAt, @activeSession,
+      @waitingReason, @waitingOn, @closeoutStatus, @closeoutSummary, @closeoutJson, @artifactRefs,
+      @errorCode, @errorDetail, @createdAt, @updatedAt, @startedAt, @finishedAt
+    )
+  `).run({
+    workId,
+    sourceSystem,
+    sourceId,
+    sourceRunId: input?.sourceRunId || null,
+    kind,
+    state,
+    priority,
+    summary: input?.summary || null,
+    subject: input?.subject || null,
+    channel: input?.channel || null,
+    endpointId: input?.endpointId || null,
+    replyChannel: input?.replyChannel || null,
+    replyEndpoint: input?.replyEndpoint || null,
+    requireIdle: input?.requireIdle ? 1 : 0,
+    parentWorkId: input?.parentWorkId || null,
+    leaseOwner: input?.leaseOwner || null,
+    leaseAcquiredAt: input?.leaseAcquiredAt || null,
+    leaseExpiresAt: input?.leaseExpiresAt || null,
+    activeSession: input?.activeSession || null,
+    waitingReason: input?.waitingReason || null,
+    waitingOn: input?.waitingOn || null,
+    closeoutStatus: input?.closeoutStatus || null,
+    closeoutSummary: input?.closeoutSummary || null,
+    closeoutJson: normalizeJsonText(input?.closeoutJson, null),
+    artifactRefs: artifactRefsText,
+    errorCode: input?.errorCode || null,
+    errorDetail: input?.errorDetail || null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    startedAt: input?.startedAt || null,
+    finishedAt: input?.finishedAt || null
+  });
+
+  appendEvent(workId, 'created', {
+    sourceSystem,
+    sourceId,
+    kind,
+    state,
+    priority
+  });
+
+  return getWork(workId);
+}
+
+export function transitionWork(workId, patch) {
+  if (!patch || typeof patch !== 'object') {
+    throw new Error('patch object is required');
+  }
+
+  const current = ensureWorkExists(workId);
+  const nextState = patch.state ?? current.state;
+
+  if (!VALID_STATES.has(nextState)) {
+    throw new Error(`Invalid state: ${nextState}`);
+  }
+
+  if (nextState !== current.state && !ALLOWED_TRANSITIONS[current.state].has(nextState)) {
+    throw new Error(`Invalid state transition: ${current.state} -> ${nextState}`);
+  }
+
+  const updateFields = ['state = @state', 'updated_at = @updatedAt'];
+  const params = {
+    workId,
+    state: nextState,
+    updatedAt: nowSeconds()
+  };
+
+  const writableFields = [
+    ['summary', 'summary'],
+    ['subject', 'subject'],
+    ['waitingReason', 'waiting_reason'],
+    ['waitingOn', 'waiting_on'],
+    ['errorCode', 'error_code'],
+    ['errorDetail', 'error_detail'],
+    ['leaseOwner', 'lease_owner'],
+    ['leaseAcquiredAt', 'lease_acquired_at'],
+    ['leaseExpiresAt', 'lease_expires_at'],
+    ['activeSession', 'active_session']
+  ];
+
+  for (const [inputKey, columnName] of writableFields) {
+    if (Object.hasOwn(patch, inputKey)) {
+      updateFields.push(`${columnName} = @${inputKey}`);
+      params[inputKey] = patch[inputKey];
+    }
+  }
+
+  if (Object.hasOwn(patch, 'priority')) {
+    if (!Number.isInteger(patch.priority) || patch.priority < 1 || patch.priority > 3) {
+      throw new Error(`Invalid priority: ${patch.priority}`);
+    }
+    updateFields.push('priority = @priority');
+    params.priority = patch.priority;
+  }
+
+  if (nextState !== current.state && nextState === 'running' && !current.started_at) {
+    updateFields.push('started_at = @startedAt');
+    params.startedAt = params.updatedAt;
+  }
+
+  if (nextState !== current.state && TERMINAL_STATES.has(nextState)) {
+    updateFields.push('finished_at = @finishedAt');
+    params.finishedAt = params.updatedAt;
+  }
+
+  const db = getDb();
+  db.prepare(`
+    UPDATE runtime_work
+    SET ${updateFields.join(', ')}
+    WHERE work_id = @workId
+  `).run(params);
+
+  appendEvent(workId, 'state_transition', {
+    from: current.state,
+    to: nextState,
+    patch
+  });
+
+  return getWork(workId);
+}
+
+export function appendEvent(workId, eventType, eventPayload = null) {
+  if (!eventType) {
+    throw new Error('eventType is required');
+  }
+
+  ensureWorkExists(workId);
+
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO runtime_work_event (work_id, event_type, event_json, created_at)
+    VALUES (?, ?, ?, ?)
+  `).run(
+    workId,
+    eventType,
+    normalizeJsonText(eventPayload, null),
+    nowSeconds()
+  );
+
+  return Number(result.lastInsertRowid);
+}
+
+export function closeOut(workId, payload = {}) {
+  const current = ensureWorkExists(workId);
+  const status = payload.status || payload.closeoutStatus || current.closeout_status || 'done';
+  if (!TERMINAL_STATES.has(status)) {
+    throw new Error(`closeOut status must be terminal: ${status}`);
+  }
+
+  const timestamp = nowSeconds();
+  const closeoutSummary = payload.summary ?? payload.closeoutSummary ?? null;
+  const closeoutJson = normalizeJsonText(payload.closeoutJson ?? payload.payload, null);
+  const artifactRefs = normalizeJsonText(payload.artifactRefs, current.artifact_refs || []);
+
+  const db = getDb();
+  db.prepare(`
+    UPDATE runtime_work
+    SET state = @state,
+        closeout_status = @closeoutStatus,
+        closeout_summary = @closeoutSummary,
+        closeout_json = @closeoutJson,
+        artifact_refs = @artifactRefs,
+        error_code = @errorCode,
+        error_detail = @errorDetail,
+        updated_at = @updatedAt,
+        finished_at = @finishedAt
+    WHERE work_id = @workId
+  `).run({
+    workId,
+    state: status,
+    closeoutStatus: status,
+    closeoutSummary,
+    closeoutJson,
+    artifactRefs,
+    errorCode: payload.errorCode ?? current.error_code ?? null,
+    errorDetail: payload.errorDetail ?? current.error_detail ?? null,
+    updatedAt: timestamp,
+    finishedAt: timestamp
+  });
+
+  appendEvent(workId, 'close_out', {
+    status,
+    summary: closeoutSummary,
+    errorCode: payload.errorCode ?? null
+  });
+
+  return getWork(workId);
+}
+
+export function getWork(workId) {
+  const db = getDb();
+  const row = db.prepare('SELECT * FROM runtime_work WHERE work_id = ?').get(workId);
+  return parseWorkRow(row);
+}
+
+export function listWork(options = {}) {
+  const state = options.state || null;
+  const limit = Number.isInteger(options.limit) ? options.limit : 50;
+  const safeLimit = Math.min(Math.max(limit, 1), 200);
+
+  const db = getDb();
+  const rows = state
+    ? db.prepare(`
+        SELECT * FROM runtime_work
+        WHERE state = ?
+        ORDER BY created_at DESC
+        LIMIT ?
+      `).all(state, safeLimit)
+    : db.prepare(`
+        SELECT * FROM runtime_work
+        ORDER BY created_at DESC
+        LIMIT ?
+      `).all(safeLimit);
+
+  return rows.map(parseWorkRow);
+}
+
+export function getWorkEvents(workId, options = {}) {
+  const limit = Number.isInteger(options.limit) ? options.limit : 200;
+  const safeLimit = Math.min(Math.max(limit, 1), 1000);
+
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT * FROM runtime_work_event
+    WHERE work_id = ?
+    ORDER BY created_at ASC, id ASC
+    LIMIT ?
+  `).all(workId, safeLimit);
+
+  return rows.map(parseEventRow);
+}

--- a/skills/runtime-work/scripts/cli.js
+++ b/skills/runtime-work/scripts/cli.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { getWork, getWorkEvents, listWork } from './api.js';
+
+const HELP = `
+Runtime Work CLI
+
+Usage: runtime-work cli.js <command> [options]
+
+Commands:
+  list [--state <state>] [--limit <n>] [--json]
+  show <work-id> [--json]
+`;
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const args = [];
+  const options = {};
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (!token.startsWith('--')) {
+      args.push(token);
+      continue;
+    }
+
+    const key = token.slice(2);
+    if (key === 'json') {
+      options.json = true;
+      continue;
+    }
+
+    const value = rest[i + 1];
+    if (value === undefined) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    options[key] = value;
+    i += 1;
+  }
+
+  return { command, args, options };
+}
+
+function fmtTs(ts) {
+  if (!ts) {
+    return '-';
+  }
+  return new Date(ts * 1000).toISOString();
+}
+
+function printList(rows) {
+  if (!rows.length) {
+    console.log('No work items found.');
+    return;
+  }
+
+  console.log('work_id                 state            source        kind              pri  created_at');
+  console.log('---------------------------------------------------------------------------------------------');
+  for (const row of rows) {
+    const workId = row.work_id.slice(0, 22).padEnd(22);
+    const state = row.state.padEnd(16);
+    const source = row.source_system.padEnd(12);
+    const kind = row.kind.padEnd(17);
+    const pri = String(row.priority).padEnd(3);
+    console.log(`${workId} ${state} ${source} ${kind} ${pri}  ${fmtTs(row.created_at)}`);
+  }
+}
+
+function findWorkByPrefix(rawId) {
+  const rows = listWork({ limit: 200 });
+  const exact = rows.find((row) => row.work_id === rawId);
+  if (exact) {
+    return exact.work_id;
+  }
+
+  const matched = rows.filter((row) => row.work_id.startsWith(rawId));
+  if (matched.length === 1) {
+    return matched[0].work_id;
+  }
+  if (matched.length > 1) {
+    throw new Error(`Ambiguous work id prefix "${rawId}"`);
+  }
+
+  return rawId;
+}
+
+function cmdList(options) {
+  const limit = options.limit ? parseInt(options.limit, 10) : 50;
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error('limit must be a positive integer');
+  }
+
+  const rows = listWork({
+    state: options.state || null,
+    limit
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  printList(rows);
+}
+
+function cmdShow(args, options) {
+  const rawId = args[0];
+  if (!rawId) {
+    throw new Error('show requires <work-id>');
+  }
+
+  const workId = findWorkByPrefix(rawId);
+  const work = getWork(workId);
+  if (!work) {
+    throw new Error(`Work not found: ${rawId}`);
+  }
+
+  const events = getWorkEvents(workId, { limit: 200 });
+  const payload = { work, events };
+
+  if (options.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+function main() {
+  try {
+    const { command, args, options } = parseArgs(process.argv.slice(2));
+
+    if (!command || command === 'help' || command === '--help' || command === '-h') {
+      console.log(HELP.trim());
+      return;
+    }
+
+    if (command === 'list') {
+      cmdList(options);
+      return;
+    }
+
+    if (command === 'show') {
+      cmdShow(args, options);
+      return;
+    }
+
+    throw new Error(`Unknown command: ${command}`);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    console.log(HELP.trim());
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/skills/runtime-work/scripts/db.js
+++ b/skills/runtime-work/scripts/db.js
@@ -1,0 +1,78 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const INIT_SQL_PATH = path.join(__dirname, '..', 'init-db.sql');
+
+let db = null;
+let activeDbPath = null;
+
+function resolveDbPath() {
+  if (process.env.RUNTIME_WORK_DB_PATH) {
+    return process.env.RUNTIME_WORK_DB_PATH;
+  }
+
+  const zylosDir = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
+  return path.join(zylosDir, 'runtime-work', 'runtime-work.db');
+}
+
+function ensureDbDir(dbPath) {
+  const dir = path.dirname(dbPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function initSchema(database) {
+  const sql = fs.readFileSync(INIT_SQL_PATH, 'utf8');
+  database.exec(sql);
+}
+
+export function getDbPath() {
+  return resolveDbPath();
+}
+
+export function getDb() {
+  const dbPath = resolveDbPath();
+
+  if (db && activeDbPath === dbPath) {
+    return db;
+  }
+
+  if (db && activeDbPath !== dbPath) {
+    db.close();
+    db = null;
+    activeDbPath = null;
+  }
+
+  ensureDbDir(dbPath);
+  db = new Database(dbPath);
+  activeDbPath = dbPath;
+  db.pragma('journal_mode = WAL');
+  db.pragma('busy_timeout = 5000');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  return db;
+}
+
+export function closeDb() {
+  if (db) {
+    db.close();
+    db = null;
+    activeDbPath = null;
+  }
+}
+
+export function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+export function generateWorkId() {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `work-${ts}-${rand}`;
+}

--- a/test/runtime-work.test.js
+++ b/test/runtime-work.test.js
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+
+import { closeDb, getDb } from '../skills/runtime-work/scripts/db.js';
+import {
+  appendEvent,
+  closeOut,
+  createWork,
+  getWork,
+  getWorkEvents,
+  transitionWork
+} from '../skills/runtime-work/scripts/api.js';
+
+let tempDir = null;
+
+function makeWorkInput(overrides = {}) {
+  return {
+    sourceSystem: 'conversation',
+    sourceId: `conv-${Date.now()}`,
+    kind: 'human_message',
+    state: 'queued',
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runtime-work-'));
+  process.env.RUNTIME_WORK_DB_PATH = path.join(tempDir, 'runtime-work.db');
+  closeDb();
+});
+
+afterEach(() => {
+  closeDb();
+  delete process.env.RUNTIME_WORK_DB_PATH;
+  if (tempDir) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+describe('runtime-work module', () => {
+  test('initializes runtime_work and runtime_work_event tables', () => {
+    const db = getDb();
+    const rows = db.prepare(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table'
+        AND name IN ('runtime_work', 'runtime_work_event')
+      ORDER BY name
+    `).all();
+
+    expect(rows.map((row) => row.name)).toEqual(['runtime_work', 'runtime_work_event']);
+  });
+
+  test('createWork creates queued work with created event', () => {
+    const work = createWork(makeWorkInput());
+    expect(work).toBeTruthy();
+    expect(work.state).toBe('queued');
+    expect(work.source_system).toBe('conversation');
+    expect(work.kind).toBe('human_message');
+
+    const events = getWorkEvents(work.work_id);
+    expect(events.length).toBe(1);
+    expect(events[0].event_type).toBe('created');
+  });
+
+  test('transitionWork supports queued -> running -> done and records transitions', () => {
+    const work = createWork(makeWorkInput());
+
+    const running = transitionWork(work.work_id, { state: 'running', summary: 'claimed' });
+    expect(running.state).toBe('running');
+    expect(running.started_at).toBeTruthy();
+
+    const done = transitionWork(work.work_id, { state: 'done' });
+    expect(done.state).toBe('done');
+    expect(done.finished_at).toBeTruthy();
+
+    const events = getWorkEvents(work.work_id);
+    const transitionEvents = events.filter((evt) => evt.event_type === 'state_transition');
+    expect(transitionEvents.length).toBe(2);
+    expect(transitionEvents[0].event_json.from).toBe('queued');
+    expect(transitionEvents[0].event_json.to).toBe('running');
+    expect(transitionEvents[1].event_json.from).toBe('running');
+    expect(transitionEvents[1].event_json.to).toBe('done');
+  });
+
+  test('appendEvent adds custom event rows', () => {
+    const work = createWork(makeWorkInput());
+    appendEvent(work.work_id, 'note', { detail: 'manual-note' });
+
+    const events = getWorkEvents(work.work_id);
+    const note = events.find((evt) => evt.event_type === 'note');
+    expect(note).toBeTruthy();
+    expect(note.event_json.detail).toBe('manual-note');
+  });
+
+  test('closeOut updates terminal status and writes close_out event', () => {
+    const work = createWork(makeWorkInput());
+    transitionWork(work.work_id, { state: 'running' });
+
+    const closed = closeOut(work.work_id, {
+      status: 'done',
+      summary: 'completed',
+      closeoutJson: { result: 'ok' },
+      artifactRefs: ['https://example.com/artifact/1']
+    });
+
+    expect(closed.state).toBe('done');
+    expect(closed.closeout_status).toBe('done');
+    expect(closed.closeout_summary).toBe('completed');
+    expect(closed.closeout_json.result).toBe('ok');
+    expect(closed.artifact_refs).toEqual(['https://example.com/artifact/1']);
+    expect(closed.finished_at).toBeTruthy();
+
+    const persisted = getWork(work.work_id);
+    expect(persisted.closeout_status).toBe('done');
+    expect(persisted.closeout_summary).toBe('completed');
+
+    const events = getWorkEvents(work.work_id);
+    expect(events[events.length - 1].event_type).toBe('close_out');
+  });
+});


### PR DESCRIPTION
## Summary
- add a standalone `skills/runtime-work` module with schema bootstrap, lifecycle APIs, and inspection CLI
- record runtime work state transitions and close-out events in `runtime_work` and `runtime_work_event`
- cover the new module with unit tests and CLI smoke validation

## Testing
- npm run test:jest -- --runTestsByPath test/runtime-work.test.js
- npm test

Closes #391