### PR TITLE
fix(heartbeat): set heartbeat check priority to highest (0)

### DIFF
--- a/cli/lib/heartbeat/claude-probe.js
+++ b/cli/lib/heartbeat/claude-probe.js
@@ -74,7 +74,7 @@ export function createClaudeProbe({
       try {
         const out = execFileSync('node', [C4_CONTROL, 'enqueue',
           '--content', 'Heartbeat check.',
-          '--priority', '3',
+          '--priority', '0',
           '--bypass-state',
           '--ack-deadline', String(deadline),
         ], { encoding: 'utf8', stdio: 'pipe', timeout: 15_000 });

--- a/cli/lib/heartbeat/codex-probe.js
+++ b/cli/lib/heartbeat/codex-probe.js
@@ -65,7 +65,7 @@ export function createCodexProbe({
       try {
         const out = execFileSync('node', [C4_CONTROL, 'enqueue',
           '--content', 'Heartbeat check.',
-          '--priority', '3',
+          '--priority', '0',
           '--bypass-state',
           '--ack-deadline', String(deadline),
         ], { encoding: 'utf8', stdio: 'pipe', timeout: 15_000 });


### PR DESCRIPTION
## Summary
- Change heartbeat probe priority from `3` to `0` (highest) in both `claude-probe.js` and `codex-probe.js`
- Ensures heartbeat liveness checks are dispatched ahead of all other queued messages

## Test plan
- [ ] Verify heartbeat messages are enqueued with priority 0
- [ ] Confirm heartbeat ack flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)