### PR TITLE
chore(release): prepare v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.6] - 2026-03-26 ⚠️ UPGRADE STRONGLY RECOMMENDED
+## [0.4.7] - 2026-03-26
+
+### Fixed
+- **Periodic probe interval corrected to 30 minutes**: activity-monitor periodic liveness checks were unintentionally reduced from 5 minutes to 3 minutes in v0.4.1. They now run every 30 minutes as intended, avoiding unnecessary idle probe traffic while preserving message-triggered and heartbeat-based recovery paths (#426)
+
+## [0.4.6] - 2026-03-26 _(superseded by 0.4.7 — restores the intended periodic probe interval after the previous over-aggressive reduction)_ ⚠️ UPGRADE STRONGLY RECOMMENDED
 
 > **All instances should upgrade to this version.** Heartbeat probes previously used normal priority (3), which could be delayed behind queued conversation messages. This caused false liveness timeouts and unnecessary kill-restart cycles. v0.4.6 sets heartbeat priority to 0 (highest), ensuring timely delivery regardless of queue depth.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.4.5",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- restore the intended periodic probe interval to 30 minutes in activity-monitor
- bump version metadata to 0.4.7 and update the changelog supersedence note for 0.4.6
- refresh package-lock root metadata and validate the release worktree with the full test suite

## Test plan
- [x] `env -u NODE_ENV npm test`
