### PR TITLE
fix: fallback tmpdir for copyTree self-copy backups

### DIFF
--- a/cli/lib/__tests__/diff3.test.js
+++ b/cli/lib/__tests__/diff3.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+const origHome = process.env.HOME;
+const origTmpdir = process.env.TMPDIR;
+const tmpDirs = [];
+
+const { merge3, isDiff3Available } = await import('../diff3.js');
+
+function makeTmpDir() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-diff3-test-'));
+  tmpDirs.push(tmpDir);
+  return tmpDir;
+}
+
+afterEach(() => {
+  if (origHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = origHome;
+  }
+  if (origTmpdir === undefined) {
+    delete process.env.TMPDIR;
+  } else {
+    process.env.TMPDIR = origTmpdir;
+  }
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('merge3', () => {
+  it('falls back to ~/tmp when TMPDIR is not writable', () => {
+    if (!isDiff3Available()) {
+      return;
+    }
+
+    const tmpDir = makeTmpDir();
+    process.env.HOME = tmpDir;
+    process.env.TMPDIR = '/nonexistent';
+
+    const result = merge3(
+      'line1\nline2\nline3\nline4\nline5\n',
+      'line1\nlocal\nline3\nline4\nline5\n',
+      'line1\nline2\nline3\nline4\nremote\n'
+    );
+
+    assert.equal(result.clean, true);
+    assert.match(result.content, /local/);
+    assert.match(result.content, /remote/);
+  });
+});

--- a/cli/lib/__tests__/fs-utils.test.js
+++ b/cli/lib/__tests__/fs-utils.test.js
@@ -5,10 +5,22 @@ import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 
 const tmpDirs = [];
+const origHome = process.env.HOME;
+const origTmpdir = process.env.TMPDIR;
 
 const { copyTree } = await import('../fs-utils.js');
 
 afterEach(() => {
+  if (origHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = origHome;
+  }
+  if (origTmpdir === undefined) {
+    delete process.env.TMPDIR;
+  } else {
+    process.env.TMPDIR = origTmpdir;
+  }
   while (tmpDirs.length > 0) {
     fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
   }
@@ -36,5 +48,22 @@ describe('copyTree', () => {
     const stat = fs.lstatSync(backupTarget);
     assert.equal(stat.isSymbolicLink(), true);
     assert.equal(fs.readlinkSync(backupTarget), realSkillsDir);
+  });
+
+  it('falls back to ~/tmp when TMPDIR is not writable during self-copy backup', () => {
+    const tmpDir = makeTmpDir();
+    const srcDir = path.join(tmpDir, 'skill');
+    const nestedBackup = path.join(srcDir, '.backup', 'run-1');
+
+    process.env.HOME = tmpDir;
+    process.env.TMPDIR = '/nonexistent';
+
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, 'SKILL.md'), '# test\n', 'utf8');
+
+    copyTree(srcDir, nestedBackup, { excludes: ['node_modules', '.backup'] });
+
+    assert.equal(fs.existsSync(path.join(nestedBackup, 'SKILL.md')), true);
+    assert.equal(fs.existsSync(path.join(tmpDir, 'tmp')), true);
   });
 });

--- a/cli/lib/diff3.js
+++ b/cli/lib/diff3.js
@@ -12,6 +12,19 @@ import { execFileSync } from 'node:child_process';
 
 let _diff3Available = null;
 
+function getWritableTmpBase(prefix = 'zylos-merge-probe-') {
+  let base = os.tmpdir();
+  try {
+    const probe = fs.mkdtempSync(path.join(base, prefix));
+    fs.rmSync(probe, { recursive: true, force: true });
+  } catch {
+    // System tmp unavailable — fallback to ~/tmp
+    base = path.join(os.homedir(), 'tmp');
+    fs.mkdirSync(base, { recursive: true });
+  }
+  return base;
+}
+
 /**
  * Check if the diff3 command is available on this system.
  * Result is cached after first check.
@@ -40,7 +53,7 @@ export function isDiff3Available() {
  *   clean=false: merge has conflict markers, content contains <<<<<<< markers
  */
 export function merge3(baseContent, localContent, newContent) {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-merge-'));
+  const tmpDir = fs.mkdtempSync(path.join(getWritableTmpBase(), 'zylos-merge-'));
 
   const basePath = path.join(tmpDir, 'base');
   const localPath = path.join(tmpDir, 'local');

--- a/cli/lib/fs-utils.js
+++ b/cli/lib/fs-utils.js
@@ -7,6 +7,19 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
+function getWritableTmpBase(prefix = 'zylos-copy-probe-') {
+  let base = os.tmpdir();
+  try {
+    const probe = fs.mkdtempSync(path.join(base, prefix));
+    fs.rmSync(probe, { recursive: true, force: true });
+  } catch {
+    // System tmp unavailable — fallback to ~/tmp
+    base = path.join(os.homedir(), 'tmp');
+    fs.mkdirSync(base, { recursive: true });
+  }
+  return base;
+}
+
 /**
  * Check if a relative path should be excluded.
  * Matches top-level directory names (e.g., 'node_modules', '.git').
@@ -59,7 +72,7 @@ export function copyTree(src, dest, { excludes = [] } = {}) {
 
   // Detect self-copy: dest is inside src (e.g., src/.backup/timestamp)
   if (resolvedDest.startsWith(resolvedSrc + path.sep)) {
-    const tmpDest = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-copy-'));
+    const tmpDest = fs.mkdtempSync(path.join(getWritableTmpBase(), 'zylos-copy-'));
     try {
       cpSyncFiltered(resolvedSrc, tmpDest, excludes);
       // Move from temp to real dest


### PR DESCRIPTION
## Summary
- reuse the upgrade tmpdir fallback pattern inside `copyTree()` when it needs an intermediate temp dir
- fall back to `~/tmp` if `TMPDIR` is invalid or not writable
- add a regression test covering nested backup copy with `TMPDIR=/nonexistent`

## Testing
- node --test cli/lib/__tests__/fs-utils.test.js cli/lib/__tests__/self-upgrade.test.js