### PR TITLE
Fix settings hook migration for existing matcher groups

### DIFF
--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -282,3 +282,138 @@ describe('Boolean setting migration hints (autoMemoryEnabled, autoDreamEnabled)'
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+function makeHook(scriptPath, timeout = 10000) {
+  return { type: 'command', command: `node ${scriptPath}`, timeout };
+}
+
+function makeMatcherGroup(matcher, scriptPaths) {
+  return {
+    matcher,
+    hooks: scriptPaths.map(p => makeHook(p)),
+  };
+}
+
+describe('settings hook migration hints', () => {
+  it('detects missing hooks inside the corresponding matcher group', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-hook-hints-'));
+    const templatesDir = path.join(tmpDir, 'templates');
+    const zylosDir = path.join(tmpDir, 'zylos');
+
+    fs.mkdirSync(path.join(templatesDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+
+    const hookA = '~/zylos/.claude/skills/activity-monitor/scripts/a.js';
+    const hookB = '~/zylos/.claude/skills/activity-monitor/scripts/b.js';
+    fs.writeFileSync(path.join(templatesDir, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [
+          makeMatcherGroup('startup', [hookA, hookB]),
+          makeMatcherGroup('clear', [hookA, hookB]),
+        ],
+      },
+    }), 'utf8');
+    fs.writeFileSync(path.join(zylosDir, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [
+          makeMatcherGroup('startup', [hookA]),
+          makeMatcherGroup('clear', [hookA, hookB]),
+        ],
+      },
+    }), 'utf8');
+
+    const hints = generateMigrationHints(templatesDir, { zylosDir });
+    const missing = hints.filter((hint) => hint.type === 'missing_hook');
+
+    assert.deepEqual(missing.map((hint) => ({
+      event: hint.event,
+      matcher: hint.matcher,
+      command: hint.command,
+    })), [{
+      event: 'SessionStart',
+      matcher: 'startup',
+      command: `node ${hookB}`,
+    }]);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('applies removed-hook hints only to the hinted matcher group', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-hook-remove-hints-'));
+    const templatesDir = path.join(tmpDir, 'templates');
+    const zylosDir = path.join(tmpDir, 'zylos');
+    const settingsPath = path.join(zylosDir, '.claude', 'settings.json');
+
+    fs.mkdirSync(path.join(templatesDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+
+    const hookA = '~/zylos/.claude/skills/activity-monitor/scripts/a.js';
+    fs.writeFileSync(path.join(templatesDir, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [
+          makeMatcherGroup('startup', [hookA]),
+          makeMatcherGroup('clear', []),
+        ],
+      },
+    }), 'utf8');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          makeMatcherGroup('startup', [hookA]),
+          makeMatcherGroup('clear', [hookA]),
+        ],
+      },
+    }) + '\n', 'utf8');
+
+    const hints = generateMigrationHints(templatesDir, { zylosDir });
+    assert.deepEqual(hints.filter((hint) => hint.type === 'removed_hook').map((hint) => ({
+      matcher: hint.matcher,
+      command: hint.command,
+    })), [{
+      matcher: 'clear',
+      command: `node ${hookA}`,
+    }]);
+
+    const result = applyMigrationHints(hints, { zylosDir });
+    const updated = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+
+    assert.equal(result.applied, 1);
+    assert.equal(updated.hooks.SessionStart.length, 1);
+    assert.equal(updated.hooks.SessionStart[0].matcher, 'startup');
+    assert.equal(updated.hooks.SessionStart[0].hooks[0].command, `node ${hookA}`);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not duplicate stale missing-hook hints during apply', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-hook-stale-hints-'));
+    const zylosDir = path.join(tmpDir, 'zylos');
+    const settingsPath = path.join(zylosDir, '.claude', 'settings.json');
+
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+
+    const hookA = '~/zylos/.claude/skills/activity-monitor/scripts/a.js';
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          makeMatcherGroup('startup', [hookA]),
+        ],
+      },
+    }) + '\n', 'utf8');
+
+    const result = applyMigrationHints([{
+      type: 'missing_hook',
+      event: 'SessionStart',
+      matcher: 'startup',
+      hook: makeHook(hookA),
+      command: `node ${hookA}`,
+    }], { zylosDir });
+    const updated = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+
+    assert.equal(result.applied, 0);
+    assert.equal(updated.hooks.SessionStart[0].hooks.length, 1);
+    assert.equal(updated.hooks.SessionStart[0].hooks[0].command, `node ${hookA}`);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -454,13 +454,14 @@ describe('migrateMatcherSplit', () => {
 describe('syncHooks forward pass', () => {
   const noopLog = () => {};
 
-  it('does not modify user-owned matcher group (respects user intent)', () => {
+  it('adds missing template hooks to an existing matcher group and preserves user hooks', () => {
     const installed = {
       hooks: {
         SessionStart: [
           makeMatcherGroup('startup', [
             '~/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js',
             '~/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js',
+            '/custom/user-startup-hook.js',
           ]),
         ],
       },
@@ -489,9 +490,12 @@ describe('syncHooks forward pass', () => {
 
     const result = syncHooks(installed, template, { log: noopLog });
 
-    // startup should NOT gain a 3rd hook
+    assert.equal(result.added, 7);
+
     const startupGroup = installed.hooks.SessionStart.find(g => g.matcher === 'startup');
-    assert.equal(startupGroup.hooks.length, 2);
+    assert.equal(startupGroup.hooks.length, 4);
+    assert.ok(startupGroup.hooks.some(h => h.command.includes('session-start-prompt.js')));
+    assert.ok(startupGroup.hooks.some(h => h.command.includes('user-startup-hook.js')));
 
     // clear and compact should be added
     assert.equal(installed.hooks.SessionStart.length, 3);
@@ -544,6 +548,61 @@ describe('syncHooks forward pass', () => {
 
     assert.equal(result.updated, 1);
     assert.equal(installed.hooks.SessionStart[0].hooks[0].timeout, 10000);
+  });
+
+  it('backfills hooks added after v0.4.13 into existing historical settings', () => {
+    const template = JSON.parse(fs.readFileSync(TEMPLATE_SETTINGS_PATH, 'utf8'));
+    const installed = structuredClone(template);
+
+    for (const group of installed.hooks.SessionStart) {
+      group.hooks = group.hooks.filter(h => !h.command.includes('session-foreground.js'));
+    }
+    delete installed.hooks.PostToolUseFailure;
+    installed.hooks.SessionStart[0].hooks.push({
+      type: 'command',
+      command: 'node /custom/user-startup-hook.js',
+      timeout: 1234,
+    });
+
+    const result = syncHooks(installed, template, { log: noopLog });
+
+    assert.equal(result.added, 4);
+    for (const group of installed.hooks.SessionStart) {
+      assert.ok(
+        group.hooks.some(h => h.command.includes('session-foreground.js')),
+        `${group.matcher} should include session-foreground.js`
+      );
+    }
+    assert.ok(installed.hooks.PostToolUseFailure);
+    assert.ok(
+      installed.hooks.SessionStart[0].hooks.some(h => h.command.includes('user-startup-hook.js'))
+    );
+  });
+
+  it('dry run reports missing hooks in existing matcher groups without mutating settings', () => {
+    const installed = {
+      hooks: {
+        SessionStart: [
+          makeMatcherGroup('startup', ['~/zylos/.claude/skills/a/scripts/a.js']),
+        ],
+      },
+    };
+    const before = JSON.stringify(installed);
+    const template = {
+      hooks: {
+        SessionStart: [
+          makeMatcherGroup('startup', [
+            '~/zylos/.claude/skills/a/scripts/a.js',
+            '~/zylos/.claude/skills/b/scripts/b.js',
+          ]),
+        ],
+      },
+    };
+
+    const result = syncHooks(installed, template, { dryRun: true, log: noopLog });
+
+    assert.equal(result.added, 1);
+    assert.equal(JSON.stringify(installed), before);
   });
 
   it('handles the full migration scenario: catch-all → specific matchers', () => {
@@ -612,7 +671,7 @@ describe('syncHooks forward pass', () => {
     assert.equal(result.removed, 0);
   });
 
-  it('reverse pass preserves user hooks not in template', () => {
+  it('preserves user hooks while adding missing template hooks', () => {
     const installed = {
       hooks: {
         SessionStart: [
@@ -632,10 +691,10 @@ describe('syncHooks forward pass', () => {
 
     syncHooks(installed, template, { log: noopLog });
 
-    // User's custom hook should still be there (startup group exists, not modified)
     const startupGroup = installed.hooks.SessionStart.find(g => g.matcher === 'startup');
-    assert.equal(startupGroup.hooks.length, 1);
-    assert.ok(startupGroup.hooks[0].command.includes('my-hook.js'));
+    assert.equal(startupGroup.hooks.length, 2);
+    assert.ok(startupGroup.hooks.some(h => h.command.includes('my-hook.js')));
+    assert.ok(startupGroup.hooks.some(h => h.command.includes('/skills/a/scripts/a.js')));
   });
 
   it('reverse pass removes core hook from one matcher when template removes it (matcher-aware)', () => {

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -389,6 +389,10 @@ function listTemplateFiles(templatesDir) {
   return files;
 }
 
+function hookMatcherValue(group) {
+  return group && group.matcher !== undefined ? group.matcher : null;
+}
+
 /**
  * Compare template settings.json hooks with installed settings.json.
  * Matches hooks by script path (not full command string) to detect:
@@ -442,24 +446,24 @@ export function generateMigrationHints(templatesDir, deps = {}) {
     const installedMatchers = Array.isArray(installedHooks[event]) ? installedHooks[event] : [];
 
     for (const matcher of matchers) {
+      const matcherValue = hookMatcherValue(matcher);
+      const installedGroup = installedMatchers.find(
+        im => hookMatcherValue(im) === matcherValue
+      );
+      const installedGroupHooks = installedGroup ? getCommandHooks(installedGroup) : [];
+
       for (const templateCmd of getCommandHooks(matcher)) {
         const templateKey = extractScriptPath(templateCmd.command);
-
-        // Find installed hook with the same script path
-        let matched = null;
-        for (const im of installedMatchers) {
-          matched = getCommandHooks(im).find(
-            h => extractScriptPath(h.command) === templateKey
-          );
-          if (matched) break;
-        }
+        const matched = installedGroupHooks.find(
+          h => extractScriptPath(h.command) === templateKey
+        );
 
         if (!matched) {
           hints.push({
             type: 'missing_hook',
             event,
             hook: { ...templateCmd },
-            matcher: matcher.matcher !== undefined ? matcher.matcher : null,
+            matcher: matcherValue,
             // Keep flat fields for backward compatibility
             command: templateCmd.command,
             timeout: templateCmd.timeout,
@@ -469,6 +473,7 @@ export function generateMigrationHints(templatesDir, deps = {}) {
             type: 'modified_hook',
             event,
             hook: { ...templateCmd },
+            matcher: matcherValue,
             command: templateCmd.command,
             timeout: templateCmd.timeout,
             oldCommand: matched.command,
@@ -520,6 +525,11 @@ export function generateMigrationHints(templatesDir, deps = {}) {
     const templateMatchers = Array.isArray(templateHooks[event]) ? templateHooks[event] : [];
 
     for (const matcher of matchers) {
+      const matcherValue = hookMatcherValue(matcher);
+      const correspondingTemplate = templateMatchers.find(
+        tm => hookMatcherValue(tm) === matcherValue
+      );
+
       for (const installedCmd of getCommandHooks(matcher)) {
         // Only flag hooks from core skills to avoid false positives
         // for optional component hooks
@@ -527,16 +537,17 @@ export function generateMigrationHints(templatesDir, deps = {}) {
         if (!skillName || !coreSkillNames.has(skillName)) continue;
 
         const installedKey = extractScriptPath(installedCmd.command);
-        const foundInTemplate = templateMatchers.some(tm =>
-          getCommandHooks(tm).some(
-            h => extractScriptPath(h.command) === installedKey
-          )
-        );
+        const foundInTemplate = correspondingTemplate
+          ? getCommandHooks(correspondingTemplate).some(
+              h => extractScriptPath(h.command) === installedKey
+            )
+          : false;
 
         if (!foundInTemplate) {
           hints.push({
             type: 'removed_hook',
             event,
+            matcher: matcherValue,
             command: installedCmd.command,
             timeout: installedCmd.timeout,
           });
@@ -910,20 +921,21 @@ export function applyMigrationHints(hints, deps = {}) {
 
         // Find or create a matcher group
         const matcherValue = hint.matcher !== undefined ? hint.matcher : null;
-        let targetGroup = null;
-
-        if (matcherValue !== null) {
-          // Look for an existing group with this matcher
-          targetGroup = settings.hooks[hint.event].find(
-            g => g.matcher === matcherValue
-          );
-        }
+        let targetGroup = settings.hooks[hint.event].find(
+          g => hookMatcherValue(g) === matcherValue
+        );
 
         if (!targetGroup) {
           targetGroup = { hooks: [] };
           if (matcherValue !== null) targetGroup.matcher = matcherValue;
           settings.hooks[hint.event].push(targetGroup);
         }
+
+        const hookKey = extractScriptPath(hookObj.command);
+        const alreadyPresent = getCommandHooks(targetGroup).some(
+          h => extractScriptPath(h.command) === hookKey
+        );
+        if (alreadyPresent) continue;
 
         targetGroup.hooks.push(hookObj);
         result.applied++;
@@ -934,9 +946,11 @@ export function applyMigrationHints(hints, deps = {}) {
         if (!Array.isArray(matchers)) continue;
 
         const oldScriptPath = extractScriptPath(hint.oldCommand);
+        const hasMatcher = Object.hasOwn(hint, 'matcher');
         let updated = false;
 
         for (const group of matchers) {
+          if (hasMatcher && hookMatcherValue(group) !== hint.matcher) continue;
           if (!Array.isArray(group.hooks)) continue;
           for (let i = 0; i < group.hooks.length; i++) {
             const h = group.hooks[i];
@@ -983,10 +997,12 @@ export function applyMigrationHints(hints, deps = {}) {
         if (!Array.isArray(matchers)) continue;
 
         const scriptPath = extractScriptPath(hint.command);
+        const hasMatcher = Object.hasOwn(hint, 'matcher');
         let removed = false;
 
         for (let gi = matchers.length - 1; gi >= 0; gi--) {
           const group = matchers[gi];
+          if (hasMatcher && hookMatcherValue(group) !== hint.matcher) continue;
           if (!Array.isArray(group.hooks)) continue;
 
           group.hooks = group.hooks.filter(h => {

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -174,10 +174,10 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
     updated += migrated;
   }
 
-  // --- Forward pass: add missing matcher groups, update hooks in matched groups ---
+  // --- Forward pass: add missing matcher groups/hooks, update hooks in matched groups ---
   // Strategy: align by matcher group, not by individual hook across all groups.
-  //   - If installed has a group with the same matcher → respect user config, only
-  //     update existing hooks (command/timeout drift) but don't add new hooks
+  //   - If installed has a group with the same matcher → update existing template
+  //     hooks and append missing template hooks, preserving unrelated user hooks
   //   - If installed has NO group with that matcher → add the whole group from template
   for (const [event, matchers] of Object.entries(templateHooks)) {
     if (!Array.isArray(matchers)) continue;
@@ -193,7 +193,8 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
       );
 
       if (installedGroup) {
-        // Group exists — only update existing hooks (command/timeout drift)
+        // Group exists — update existing template hooks and append missing
+        // template hooks while preserving unrelated user hooks in the group.
         for (const templateCmd of getCommandHooks(templateGroup)) {
           const templateKey = extractScriptPath(templateCmd.command);
           const existing = getCommandHooks(installedGroup).find(
@@ -206,6 +207,13 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
             }
             updated++;
             log(`  ~ ${event}[${matcherValue}]: ${templateCmd.command}`);
+          } else if (!existing) {
+            if (!dryRun) {
+              if (!Array.isArray(installedGroup.hooks)) installedGroup.hooks = [];
+              installedGroup.hooks.push({ ...templateCmd });
+            }
+            added++;
+            log(`  + ${event}[${matcherValue}]: ${templateCmd.command}`);
           }
         }
       } else {

--- a/docs/settings-hook-migration-fix.md
+++ b/docs/settings-hook-migration-fix.md
@@ -1,0 +1,131 @@
+# Settings Hook Migration Fix
+
+## Problem Confirmation
+
+Latest `main` at `330dd9e` contains a reproducible migration gap for
+`~/zylos/.claude/settings.json`.
+
+The current template adds `session-foreground.js` to each `SessionStart`
+matcher group. A user upgrading from `v0.4.13` already has the
+`startup`, `clear`, and `compact` matcher groups, but those groups do not
+contain `session-foreground.js`.
+
+Current `syncHooks()` aligns by matcher group and, when a group already
+exists, only updates hooks that are already present. It does not add newly
+introduced core hooks into that existing matcher group. Reproducing with
+the real `v0.4.13` template as installed settings and current `main` as
+the desired template produced:
+
+```json
+{
+  "result": { "added": 1, "updated": 0, "removed": 0 },
+  "foregroundMissing": ["startup", "clear", "compact"],
+  "postToolUseFailureAdded": true
+}
+```
+
+This confirms that the new `PostToolUseFailure` event is added because the
+event group is missing, while `session-foreground.js` is skipped because
+the containing `SessionStart` matcher groups already exist.
+
+## Root Cause
+
+The matcher-aware forward pass was introduced to avoid an older bug where
+hooks were matched across all matcher groups, causing missing groups such
+as `clear` and `compact` to be skipped. That fix intentionally stopped
+adding hooks to an existing matcher group to respect user config.
+
+That rule is too broad for template-owned Zylos core hooks. It treats a
+normal older Zylos matcher group as fully user-owned, so new core hooks in
+the same matcher group never migrate.
+
+The legacy self-upgrade fallback path has a related weakness:
+`generateMigrationHints()` still detects missing hooks by script path
+across the whole event instead of within the matching matcher group.
+
+## Requirements
+
+- Do not overwrite the whole user `settings.json`.
+- Preserve user top-level settings such as `model`,
+  `autoMemoryEnabled`, and `autoDreamEnabled` when already configured.
+- Preserve user custom hooks and hook ordering.
+- Add missing Zylos core hooks from the current template to the matching
+  event and matcher group.
+- Avoid duplicate core hooks by comparing normalized script paths.
+- Continue updating existing template-managed hooks when their command or
+  timeout changes.
+- Continue removing obsolete Zylos core hooks only when they belong to a
+  core skill present in the template-owned skill set.
+
+## Fix Design
+
+1. Change `syncHooks()` forward pass from group-level all-or-nothing sync
+   to per-hook sync inside the matching matcher group.
+2. If the matcher group does not exist, add the whole template group as it
+   does today.
+3. If the matcher group exists:
+   - find existing command hooks by normalized script path within that
+     group;
+   - update command and timeout drift for existing template hooks;
+   - append missing template hooks to that same group;
+   - leave all unrelated user hooks untouched.
+4. Keep the matcher-aware reverse pass, so obsolete core hooks are removed
+   only from the corresponding matcher group.
+5. Update `generateMigrationHints()` fallback to detect missing and
+   modified hooks in the corresponding matcher group rather than anywhere
+   in the event.
+6. Add regression tests using real historical templates where possible:
+   - `v0.4.13` settings upgraded to current template gains
+     `session-foreground.js` in `startup`, `clear`, and `compact`;
+   - `PostToolUseFailure` is still added;
+   - user custom hooks in the same group are preserved;
+   - dry-run does not mutate installed settings;
+   - fallback migration hints include per-matcher missing hooks.
+
+## Design Review
+
+### User Customization Safety
+
+The migration still writes a merged JSON document, not the template as a
+whole. Existing user top-level settings are already guarded by
+`Object.hasOwn()` checks and remain unchanged. User hook entries that are
+not matched by template script paths are not edited or removed.
+
+### Core Hook Ownership
+
+Zylos core hooks are operational infrastructure. Missing core hooks can
+break activity tracking, startup state, or restart behavior. The sync
+should therefore treat template core hooks as managed entries and ensure
+they are present, while still preserving user-added hooks around them.
+
+### Regression Against Matcher-Aware Sync
+
+The previous matcher-aware fix remains important: matching across all
+groups would still be wrong because it can skip required `clear` or
+`compact` groups when `startup` already contains the same scripts. This
+fix keeps matcher alignment but changes the behavior within a matched
+group from "update only" to "update or append missing template hooks".
+
+### Duplicate Avoidance
+
+All comparisons use `extractScriptPath()`, so command wrappers and `~/`
+normalization continue to avoid duplicate entries for the same underlying
+script.
+
+### Fallback Path
+
+Normal self-upgrade shells out to the newly installed
+`sync-settings-hooks.js`, but the fallback `generateMigrationHints()` path
+should still be correct for bootstrap failures. Updating both paths avoids
+two different migration semantics.
+
+## Implementation Notes
+
+The implementation should stay narrowly scoped to:
+
+- `cli/lib/sync-settings-hooks.js`
+- `cli/lib/self-upgrade.js`
+- `cli/lib/__tests__/sync-settings-hooks.test.js`
+- `cli/lib/__tests__/self-upgrade.test.js`
+
+No template changes are required.


### PR DESCRIPTION
## Summary
- Confirmed current main skips new core hooks when the target matcher group already exists in `settings.json`.
- Added per-hook merge inside existing matcher groups so missing Zylos template hooks are appended while unrelated user hooks are preserved.
- Aligned the self-upgrade fallback migration-hints path with matcher-aware sync semantics and added duplicate protection for stale hints.
- Added `docs/settings-hook-migration-fix.md` with problem confirmation, root cause, fix design, and review notes.

## Verification
- Reproduced v0.4.13 -> current template behavior before the fix: only `PostToolUseFailure` was added and `session-foreground.js` stayed missing from `startup`, `clear`, and `compact`.
- Verified after the fix: `session-foreground.js` is added to all three `SessionStart` matchers and `PostToolUseFailure` is still added.
- `node --test cli/lib/__tests__/sync-settings-hooks.test.js cli/lib/__tests__/self-upgrade.test.js`
- `npm test`
