### PR TITLE
fix(upgrade): back up dataDir before upgrade

### DIFF
--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -570,12 +570,21 @@ export function rollback(ctx) {
       results.push({ action: 'restore_files', success: false, error: err.message });
     }
 
-    // Restore dataDir from backup
+    // Restore dataDir from backup (symmetric: delete files not in backup, then copy back)
     const dataBackupDir = path.join(ctx.backupDir, '_datadir');
     if (ctx.dataDir && fs.existsSync(dataBackupDir)) {
       try {
-        const entries = fs.readdirSync(dataBackupDir);
-        for (const entry of entries) {
+        fs.mkdirSync(ctx.dataDir, { recursive: true });
+        const backedUpFiles = new Set(fs.readdirSync(dataBackupDir));
+        // Remove top-level files added by the failed upgrade (not in backup)
+        for (const entry of fs.readdirSync(ctx.dataDir)) {
+          const entryPath = path.join(ctx.dataDir, entry);
+          if (!backedUpFiles.has(entry) && fs.statSync(entryPath).isFile()) {
+            fs.unlinkSync(entryPath);
+          }
+        }
+        // Restore backed-up files
+        for (const entry of backedUpFiles) {
           fs.copyFileSync(path.join(dataBackupDir, entry), path.join(ctx.dataDir, entry));
         }
         results.push({ action: 'restore_data', success: true });

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -383,6 +383,7 @@ function step1_stopService(ctx) {
 
 /**
  * Step 2: filesystem backup to .backup/<timestamp>/
+ * Backs up both skillDir (source code) and dataDir (runtime data: databases, config).
  */
 function step2_backup(ctx) {
   const startTime = Date.now();
@@ -391,6 +392,21 @@ function step2_backup(ctx) {
 
   try {
     copyTree(ctx.skillDir, backupDir, { excludes: ['node_modules', '.backup', '.zylos'] });
+
+    // Back up dataDir (databases, config, credentials) if it exists and differs from skillDir
+    if (ctx.dataDir && fs.existsSync(ctx.dataDir) && fs.realpathSync(ctx.dataDir) !== fs.realpathSync(ctx.skillDir)) {
+      const dataBackupDir = path.join(backupDir, '_datadir');
+      fs.mkdirSync(dataBackupDir, { recursive: true });
+      const entries = fs.readdirSync(ctx.dataDir);
+      for (const entry of entries) {
+        const srcPath = path.join(ctx.dataDir, entry);
+        const stat = fs.statSync(srcPath);
+        // Back up files (db, json, config) and small directories; skip large dirs like node_modules, resumes, logs
+        if (stat.isFile()) {
+          fs.copyFileSync(srcPath, path.join(dataBackupDir, entry));
+        }
+      }
+    }
 
     ctx.backupDir = backupDir;
     return { step: 2, name: 'backup', status: 'done', message: path.basename(backupDir), duration: Date.now() - startTime };
@@ -548,10 +564,24 @@ export function rollback(ctx) {
   // Restore files from backup (--delete removes files added by the failed upgrade)
   if (ctx.backupDir && fs.existsSync(ctx.backupDir)) {
     try {
-      syncTree(ctx.backupDir, ctx.skillDir, { excludes: ['node_modules', '.backup', '.zylos'] });
+      syncTree(ctx.backupDir, ctx.skillDir, { excludes: ['node_modules', '.backup', '.zylos', '_datadir'] });
       results.push({ action: 'restore_files', success: true });
     } catch (err) {
       results.push({ action: 'restore_files', success: false, error: err.message });
+    }
+
+    // Restore dataDir from backup
+    const dataBackupDir = path.join(ctx.backupDir, '_datadir');
+    if (ctx.dataDir && fs.existsSync(dataBackupDir)) {
+      try {
+        const entries = fs.readdirSync(dataBackupDir);
+        for (const entry of entries) {
+          fs.copyFileSync(path.join(dataBackupDir, entry), path.join(ctx.dataDir, entry));
+        }
+        results.push({ action: 'restore_data', success: true });
+      } catch (err) {
+        results.push({ action: 'restore_data', success: false, error: err.message });
+      }
     }
 
     // Restore dependencies


### PR DESCRIPTION
## Summary

- `step2_backup` now copies all files from `dataDir` (`~/zylos/components/<name>/`) into `_datadir/` within the backup directory
- `rollback()` restores `dataDir` files alongside source code when an upgrade fails
- Only backs up top-level files in dataDir (skips subdirectories like `resumes/`, `logs/` to keep backup size reasonable)

## Context

During a Recruit ATS upgrade (v0.2.7 → v0.2.8), a migration bug triggered CASCADE DELETE on the production SQLite database, destroying all data. Because `dataDir` was not backed up, the data was unrecoverable. See #502 for full incident details.

## Test plan

- [ ] Upgrade a component that has a dataDir with a `.db` file — verify `_datadir/` appears in `.backup/<timestamp>/`
- [ ] Force a failed upgrade (e.g., bad post-install hook) — verify rollback restores the `.db` file
- [ ] Upgrade a component with no dataDir — verify no error, backup completes normally
- [ ] Verify `cleanOldBackups` still works (only latest backup retained)

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)