### PR TITLE
fix(c4): add Claude input fallback and reduce send retries

### DIFF
--- a/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
@@ -230,6 +230,17 @@ describe('checkInputBoxByText', () => {
     ].join('\n');
     assert.equal(checkInputBoxByText(capture, { runtime: 'claude' }), 'has_content');
   });
+
+  it('treats Claude buddy-art variants as empty when first 10 chars are blank', () => {
+    const sep = '\u2500'.repeat(20);
+    const capture = [
+      'output',
+      sep,
+      '❯          (  ~~  )',
+      sep
+    ].join('\n');
+    assert.equal(checkInputBoxByText(capture, { runtime: 'claude' }), 'empty');
+  });
 });
 
 // ── isUsageOverlayCapture ───────────────────────────────────────────

--- a/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
@@ -24,8 +24,8 @@ const mod = await import(new URL(`../c4-dispatcher.js?${cacheBuster}`, import.me
 const {
   sanitizeMessage,
   getDeliveryDelay,
-  getInputBoxText,
-  checkInputBoxByText,
+  getClaudeInputBoxText,
+  checkClaudeFallbackInputBox,
   findPromptY,
   isUsageOverlayCapture,
   isBypassState,
@@ -176,9 +176,9 @@ describe('findPromptY', () => {
   });
 });
 
-// ── getInputBoxText / checkInputBoxByText ──────────────────────────
+// ── getClaudeInputBoxText / checkClaudeFallbackInputBox ────────────
 
-describe('getInputBoxText', () => {
+describe('getClaudeInputBoxText', () => {
   it('extracts Claude input text between separator lines', () => {
     const sep = '\u2500'.repeat(24);
     const capture = [
@@ -189,26 +189,23 @@ describe('getInputBoxText', () => {
       'footer'
     ].join('\n');
     assert.equal(
-      getInputBoxText(capture, { runtime: 'claude' }),
+      getClaudeInputBoxText(capture),
       '❯ hello from claude'
     );
   });
 
-  it('extracts Codex input text from prompt+footer layout', () => {
+  it('returns null when Claude separators are not found', () => {
     const capture = [
       '• output',
-      '› hello codex',
+      '› maybe input',
       '',
-      '  gpt-5.4 medium · 82% left · ~/zylos'
+      '  footer'
     ].join('\n');
-    assert.equal(
-      getInputBoxText(capture, { runtime: 'codex' }),
-      'hello codex'
-    );
+    assert.equal(getClaudeInputBoxText(capture), null);
   });
 });
 
-describe('checkInputBoxByText', () => {
+describe('checkClaudeFallbackInputBox', () => {
   it('returns empty for Claude empty prompt', () => {
     const sep = '\u2500'.repeat(20);
     const capture = [
@@ -217,7 +214,7 @@ describe('checkInputBoxByText', () => {
       '❯ ',
       sep
     ].join('\n');
-    assert.equal(checkInputBoxByText(capture, { runtime: 'claude' }), 'empty');
+    assert.equal(checkClaudeFallbackInputBox(capture), 'empty');
   });
 
   it('returns has_content for Claude non-empty prompt', () => {
@@ -228,7 +225,7 @@ describe('checkInputBoxByText', () => {
       '❯ run tests',
       sep
     ].join('\n');
-    assert.equal(checkInputBoxByText(capture, { runtime: 'claude' }), 'has_content');
+    assert.equal(checkClaudeFallbackInputBox(capture), 'has_content');
   });
 
   it('treats Claude buddy-art variants as empty when first 10 chars are blank', () => {
@@ -239,7 +236,7 @@ describe('checkInputBoxByText', () => {
       '❯          (  ~~  )',
       sep
     ].join('\n');
-    assert.equal(checkInputBoxByText(capture, { runtime: 'claude' }), 'empty');
+    assert.equal(checkClaudeFallbackInputBox(capture), 'empty');
   });
 });
 

--- a/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
@@ -24,6 +24,8 @@ const mod = await import(new URL(`../c4-dispatcher.js?${cacheBuster}`, import.me
 const {
   sanitizeMessage,
   getDeliveryDelay,
+  getInputBoxText,
+  checkInputBoxByText,
   findPromptY,
   isUsageOverlayCapture,
   isBypassState,
@@ -171,6 +173,62 @@ describe('findPromptY', () => {
       '  gpt-5.4 medium · 82% left · ~/zylos'             // Y=6
     ].join('\n');
     assert.equal(findPromptY(capture), 4);
+  });
+});
+
+// ── getInputBoxText / checkInputBoxByText ──────────────────────────
+
+describe('getInputBoxText', () => {
+  it('extracts Claude input text between separator lines', () => {
+    const sep = '\u2500'.repeat(24);
+    const capture = [
+      'previous output',
+      sep,
+      '❯ hello from claude',
+      sep,
+      'footer'
+    ].join('\n');
+    assert.equal(
+      getInputBoxText(capture, { runtime: 'claude' }),
+      '❯ hello from claude'
+    );
+  });
+
+  it('extracts Codex input text from prompt+footer layout', () => {
+    const capture = [
+      '• output',
+      '› hello codex',
+      '',
+      '  gpt-5.4 medium · 82% left · ~/zylos'
+    ].join('\n');
+    assert.equal(
+      getInputBoxText(capture, { runtime: 'codex' }),
+      'hello codex'
+    );
+  });
+});
+
+describe('checkInputBoxByText', () => {
+  it('returns empty for Claude empty prompt', () => {
+    const sep = '\u2500'.repeat(20);
+    const capture = [
+      'output',
+      sep,
+      '❯ ',
+      sep
+    ].join('\n');
+    assert.equal(checkInputBoxByText(capture, { runtime: 'claude' }), 'empty');
+  });
+
+  it('returns has_content for Claude non-empty prompt', () => {
+    const sep = '\u2500'.repeat(20);
+    const capture = [
+      'output',
+      sep,
+      '❯ run tests',
+      sep
+    ].join('\n');
+    assert.equal(checkInputBoxByText(capture, { runtime: 'claude' }), 'has_content');
   });
 });
 

--- a/skills/comm-bridge/scripts/c4-config.js
+++ b/skills/comm-bridge/scripts/c4-config.js
@@ -9,7 +9,7 @@ export const DELIVERY_DELAY_BASE = 200;
 export const DELIVERY_DELAY_PER_KB = 100;
 export const DELIVERY_DELAY_MAX = 1000;
 
-export const MAX_RETRIES = 5;
+export const MAX_RETRIES = 2;
 export const RETRY_BASE_MS = 500;
 export const CONTROL_MAX_RETRIES = 3;
 export const CONTROL_RETENTION_DAYS = 7;

--- a/skills/comm-bridge/scripts/c4-dispatcher.js
+++ b/skills/comm-bridge/scripts/c4-dispatcher.js
@@ -198,53 +198,22 @@ export function getDeliveryDelay(byteLength) {
   return Math.min(DELIVERY_DELAY_BASE + extra, DELIVERY_DELAY_MAX);
 }
 
-export function getInputBoxText(capture, { runtime = ACTIVE_RUNTIME } = {}) {
+export function getClaudeInputBoxText(capture) {
   const lines = capture.split('\n');
 
-  // Separator detection is Claude-only — Codex has no prompt separators.
-  if (runtime === 'claude') {
-    const separatorIndexes = [];
-    for (let i = 0; i < lines.length; i++) {
-      if (/^\u2500{10,}/.test(lines[i])) {
-        separatorIndexes.push(i);
-      }
-    }
-    if (separatorIndexes.length >= 2) {
-      const start = separatorIndexes[separatorIndexes.length - 2] + 1;
-      const end = separatorIndexes[separatorIndexes.length - 1];
-      return lines.slice(start, end).join('\n');
+  const separatorIndexes = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\u2500{10,}/.test(lines[i])) {
+      separatorIndexes.push(i);
     }
   }
-
-  const footerIndex = lines.findIndex(line =>
-    /tab to queue message/i.test(line) ||
-    /\b\d+%\s+left\s+·\s+~\//i.test(line)
-  );
-  if (footerIndex === -1) {
+  if (separatorIndexes.length < 2) {
     return null;
   }
 
-  let promptIndex = -1;
-  for (let i = footerIndex - 1; i >= 0; i--) {
-    if (/^\s*[›❯](?:\s.*)?$/.test(lines[i])) {
-      promptIndex = i;
-      break;
-    }
-  }
-
-  if (promptIndex === -1) {
-    return null;
-  }
-
-  const promptText = [lines[promptIndex].replace(/^\s*[›❯]\s?/, '')];
-  for (let i = promptIndex + 1; i < footerIndex; i++) {
-    const line = lines[i];
-    if (!line.trim()) break;
-    if (/^\s*[›❯](?:\s.*)?$/.test(line)) break;
-    promptText.push(line);
-  }
-
-  return promptText.join('\n').trimEnd();
+  const start = separatorIndexes[separatorIndexes.length - 2] + 1;
+  const end = separatorIndexes[separatorIndexes.length - 1];
+  return lines.slice(start, end).join('\n');
 }
 
 /**
@@ -263,27 +232,20 @@ export function findPromptY(capture) {
 }
 
 /**
- * Legacy separator/text parser used as a fallback for Claude runtime.
+ * Claude-only fallback parser.
  */
-export function checkInputBoxByText(capture, { runtime = ACTIVE_RUNTIME } = {}) {
-  const text = getInputBoxText(capture, { runtime });
+export function checkClaudeFallbackInputBox(capture) {
+  const text = getClaudeInputBoxText(capture);
   if (text === null) {
     return 'indeterminate';
   }
 
-  // Claude fallback: only inspect the first 10 chars to the right of the
-  // prompt symbol to avoid buddy-art variants on the far right side.
-  if (runtime === 'claude') {
-    const firstLine = text.split('\n')[0] || '';
-    const promptRight = firstLine.replace(/^\s*[›❯]/, '');
-    const window = Array.from(promptRight).slice(0, 10).join('');
-    const stripped = window.replace(/[\p{C}\p{Z}]+/gu, '');
-    return stripped.length === 0 ? 'empty' : 'has_content';
-  }
-
-  const stripped = text
-    .replace(/[›❯]/g, '')
-    .replace(/[\p{C}\p{Z}]+/gu, '');
+  // Only inspect the first 10 chars to the right of the prompt symbol
+  // to avoid buddy-art variants on the far right side.
+  const firstLine = text.split('\n')[0] || '';
+  const promptRight = firstLine.replace(/^\s*[›❯]/, '');
+  const window = Array.from(promptRight).slice(0, 10).join('');
+  const stripped = window.replace(/[\p{C}\p{Z}]+/gu, '');
 
   return stripped.length === 0 ? 'empty' : 'has_content';
 }
@@ -342,7 +304,7 @@ export function checkInputBox() {
     return cursorState;
   }
 
-  const fallbackState = checkInputBoxByText(capture, { runtime: 'claude' });
+  const fallbackState = checkClaudeFallbackInputBox(capture);
   return fallbackState === 'indeterminate' ? cursorState : fallbackState;
 }
 

--- a/skills/comm-bridge/scripts/c4-dispatcher.js
+++ b/skills/comm-bridge/scripts/c4-dispatcher.js
@@ -42,6 +42,7 @@ import {
   REQUIRE_IDLE_POST_SEND_HOLD_MS,
   REQUIRE_IDLE_EXECUTION_MAX_WAIT_MS,
   REQUIRE_IDLE_EXECUTION_POLL_MS,
+  ACTIVE_RUNTIME,
   TMUX_SESSION,
   AGENT_STATUS_FILE,
   PROC_STATE_FILE,
@@ -197,6 +198,55 @@ export function getDeliveryDelay(byteLength) {
   return Math.min(DELIVERY_DELAY_BASE + extra, DELIVERY_DELAY_MAX);
 }
 
+export function getInputBoxText(capture, { runtime = ACTIVE_RUNTIME } = {}) {
+  const lines = capture.split('\n');
+
+  // Separator detection is Claude-only — Codex has no prompt separators.
+  if (runtime === 'claude') {
+    const separatorIndexes = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (/^\u2500{10,}/.test(lines[i])) {
+        separatorIndexes.push(i);
+      }
+    }
+    if (separatorIndexes.length >= 2) {
+      const start = separatorIndexes[separatorIndexes.length - 2] + 1;
+      const end = separatorIndexes[separatorIndexes.length - 1];
+      return lines.slice(start, end).join('\n');
+    }
+  }
+
+  const footerIndex = lines.findIndex(line =>
+    /tab to queue message/i.test(line) ||
+    /\b\d+%\s+left\s+·\s+~\//i.test(line)
+  );
+  if (footerIndex === -1) {
+    return null;
+  }
+
+  let promptIndex = -1;
+  for (let i = footerIndex - 1; i >= 0; i--) {
+    if (/^\s*[›❯](?:\s.*)?$/.test(lines[i])) {
+      promptIndex = i;
+      break;
+    }
+  }
+
+  if (promptIndex === -1) {
+    return null;
+  }
+
+  const promptText = [lines[promptIndex].replace(/^\s*[›❯]\s?/, '')];
+  for (let i = promptIndex + 1; i < footerIndex; i++) {
+    const line = lines[i];
+    if (!line.trim()) break;
+    if (/^\s*[›❯](?:\s.*)?$/.test(line)) break;
+    promptText.push(line);
+  }
+
+  return promptText.join('\n').trimEnd();
+}
+
 /**
  * Find the Y coordinate (0-indexed line number) of the last prompt line
  * (starting with › or ❯) in a tmux capture string.
@@ -213,14 +263,27 @@ export function findPromptY(capture) {
 }
 
 /**
- * Unified input box state detection for both Claude and Codex runtimes.
- *
- * Primary signal: cursor_x (from tmux) — fast, no content parsing.
- * Secondary signal: when cursor_x ≤ threshold, compare cursor_y with the
- * prompt line's Y coordinate to catch multi-line wrapped input where the
- * cursor wraps to a new line at x ≤ 2.
+ * Legacy separator/text parser used as a fallback for Claude runtime.
  */
-export function checkInputBox() {
+export function checkInputBoxByText(capture, { runtime = ACTIVE_RUNTIME } = {}) {
+  const text = getInputBoxText(capture, { runtime });
+  if (text === null) {
+    return 'indeterminate';
+  }
+
+  // Strip buddy art from the right side of each line.
+  const cleaned = text.replace(/\s{10,}\S.*$/gm, '');
+  const stripped = cleaned
+    .replace(/[›❯]/g, '')
+    .replace(/[\p{C}\p{Z}]+/gu, '');
+
+  return stripped.length === 0 ? 'empty' : 'has_content';
+}
+
+/**
+ * Cursor-based detector: primary signal for all runtimes.
+ */
+export function checkInputBoxByCursor() {
   const cursorX = getCursorX();
   if (cursorX < 0) return 'indeterminate';
   if (cursorX > CURSOR_EMPTY_THRESHOLD) return 'has_content';
@@ -245,6 +308,34 @@ export function checkInputBox() {
   // If cursor is on the prompt line itself, input is empty.
   // If cursor is below the prompt line, there's wrapped multi-line content.
   return cursorY === promptY ? 'empty' : 'has_content';
+}
+
+/**
+ * Unified detector:
+ * - Codex: cursor-only.
+ * - Claude: cursor-first; if it reports has_content, fallback to text parser.
+ */
+export function checkInputBox() {
+  const cursorState = checkInputBoxByCursor();
+  if (cursorState !== 'has_content') {
+    return cursorState;
+  }
+
+  if (ACTIVE_RUNTIME !== 'claude') {
+    return cursorState;
+  }
+
+  let capture;
+  try {
+    capture = execFileSync('tmux', ['capture-pane', '-p', '-t', TMUX_SESSION], {
+      encoding: 'utf8', stdio: 'pipe', timeout: 5000
+    });
+  } catch {
+    return cursorState;
+  }
+
+  const fallbackState = checkInputBoxByText(capture, { runtime: 'claude' });
+  return fallbackState === 'indeterminate' ? cursorState : fallbackState;
 }
 
 export function isUsageOverlayCapture(capture) {

--- a/skills/comm-bridge/scripts/c4-dispatcher.js
+++ b/skills/comm-bridge/scripts/c4-dispatcher.js
@@ -271,9 +271,17 @@ export function checkInputBoxByText(capture, { runtime = ACTIVE_RUNTIME } = {}) 
     return 'indeterminate';
   }
 
-  // Strip buddy art from the right side of each line.
-  const cleaned = text.replace(/\s{10,}\S.*$/gm, '');
-  const stripped = cleaned
+  // Claude fallback: only inspect the first 10 chars to the right of the
+  // prompt symbol to avoid buddy-art variants on the far right side.
+  if (runtime === 'claude') {
+    const firstLine = text.split('\n')[0] || '';
+    const promptRight = firstLine.replace(/^\s*[›❯]/, '');
+    const window = Array.from(promptRight).slice(0, 10).join('');
+    const stripped = window.replace(/[\p{C}\p{Z}]+/gu, '');
+    return stripped.length === 0 ? 'empty' : 'has_content';
+  }
+
+  const stripped = text
     .replace(/[›❯]/g, '')
     .replace(/[\p{C}\p{Z}]+/gu, '');
 


### PR DESCRIPTION
## Summary
- add Claude-only fallback for input box verification: when cursor-based check reports has_content, re-check with separate-line text parser
- keep Codex runtime on cursor-only input detection
- reduce C4 conversation send retry limit from 5 to 2
- add unit tests for text extraction and fallback parser behavior

## Testing
- node --test skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js