### PR TITLE
fix: treat Codex empty prompt as empty input box

### DIFF
--- a/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
@@ -167,6 +167,18 @@ describe('getInputBoxText', () => {
     ].join('\n');
     assert.equal(getInputBoxText(capture), '');
   });
+
+  it('falls back to Codex status-line layout when queue footer is absent', () => {
+    const capture = [
+      '',
+      '› hello from lark',
+      '  wrapped line',
+      '',
+      'gpt-5.4 default · 75% left · ~/zylos',
+      '────────────────────────────────────────'
+    ].join('\n');
+    assert.equal(getInputBoxText(capture), 'hello from lark\n  wrapped line');
+  });
 });
 
 // ── checkInputBox ───────────────────────────────────────────────────
@@ -225,6 +237,18 @@ describe('checkInputBox', () => {
       '  tab to queue message                                        72% context left'
     ].join('\n');
     assert.equal(checkInputBox(capture), 'empty');
+  });
+
+  it('returns "has_content" for Codex status-line captures', () => {
+    const capture = [
+      '',
+      '› hello from lark',
+      '  wrapped line',
+      '',
+      'gpt-5.4 default · 75% left · ~/zylos',
+      '────────────────────────────────────────'
+    ].join('\n');
+    assert.equal(checkInputBox(capture), 'has_content');
   });
 });
 

--- a/skills/comm-bridge/scripts/c4-dispatcher.js
+++ b/skills/comm-bridge/scripts/c4-dispatcher.js
@@ -208,7 +208,10 @@ export function getInputBoxText(capture) {
   }
 
   if (separatorIndexes.length < 2) {
-    const footerIndex = lines.findIndex(line => /tab to queue message/i.test(line));
+    const footerIndex = lines.findIndex(line =>
+      /tab to queue message/i.test(line) ||
+      /\b\d+%\s+left\s+·\s+~\//i.test(line)
+    );
     if (footerIndex === -1) {
       return null;
     }


### PR DESCRIPTION
## Summary
- treat Codex `›` prompt-only captures as an empty input box during dispatcher verification
- add regression coverage for bare `›` prompt captures in the dispatcher pure tests

## Testing
- `node --test /home/op/zylos/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js`
- repo checkout note: the same skill test does not run directly under `workspace/zylos-core` because that checkout does not currently include the skill-side `better-sqlite3` dependency required by `c4-db.js`