### PR TITLE
fix: address context monitor session-switch review feedback

### DIFF
--- a/cli/lib/__tests__/codex-context-monitor.test.js
+++ b/cli/lib/__tests__/codex-context-monitor.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseSqliteThreadRow } from '../runtime/codex-context-monitor.js';
+
+describe('parseSqliteThreadRow', () => {
+  it('parses sqlite3 -json output with rollout paths that contain separators', () => {
+    const parsed = parseSqliteThreadRow(JSON.stringify([
+      {
+        id: '42',
+        tokens_used: 1234,
+        rollout_path: '/tmp/rollout|with|pipes.jsonl',
+      },
+    ]));
+
+    assert.deepEqual(parsed, {
+      threadIdRaw: '42',
+      tokensUsed: 1234,
+      rolloutPathRaw: '/tmp/rollout|with|pipes.jsonl',
+    });
+  });
+
+  it('returns null for malformed sqlite payloads', () => {
+    assert.equal(parseSqliteThreadRow('not-json'), null);
+    assert.equal(parseSqliteThreadRow(JSON.stringify([{ id: '1', tokens_used: 'oops' }])), null);
+  });
+});

--- a/cli/lib/__tests__/context-monitor-base.test.js
+++ b/cli/lib/__tests__/context-monitor-base.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ContextMonitorBase } from '../runtime/context-monitor-base.js';
+
+class FakeMonitor extends ContextMonitorBase {
+  constructor(results, opts) {
+    super(opts);
+    this._results = Array.isArray(results) ? [...results] : [results];
+  }
+
+  async getUsage() {
+    return this._results.shift() ?? null;
+  }
+}
+
+describe('ContextMonitorBase.checkOnce', () => {
+  it('fires onSessionChange when the runtime session id changes', async () => {
+    const monitor = new FakeMonitor([
+      { used: 10, ceiling: 100, sessionId: 'session-a' },
+      { used: 15, ceiling: 100, sessionId: 'session-b' },
+    ]);
+
+    const seen = [];
+    await monitor.checkOnce({
+      onSessionChange: async (info) => {
+        seen.push(info);
+      },
+    });
+    await monitor.checkOnce({
+      onSessionChange: async (info) => {
+        seen.push(info);
+      },
+    });
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].previousSessionId, 'session-a');
+    assert.equal(seen[0].sessionId, 'session-b');
+    assert.equal(seen[0].used, 15);
+  });
+
+  it('retains checkThreshold backward compatibility', async () => {
+    const monitor = new FakeMonitor({ used: 90, ceiling: 100, sessionId: 'session-a' }, { threshold: 0.75 });
+    let called = false;
+
+    await monitor.checkThreshold(async ({ ratio }) => {
+      called = true;
+      assert.equal(ratio, 0.9);
+    });
+
+    assert.equal(called, true);
+  });
+});

--- a/cli/lib/runtime/codex-context-monitor.js
+++ b/cli/lib/runtime/codex-context-monitor.js
@@ -32,6 +32,28 @@ const TAIL_BYTES = 65_536; // 64 KB
 // Fallback ceiling when models_cache.json is unavailable
 const DEFAULT_CEILING = 128_000;
 
+export function parseSqliteThreadRow(raw) {
+  if (!raw) return null;
+
+  try {
+    const rows = JSON.parse(raw);
+    const row = Array.isArray(rows) ? rows[0] : rows;
+    if (!row || typeof row !== 'object') return null;
+
+    const threadIdRaw = row.id != null ? String(row.id) : '';
+    const tokensUsed = parseInt(row.tokens_used, 10);
+    if (Number.isNaN(tokensUsed)) return null;
+
+    return {
+      threadIdRaw,
+      tokensUsed,
+      rolloutPathRaw: row.rollout_path != null ? String(row.rollout_path) : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
 export class CodexContextMonitor extends ContextMonitorBase {
   /**
    * @param {object} [opts]
@@ -194,13 +216,12 @@ export class CodexContextMonitor extends ContextMonitorBase {
                      AND updated_at >= ${this._startTime}
                    ORDER BY updated_at DESC
                    LIMIT 1;`;
-      const out = execFileSync('sqlite3', [SQLITE_FILE, '-separator', '|', sql], {
+      const out = execFileSync('sqlite3', [SQLITE_FILE, '-json', sql], {
         encoding: 'utf8', stdio: 'pipe', timeout: 5_000,
       }).trim();
-      if (!out) return null;
-      const [threadIdRaw, tokensUsedRaw, rolloutPathRaw] = out.split('|');
-      const tokensUsed = parseInt(tokensUsedRaw, 10);
-      if (isNaN(tokensUsed)) return null;
+      const parsed = parseSqliteThreadRow(out);
+      if (!parsed) return null;
+      const { threadIdRaw, tokensUsed, rolloutPathRaw } = parsed;
       const rolloutSessionId = rolloutPathRaw
         ? this._sessionIdFromRolloutPath(rolloutPathRaw)
         : undefined;

--- a/cli/lib/runtime/context-monitor-base.js
+++ b/cli/lib/runtime/context-monitor-base.js
@@ -92,7 +92,7 @@ export class ContextMonitorBase {
   }
 
   /**
-   * Start periodic polling. Calls checkThreshold() at each interval.
+   * Start periodic polling. Calls checkOnce() at each interval.
    * No-op if already started.
    *
    * @param {object} [opts]

--- a/skills/activity-monitor/scripts/activity-monitor.js
+++ b/skills/activity-monitor/scripts/activity-monitor.js
@@ -193,6 +193,7 @@ const CONV_DIR = path.join(os.homedir(), '.claude', 'projects', ZYLOS_PATH);
 const INTERVAL = 1000;
 const IDLE_THRESHOLD = 3;
 const LOG_MAX_LINES = 500;
+const SESSION_SWITCH_LOG_MAX_LINES = 1000;
 const BASE_RESTART_DELAY = 5;
 const MAX_RESTART_DELAY = 60;
 const BACKOFF_RESET_THRESHOLD = 60; // Claude must stay running this long before backoff resets
@@ -260,6 +261,7 @@ let idleSince = 0;
 let lastPeriodicProbeAt = 0;
 let lastHandledClearEventKey = '';
 let lastHandledClearPaneKey = '';
+let lastHandledClearPaneAt = 0;
 let lastClearProbeAttemptAt = 0;
 let lastLaunchAt = 0;
 let lastApiErrorScanAt = 0;
@@ -326,8 +328,20 @@ function recordSessionSwitch({ runtime, previousSessionId, sessionId, used, ceil
       ratio,
     };
     fs.appendFileSync(SESSION_SWITCH_LOG_FILE, JSON.stringify(entry) + '\n');
+    truncateJsonlFile(SESSION_SWITCH_LOG_FILE, SESSION_SWITCH_LOG_MAX_LINES);
   } catch (err) {
     log(`Failed to record session switch: ${err.message}`);
+  }
+}
+
+function truncateJsonlFile(file, maxLines) {
+  try {
+    if (!fs.existsSync(file)) return;
+    const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+    if (lines.length <= maxLines) return;
+    fs.writeFileSync(file, lines.slice(-maxLines).join('\n') + '\n');
+  } catch (err) {
+    log(`Failed to truncate ${path.basename(file)}: ${err.message}`);
   }
 }
 
@@ -1014,10 +1028,13 @@ function readLatestCodexClearEvent() {
       const text = typeof event?.text === 'string' ? event.text.trim() : '';
       if (!text.startsWith('/clear')) continue;
 
-      const ts = Number(event?.ts);
+      const rawTs = Number(event?.ts);
+      const ts = Number.isFinite(rawTs)
+        ? (rawTs > 1_000_000_000_000 ? Math.floor(rawTs / 1000) : rawTs)
+        : 0;
       const sessionId = event?.session_id ? String(event.session_id) : '';
       return {
-        ts: Number.isFinite(ts) ? ts : 0,
+        ts,
         sessionId,
         text,
       };
@@ -1047,16 +1064,20 @@ function readLatestPaneClearSignal() {
 
 function maybeTriggerClearImmediateProbe(currentTime) {
   if (adapter.runtimeId !== 'codex') return;
+  if (engine.health !== 'ok') return;
 
   // Primary signal: pane-local /clear command capture (works even when history.jsonl
   // does not persist slash commands in this Codex build).
   const paneKey = readLatestPaneClearSignal();
-  if (paneKey && paneKey !== lastHandledClearPaneKey) {
+  const paneKeyChanged = paneKey && paneKey !== lastHandledClearPaneKey;
+  const paneDedupExpired = paneKey && (currentTime - lastHandledClearPaneAt) >= 30;
+  if (paneKey && (paneKeyChanged || paneDedupExpired)) {
     if ((currentTime - lastClearProbeAttemptAt) < 5) return;
     lastClearProbeAttemptAt = currentTime;
     const ok = engine.requestImmediateProbe('clear_command');
     if (!ok) return;
     lastHandledClearPaneKey = paneKey;
+    lastHandledClearPaneAt = currentTime;
     lastPeriodicProbeAt = currentTime;
     return;
   }
@@ -1672,7 +1693,7 @@ function init() {
   contextMonitor = adapter.getContextMonitor?.() ?? null;
   if (contextMonitor) {
     contextMonitor.startPolling({
-      intervalMs: 5_000,
+      intervalMs: 30_000,
       onExceed: async ({ used, ceiling, ratio }) => {
         const pct = Math.round(ratio * 100);
         log(`Context at ${pct}% (${used}/${ceiling}), requesting new-session handoff`);


### PR DESCRIPTION
## Summary
- restore low-frequency context polling and rely on the `/clear` immediate probe path for fast session-switch detection
- add guards and durability fixes around Codex `/clear` probing and session-switch logging
- add focused tests for `checkOnce()` session change behavior and sqlite JSON parsing

## Fixes
- add `engine.health === 'ok'` guard before Codex `/clear` immediate probe work
- reduce context monitor polling back to `30_000ms`
- cap `session-switches.jsonl` growth to 1000 lines
- normalize Codex history timestamps when they arrive in milliseconds
- stop parsing sqlite rows with a fragile `|` separator and switch to `sqlite3 -json`
- cover `ContextMonitorBase.checkOnce()` and sqlite row parsing with node:test

## Verification
- `node --test cli/lib/__tests__/context-monitor-base.test.js cli/lib/__tests__/codex-context-monitor.test.js`
  - `4/4` passing

## Notes
- the review that referenced these files did not actually apply to PR #450 (`fix/issue-443-pm2-restart-semantics`); this patch is targeted at the `feat/context-monitor-session-switch-detection` line instead.
