### PR TITLE
chore: prepare release v0.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.13] - 2026-04-12
+
+### Fixed
+- **C4 dispatcher: Claude input-box fallback detection**: when running under the Claude runtime, the cursor-only input-box probe can misreport `has_content` due to a known tmux cursor-Y quirk with wrapped input. `checkInputBox()` now falls back to a text-window parser (`checkClaudeFallbackInputBox`) that reads the 10 characters to the right of the prompt marker to disambiguate. The Codex runtime path is unchanged (cursor-only). (#493)
+
+### Changed
+- **C4 send retry reduced from 5 to 2**: repeated send retries past 2 attempts almost always indicated a stuck input state rather than a transient failure, so the outer `MAX_RETRIES` budget has been cut to fail faster and surface real delivery problems sooner. (#493)
+
 ## [0.4.12] - 2026-04-08
 
 > **⚠️ UPGRADE STRONGLY RECOMMENDED for all instances.** This release hardens temporary directory handling across all upgrade paths. Previous versions could fail silently or leave orphaned temp directories when the system tmpdir was not writable, and the `--temp-dir` flag created a fragile cross-step state that risked accidental directory deletion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary

Release **v0.4.13** — ships the C4 Claude input-box fallback detection and send-retry reduction from PR #493.

### Fixed
- **C4 dispatcher: Claude input-box fallback detection** — under the Claude runtime, the cursor-only input-box probe can misreport `has_content` due to a known tmux cursor-Y quirk with wrapped input. `checkInputBox()` now falls back to `checkClaudeFallbackInputBox()`, which reads the 10 characters to the right of the prompt marker to disambiguate. Codex runtime path is unchanged. (#493)

### Changed
- **C4 send retry reduced 5 → 2** — repeated retries past 2 attempts almost always indicated a stuck input state rather than a transient failure, so the outer `MAX_RETRIES` budget has been cut to fail faster and surface real delivery problems sooner. (#493)

## Test plan
- [x] `npm test` — jest: 77/77 passed, node:test: 67/67 passed
- [x] Manual runtime verification on Claude runtime (wait=0ms + forced has_content on attempt 0) — fallback code paths executed as expected, logs confirmed `checkClaudeFallbackInputBox` runs in parallel with cursor probe and converges to `empty` after Claude clears the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)