### PR TITLE
fix: propagate stream-watchdog env vars from .env to Claude subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.14] - 2026-04-20
+
+### Fixed
+- **Claude launcher: propagate stream-watchdog env vars from `.env`**: the activity-monitor stream watchdog added in #500 is gated on `CLAUDE_ENABLE_STREAM_WATCHDOG` / `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, but `ClaudeAdapter.launch()` previously only forwarded `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_BASE_URL` from `.env` and dropped everything else. Setting the watchdog vars in `.env` therefore had no effect — the Claude subprocess never saw them. `launch()` now reads these two vars from `.env` and splices them into the shared `claudeCmd` via the existing `env` invocation, so they reach Claude in both the new-session and existing-session launch paths.
+
 ## [0.4.13] - 2026-04-12
 
 ### Fixed

--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -259,12 +259,28 @@ export class ClaudeAdapter extends RuntimeAdapter {
       if (oauthTokenValue) _approveApiKey(oauthTokenValue);
     }
 
+    // Propagate the two activity-monitor stream-watchdog config vars from
+    // .env to the Claude subprocess. Not secrets, so passed inline on the
+    // `env` command — which reaches both the new-session and existing-session
+    // launch paths via the shared claudeCmd below.
+    let streamWatchdogEnable = '';
+    let streamWatchdogTimeoutMs = '';
+    try {
+      const envContent = fs.readFileSync(path.join(ZYLOS_DIR, '.env'), 'utf8');
+      streamWatchdogEnable = _parseEnvValue(envContent, 'CLAUDE_ENABLE_STREAM_WATCHDOG');
+      streamWatchdogTimeoutMs = _parseEnvValue(envContent, 'CLAUDE_STREAM_IDLE_TIMEOUT_MS');
+    } catch { }
+    const watchdogEnvFlags = [
+      streamWatchdogEnable ? ` CLAUDE_ENABLE_STREAM_WATCHDOG='${streamWatchdogEnable}'` : '',
+      streamWatchdogTimeoutMs ? ` CLAUDE_STREAM_IDLE_TIMEOUT_MS='${streamWatchdogTimeoutMs}'` : '',
+    ].join('');
+
     // 4. Build the shell command
     const bypassFlag = bypassPermissions ? ' --dangerously-skip-permissions' : '';
     const envStripFlags = hasNativeAuth
       ? ' -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY'
       : '';
-    const claudeCmd = `${ENV_CLEAN_PREFIX}${envStripFlags} ${CLAUDE_BIN}${bypassFlag}`;
+    const claudeCmd = `${ENV_CLEAN_PREFIX}${envStripFlags}${watchdogEnvFlags} ${CLAUDE_BIN}${bypassFlag}`;
 
     const monitorDir = path.join(ZYLOS_DIR, 'activity-monitor');
     const exitLogFile = path.join(monitorDir, 'claude-exit.log');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
The activity-monitor stream watchdog added in #500 is gated on two env vars (`CLAUDE_ENABLE_STREAM_WATCHDOG`, `CLAUDE_STREAM_IDLE_TIMEOUT_MS`). Setting them in `~/zylos/.env` had no effect in practice because `ClaudeAdapter.launch()` only copies three specific auth-related vars (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_BASE_URL`) from `.env` into the Claude subprocess and silently drops everything else — so the watchdog never activated at runtime even when the user had configured it.

Minimal fix: read the two watchdog vars from `.env` and splice them, when set, into the shared `claudeCmd` via the existing `env` invocation. Because both launch paths (new-session and existing-session) build on `claudeCmd`, this single change covers both paths without introducing a generic whitelist mechanism.

The values are not secrets (a boolean flag and a timeout in ms), so passing them inline in the `env` command is appropriate — they do not need the tmpEnv file treatment reserved for auth tokens.

Bumps version to 0.4.14.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
