### PR TITLE
Fix Codex runtime auth checks for custom base URL

### DIFF
--- a/cli/lib/__tests__/codex.test.js
+++ b/cli/lib/__tests__/codex.test.js
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 const tmpDirs = [];
 
-const { buildCodexBootstrapPrompt, isOnboardingPendingState } = await import('../runtime/codex.js');
+const { CodexAdapter, buildCodexBootstrapPrompt, isOnboardingPendingState } = await import('../runtime/codex.js');
 
 function makeZylosDir(stateContent) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-bootstrap-test-'));
@@ -20,6 +20,22 @@ afterEach(() => {
   while (tmpDirs.length > 0) {
     fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
   }
+});
+
+let originalHome;
+let originalFetch;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  originalFetch = global.fetch;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+
+  if (originalFetch === undefined) delete global.fetch;
+  else global.fetch = originalFetch;
 });
 
 describe('Codex bootstrap onboarding guard', () => {
@@ -43,5 +59,37 @@ describe('Codex bootstrap onboarding guard', () => {
 
     assert.match(prompt, /node ".*session-start-prompt\.js"/);
     assert.match(prompt, /Then continue according to the latest control message and ongoing conversation context\./);
+  });
+});
+
+describe('Codex auth checks', () => {
+  it('uses the configured custom base URL for API key auth checks', async () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-test-'));
+    tmpDirs.push(tmpHome);
+    process.env.HOME = tmpHome;
+
+    fs.mkdirSync(path.join(tmpHome, '.codex'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.codex', 'auth.json'),
+      JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-test' }, null, 2) + '\n',
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(tmpHome, '.codex', 'config.toml'),
+      'openai_base_url = "https://proxy.example.com/v1"\n',
+      'utf8'
+    );
+
+    let requestedUrl = '';
+    global.fetch = async (url) => {
+      requestedUrl = String(url);
+      return { status: 200 };
+    };
+
+    const adapter = new CodexAdapter({});
+    const result = await adapter.checkAuth();
+
+    assert.equal(result.ok, true);
+    assert.equal(requestedUrl, 'https://proxy.example.com/v1/models');
   });
 });

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -34,6 +34,23 @@ const CODEX_BIN = process.env.CODEX_BIN || 'codex';
 // Defaults to enabled for unattended server operation.
 const DEFAULT_BYPASS = process.env.CODEX_BYPASS_PERMISSIONS !== 'false';
 
+function getCodexApiBaseUrl() {
+  try {
+    const configPath = path.join(os.homedir(), '.codex', 'config.toml');
+    const config = fs.readFileSync(configPath, 'utf8');
+    const match = config.match(/^\s*openai_base_url\s*=\s*"([^"]+)"\s*$/m);
+    if (match?.[1]) {
+      return match[1].replace(/\/+$/, '');
+    }
+  } catch { /* ignore missing config */ }
+
+  if (process.env.OPENAI_BASE_URL) {
+    return process.env.OPENAI_BASE_URL.replace(/\/+$/, '');
+  }
+
+  return 'https://api.openai.com/v1';
+}
+
 export function isOnboardingPendingState(stateContent = '') {
   return /^-\s+Status:\s+pending\b/m.test(stateContent);
 }
@@ -146,7 +163,8 @@ export class CodexAdapter extends RuntimeAdapter {
     // Guard against corrupted auth.json (mode set to "apikey" but key missing).
     if (!apiKey) return { ok: false, reason: 'apikey_mode_but_no_key' };
     try {
-      const res = await fetch('https://api.openai.com/v1/models', {
+      const baseUrl = getCodexApiBaseUrl();
+      const res = await fetch(`${baseUrl}/models`, {
         headers: { Authorization: `Bearer ${apiKey}` },
         signal: AbortSignal.timeout(10_000),
       });


### PR DESCRIPTION
## Summary

This PR fixes a Codex runtime switch failure when using a saved custom base URL.

Previously, Zylos could save the Codex API key and base URL successfully, but the follow-up authentication check still validated against the default endpoint. That caused valid custom-base-url setups to be rejected as unauthenticated and aborted the runtime switch.

This change makes the authentication check use the saved Codex base URL first, and only fall back to the default endpoint when no custom base URL is configured.

Closes #434

## Changes

- read the saved Codex base URL before performing the API-key authentication check
- use that saved base URL for the follow-up auth probe
- keep the default endpoint as the fallback when no custom base URL is configured
- add a regression test covering the custom-base-url auth check path

## Testing

- `node --test cli/lib/__tests__/codex.test.js`
- `node --test cli/lib/__tests__/runtime-base-url.test.js cli/lib/__tests__/init-base-url.test.js`
- `npm test`
