### PR TITLE
docs: add Node.js dependency note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ This works from Windows, ChromeOS, or any platform that can run Claude Code loca
 
 </details>
 
+> **Node.js note:** If your system already has Node.js installed, Zylos will use it instead of installing its own. This means npm packages (including Zylos itself) are tied to that Node.js installation. If you later upgrade or change your system Node.js version (e.g. via nvm), globally installed packages may disappear. In that case, simply reinstall: `npm install -g --install-links https://github.com/zylos-ai/zylos-core`
+
 `zylos init` is idempotent and supports both interactive and non-interactive modes. It will:
 1. Install missing tools (tmux, git, PM2, Claude Code or Codex)
 2. Set up authentication (Claude: browser login, API key, or [setup token](https://code.claude.com/docs/en/authentication); Codex: API key or device auth)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,14 @@ This works from Windows, ChromeOS, or any platform that can run Claude Code loca
 
 </details>
 
-> **Node.js note:** If your system already has Node.js installed, Zylos will use it instead of installing its own. This means npm packages (including Zylos itself) are tied to that Node.js installation. If you later upgrade or change your system Node.js version (e.g. via nvm), globally installed packages may disappear. In that case, simply reinstall: `npm install -g --install-links https://github.com/zylos-ai/zylos-core`
+> **Node.js requirement:** Zylos requires Node.js 20 or later. We recommend installing via [nvm](https://github.com/nvm-sh/nvm) — the install script does this automatically. If you manage Node.js yourself, make sure to use a single, stable version and avoid switching versions after installation, as globally installed npm packages (including Zylos) are tied to the Node.js version that installed them.
+>
+> ```bash
+> # Recommended: let the install script handle it, or install manually via nvm
+> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+> nvm install 24
+> nvm alias default 24
+> ```
 
 `zylos init` is idempotent and supports both interactive and non-interactive modes. It will:
 1. Install missing tools (tmux, git, PM2, Claude Code or Codex)

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This works from Windows, ChromeOS, or any platform that can run Claude Code loca
 >
 > ```bash
 > # Recommended: let the install script handle it, or install manually via nvm
-> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
 > nvm install 24
 > nvm alias default 24
 > ```

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This works from Windows, ChromeOS, or any platform that can run Claude Code loca
 >
 > ```bash
 > # Recommended: let the install script handle it, or install manually via nvm
-> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
+> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 > nvm install 24
 > nvm alias default 24
 > ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,6 +170,8 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 
 </details>
 
+> **Node.js 注意事项：** 如果你的系统已经安装了 Node.js，Zylos 会直接使用它，而不会另外安装。这意味着 npm 包（包括 Zylos 本身）与当前 Node.js 版本绑定。如果之后升级或切换了 Node.js 版本（例如通过 nvm），全局安装的包可能会丢失。遇到这种情况，重新安装即可：`npm install -g --install-links https://github.com/zylos-ai/zylos-core`
+
 `zylos init` 可重复运行，支持交互式和非交互式两种模式。它会：
 1. 安装缺失的工具（tmux、git、PM2、Claude Code 或 Codex）
 2. 配置认证（Claude：浏览器登录、API key 或 [setup token](https://code.claude.com/docs/en/authentication)；Codex：API key 或 device auth）

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,7 +174,7 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 >
 > ```bash
 > # 推荐：让安装脚本自动处理，或通过 nvm 手动安装
-> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
 > nvm install 24
 > nvm alias default 24
 > ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,7 +174,7 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 >
 > ```bash
 > # 推荐：让安装脚本自动处理，或通过 nvm 手动安装
-> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
+> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 > nvm install 24
 > nvm alias default 24
 > ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,7 +170,14 @@ curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/in
 
 </details>
 
-> **Node.js 注意事项：** 如果你的系统已经安装了 Node.js，Zylos 会直接使用它，而不会另外安装。这意味着 npm 包（包括 Zylos 本身）与当前 Node.js 版本绑定。如果之后升级或切换了 Node.js 版本（例如通过 nvm），全局安装的包可能会丢失。遇到这种情况，重新安装即可：`npm install -g --install-links https://github.com/zylos-ai/zylos-core`
+> **Node.js 要求：** Zylos 需要 Node.js 20 或更高版本。推荐通过 [nvm](https://github.com/nvm-sh/nvm) 安装 — 安装脚本会自动完成。如果你自行管理 Node.js，请使用固定版本，避免安装后切换版本，因为全局 npm 包（包括 Zylos）与安装时的 Node.js 版本绑定。
+>
+> ```bash
+> # 推荐：让安装脚本自动处理，或通过 nvm 手动安装
+> curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+> nvm install 24
+> nvm alias default 24
+> ```
 
 `zylos init` 可重复运行，支持交互式和非交互式两种模式。它会：
 1. 安装缺失的工具（tmux、git、PM2、Claude Code 或 Codex）


### PR DESCRIPTION
## Summary
- Added a note to both EN and zh-CN READMEs explaining that npm packages (including Zylos) are tied to the system Node.js version
- If users upgrade/switch Node.js (e.g. via nvm), globally installed packages may disappear
- Includes reinstall command for recovery

Context: discussed in zylos.ai Lark group — users hitting this issue when their environment already has Node.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)