### PR TITLE
fix: deduplicate PATH to prevent bloat across restarts

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -154,6 +154,10 @@ function ensureLocalBinInProfile() {
  */
 function saveSystemPath(envPath) {
   const currentPath = process.env.PATH || '';
+  // Deduplicate PATH entries before saving — prevents bloat when zylos init
+  // runs while PM2 is already live (process.env.PATH may already contain
+  // the previous ENHANCED_PATH from ecosystem.config.cjs).
+  const dedupedPath = [...new Set(currentPath.split(':').filter(Boolean))].join(':');
   let content = '';
   try {
     content = fs.readFileSync(envPath, 'utf8');
@@ -161,7 +165,7 @@ function saveSystemPath(envPath) {
     return; // .env doesn't exist yet
   }
 
-  const line = `SYSTEM_PATH=${currentPath}`;
+  const line = `SYSTEM_PATH=${dedupedPath}`;
   if (content.includes('SYSTEM_PATH=')) {
     content = content.replace(/^SYSTEM_PATH=.*$/m, line);
   } else {

--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -276,7 +276,8 @@ export class ClaudeAdapter extends RuntimeAdapter {
       await this.sendMessage(cmd);
     } else {
       // New tmux session
-      const tmuxArgs = ['new-session', '-d', '-s', SESSION, '-e', `PATH=${process.env.PATH}`];
+      const dedupedPath = [...new Set((process.env.PATH || '').split(':').filter(Boolean))].join(':');
+      const tmuxArgs = ['new-session', '-d', '-s', SESSION, '-e', `PATH=${dedupedPath}`];
       if (process.getuid?.() === 0) tmuxArgs.push('-e', 'IS_SANDBOX=1');
 
       let shellCmd;

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -300,7 +300,8 @@ export class CodexAdapter extends RuntimeAdapter {
         : `cd "${ZYLOS_DIR}"; ${codexCmd}; ${exitLogSnippet}`;
       await this.sendMessage(cmd);
     } else {
-      const tmuxArgs = ['new-session', '-d', '-s', SESSION, '-e', `PATH=${process.env.PATH}`];
+      const dedupedPath = [...new Set((process.env.PATH || '').split(':').filter(Boolean))].join(':');
+      const tmuxArgs = ['new-session', '-d', '-s', SESSION, '-e', `PATH=${dedupedPath}`];
       if (process.getuid?.() === 0) tmuxArgs.push('-e', 'IS_SANDBOX=1');
 
       const promptSnippet = tmpPrompt

--- a/templates/pm2/ecosystem.config.cjs
+++ b/templates/pm2/ecosystem.config.cjs
@@ -29,12 +29,15 @@ function readEnvValue(key, defaultValue = '') {
 }
 
 // Build PATH: Claude locations + user's full shell PATH + PM2's own PATH
-const ENHANCED_PATH = [
+// Deduplicate to prevent PATH bloat across PM2 restarts — each restart
+// re-evaluates this file with process.env.PATH already containing the
+// previous ENHANCED_PATH, which would otherwise compound indefinitely.
+const ENHANCED_PATH = [...new Set([
   path.join(HOME, '.local', 'bin'),
   path.join(HOME, '.claude', 'bin'),
-  readEnvValue('SYSTEM_PATH'),
-  process.env.PATH
-].filter(Boolean).join(':');
+  ...(readEnvValue('SYSTEM_PATH') || '').split(':').filter(Boolean),
+  ...(process.env.PATH || '').split(':').filter(Boolean),
+])].join(':');
 
 // Whether Claude should run with --dangerously-skip-permissions
 const CLAUDE_BYPASS_PERMISSIONS = readEnvValue('CLAUDE_BYPASS_PERMISSIONS', 'true');


### PR DESCRIPTION
PATH grows from ~17 unique entries to 189+ through a 4-layer compounding cycle:

1. ecosystem.config.cjs builds ENHANCED_PATH by concatenating SYSTEM_PATH + process.env.PATH without dedup. Each PM2 restart re-evaluates this file, and process.env.PATH already contains the previous ENHANCED_PATH — compounding on every restart.

2. saveSystemPath() in init.js snapshots process.env.PATH to .env as SYSTEM_PATH. If PATH is already bloated when zylos init runs, the bloated value gets persisted and fed back into (1).

3. claude.js and codex.js pass process.env.PATH directly to tmux via -e PATH=..., propagating the bloated PATH into the runtime session where shell profiles add yet another layer.

Fix: add [...new Set()] deduplication at all three points — ENHANCED_PATH construction, SYSTEM_PATH persistence, and tmux PATH pass-through. Preserves entry order (first occurrence wins).

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
