### PR TITLE
fix(upgrade): back up preserve-declared dataDir files before upgrade

### DIFF
--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -425,7 +425,8 @@ function step2_backup(ctx) {
         const srcPath = path.resolve(ctx.dataDir, entry);
         // Path traversal guard: resolved path must stay within dataDir
         if (!srcPath.startsWith(resolvedDataDir + path.sep)) continue;
-        if (fs.existsSync(srcPath) && fs.statSync(srcPath).isFile()) {
+        // Use lstatSync to reject symlinks (prevents symlink-based traversal escape)
+        if (fs.existsSync(srcPath) && fs.lstatSync(srcPath).isFile()) {
           const destPath = path.join(dataBackupDir, entry);
           fs.mkdirSync(path.dirname(destPath), { recursive: true });
           fs.copyFileSync(srcPath, destPath);

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -383,6 +383,7 @@ function step1_stopService(ctx) {
 
 /**
  * Step 2: filesystem backup to .backup/<timestamp>/
+ * Backs up skillDir (source code) and preserve-declared dataDir files (runtime data).
  */
 function step2_backup(ctx) {
   const startTime = Date.now();
@@ -391,6 +392,24 @@ function step2_backup(ctx) {
 
   try {
     copyTree(ctx.skillDir, backupDir, { excludes: ['node_modules', '.backup', '.zylos'] });
+
+    // Back up dataDir files declared in preserve with data:// prefix
+    const parsed = parseSkillMd(ctx.skillDir);
+    const preserve = parsed?.frontmatter?.lifecycle?.preserve || [];
+    const dataEntries = preserve
+      .filter(entry => typeof entry === 'string' && entry.startsWith('data://'))
+      .map(entry => entry.slice('data://'.length));
+
+    if (dataEntries.length > 0 && ctx.dataDir && fs.existsSync(ctx.dataDir)) {
+      const dataBackupDir = path.join(backupDir, '_datadir');
+      fs.mkdirSync(dataBackupDir, { recursive: true });
+      for (const entry of dataEntries) {
+        const srcPath = path.join(ctx.dataDir, entry);
+        if (fs.existsSync(srcPath) && fs.statSync(srcPath).isFile()) {
+          fs.copyFileSync(srcPath, path.join(dataBackupDir, entry));
+        }
+      }
+    }
 
     ctx.backupDir = backupDir;
     return { step: 2, name: 'backup', status: 'done', message: path.basename(backupDir), duration: Date.now() - startTime };
@@ -548,10 +567,24 @@ export function rollback(ctx) {
   // Restore files from backup (--delete removes files added by the failed upgrade)
   if (ctx.backupDir && fs.existsSync(ctx.backupDir)) {
     try {
-      syncTree(ctx.backupDir, ctx.skillDir, { excludes: ['node_modules', '.backup', '.zylos'] });
+      syncTree(ctx.backupDir, ctx.skillDir, { excludes: ['node_modules', '.backup', '.zylos', '_datadir'] });
       results.push({ action: 'restore_files', success: true });
     } catch (err) {
       results.push({ action: 'restore_files', success: false, error: err.message });
+    }
+
+    // Restore dataDir files from backup
+    const dataBackupDir = path.join(ctx.backupDir, '_datadir');
+    if (ctx.dataDir && fs.existsSync(dataBackupDir)) {
+      try {
+        fs.mkdirSync(ctx.dataDir, { recursive: true });
+        for (const entry of fs.readdirSync(dataBackupDir)) {
+          fs.copyFileSync(path.join(dataBackupDir, entry), path.join(ctx.dataDir, entry));
+        }
+        results.push({ action: 'restore_data', success: true });
+      } catch (err) {
+        results.push({ action: 'restore_data', success: false, error: err.message });
+      }
     }
 
     // Restore dependencies

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -382,6 +382,24 @@ function step1_stopService(ctx) {
 }
 
 /**
+ * Collect data:// preserve entries from one or more SKILL.md sources (union, deduplicated).
+ */
+function collectDataPreserveEntries(...dirs) {
+  const entries = new Set();
+  for (const dir of dirs) {
+    if (!dir) continue;
+    const parsed = parseSkillMd(dir);
+    const preserve = parsed?.frontmatter?.lifecycle?.preserve || [];
+    for (const entry of preserve) {
+      if (typeof entry === 'string' && entry.startsWith('data://')) {
+        entries.add(entry.slice('data://'.length));
+      }
+    }
+  }
+  return [...entries];
+}
+
+/**
  * Step 2: filesystem backup to .backup/<timestamp>/
  * Backs up skillDir (source code) and preserve-declared dataDir files (runtime data).
  */
@@ -393,26 +411,34 @@ function step2_backup(ctx) {
   try {
     copyTree(ctx.skillDir, backupDir, { excludes: ['node_modules', '.backup', '.zylos'] });
 
-    // Back up dataDir files declared in preserve with data:// prefix
-    const parsed = parseSkillMd(ctx.skillDir);
-    const preserve = parsed?.frontmatter?.lifecycle?.preserve || [];
-    const dataEntries = preserve
-      .filter(entry => typeof entry === 'string' && entry.startsWith('data://'))
-      .map(entry => entry.slice('data://'.length));
+    // Back up dataDir files declared in preserve with data:// prefix.
+    // Read from both old (skillDir) and new (tempDir) SKILL.md so that the
+    // first release introducing data:// entries is also protected.
+    const dataEntries = collectDataPreserveEntries(ctx.skillDir, ctx.tempDir);
+    const resolvedDataDir = path.resolve(ctx.dataDir || '');
 
+    let backedUp = 0;
     if (dataEntries.length > 0 && ctx.dataDir && fs.existsSync(ctx.dataDir)) {
       const dataBackupDir = path.join(backupDir, '_datadir');
       fs.mkdirSync(dataBackupDir, { recursive: true });
       for (const entry of dataEntries) {
-        const srcPath = path.join(ctx.dataDir, entry);
+        const srcPath = path.resolve(ctx.dataDir, entry);
+        // Path traversal guard: resolved path must stay within dataDir
+        if (!srcPath.startsWith(resolvedDataDir + path.sep)) continue;
         if (fs.existsSync(srcPath) && fs.statSync(srcPath).isFile()) {
-          fs.copyFileSync(srcPath, path.join(dataBackupDir, entry));
+          const destPath = path.join(dataBackupDir, entry);
+          fs.mkdirSync(path.dirname(destPath), { recursive: true });
+          fs.copyFileSync(srcPath, destPath);
+          backedUp++;
         }
       }
     }
 
     ctx.backupDir = backupDir;
-    return { step: 2, name: 'backup', status: 'done', message: path.basename(backupDir), duration: Date.now() - startTime };
+    const msg = backedUp > 0
+      ? `${path.basename(backupDir)} (+${backedUp} data files)`
+      : path.basename(backupDir);
+    return { step: 2, name: 'backup', status: 'done', message: msg, duration: Date.now() - startTime };
   } catch (err) {
     return { step: 2, name: 'backup', status: 'failed', error: `Backup failed: ${err.message}`, duration: Date.now() - startTime };
   }
@@ -573,14 +599,11 @@ export function rollback(ctx) {
       results.push({ action: 'restore_files', success: false, error: err.message });
     }
 
-    // Restore dataDir files from backup
+    // Restore dataDir files from backup (recursive to handle nested paths)
     const dataBackupDir = path.join(ctx.backupDir, '_datadir');
     if (ctx.dataDir && fs.existsSync(dataBackupDir)) {
       try {
-        fs.mkdirSync(ctx.dataDir, { recursive: true });
-        for (const entry of fs.readdirSync(dataBackupDir)) {
-          fs.copyFileSync(path.join(dataBackupDir, entry), path.join(ctx.dataDir, entry));
-        }
+        fs.cpSync(dataBackupDir, ctx.dataDir, { recursive: true, force: true });
         results.push({ action: 'restore_data', success: true });
       } catch (err) {
         results.push({ action: 'restore_data', success: false, error: err.message });


### PR DESCRIPTION
## Summary

- `step2_backup` now reads the `preserve` list from SKILL.md and backs up files with the `data://` prefix from `dataDir` into `_datadir/` within the backup directory
- `rollback` restores `dataDir` files from `_datadir/` when an upgrade fails, with `mkdirSync` to handle the directory-deleted edge case
- `syncTree` in rollback excludes `_datadir` to avoid mixing data files into skillDir

## Design

Uses the existing `preserve` field in SKILL.md — no structural change. Components declare critical dataDir files with a `data://` prefix:

```yaml
preserve:
  - config.json           # skillDir (no change)
  - data://recruit.db     # dataDir (new)
```

`preserve` is backup-only, not a write lock. On successful upgrade, all files are updated normally (skillDir by smartSync, dataDir by migration). The backup is only used on rollback.

See #502 for full design discussion.

## Test plan

- [ ] Upgrade a component with `data://` entries in preserve — verify `_datadir/` appears in `.backup/<timestamp>/` with declared files
- [ ] Force a failed upgrade — verify rollback restores dataDir files from `_datadir/`
- [ ] Upgrade a component without `data://` entries — verify no `_datadir/` created, existing behavior unchanged
- [ ] Upgrade a component with no preserve field — verify no error, backup completes normally
- [ ] Verify `data://` entry for non-existent file is skipped without error

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)