### PR TITLE
fix(c4): treat Codex /exit as lifecycle control

### DIFF
--- a/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js
@@ -31,6 +31,7 @@ const {
   isBypassState,
   isKeystrokeControl,
   parseKeystrokeKey,
+  isCodexExitLifecycleControl,
   getHeartbeatPhase,
   shouldAutoAckHeartbeat,
   readJsonFileWithRetry
@@ -431,5 +432,45 @@ describe('parseKeystrokeKey', () => {
   it('handles null/undefined content', () => {
     assert.equal(parseKeystrokeKey(null), '');
     assert.equal(parseKeystrokeKey(undefined), '');
+  });
+});
+
+// ── isCodexExitLifecycleControl ─────────────────────────────────────
+
+describe('isCodexExitLifecycleControl', () => {
+  it('matches only exact Codex /exit controls', () => {
+    assert.equal(
+      isCodexExitLifecycleControl({ type: 'control', content: '/exit' }, 'codex'),
+      true
+    );
+  });
+
+  it('does not match Codex /clear controls', () => {
+    assert.equal(
+      isCodexExitLifecycleControl({ type: 'control', content: '/clear' }, 'codex'),
+      false
+    );
+  });
+
+  it('does not match /exit outside the Codex runtime', () => {
+    assert.equal(
+      isCodexExitLifecycleControl({ type: 'control', content: '/exit' }, 'claude'),
+      false
+    );
+  });
+
+  it('does not match conversations or non-exact /exit text', () => {
+    assert.equal(
+      isCodexExitLifecycleControl({ type: 'conversation', content: '/exit' }, 'codex'),
+      false
+    );
+    assert.equal(
+      isCodexExitLifecycleControl({ type: 'control', content: ' /exit' }, 'codex'),
+      false
+    );
+    assert.equal(
+      isCodexExitLifecycleControl({ type: 'control', content: '/exit now' }, 'codex'),
+      false
+    );
   });
 });

--- a/skills/comm-bridge/scripts/c4-dispatcher.js
+++ b/skills/comm-bridge/scripts/c4-dispatcher.js
@@ -375,6 +375,7 @@ async function submitAndVerify() {
 
 async function sendToTmux(message, options = {}) {
   const strictVerify = options.strictVerify === true;
+  const acceptShutdownAfterSubmit = options.acceptShutdownAfterSubmit === true;
   const bufferName = `c4-msg-${process.pid}-${Date.now()}`;
   const sanitized = sanitizeMessage(message);
   const delayMs = getDeliveryDelay(Buffer.byteLength(sanitized, 'utf8'));
@@ -417,6 +418,10 @@ async function sendToTmux(message, options = {}) {
     const agentState = getAgentState();
     if ((procState && procState.alive === false) ||
         agentState.state === 'offline' || agentState.state === 'stopped') {
+      if (acceptShutdownAfterSubmit) {
+        log('Verification failed after lifecycle shutdown control; treating paste+Enter as submitted');
+        return 'submitted';
+      }
       log('Verification failed and agent is dead/offline — marking as verify_failed');
       return 'verify_failed';
     }
@@ -435,6 +440,10 @@ export function isKeystrokeControl(item) {
 
 export function parseKeystrokeKey(content) {
   return (content || '').slice('[KEYSTROKE]'.length).trim();
+}
+
+export function isCodexExitLifecycleControl(item, activeRuntime = ACTIVE_RUNTIME) {
+  return item.type === 'control' && activeRuntime === 'codex' && item.content === '/exit';
 }
 
 function releaseItem(item, reason = null) {
@@ -640,7 +649,8 @@ async function processNextMessage() {
   const isSlashCommand = rawContent.startsWith('/');
   const deliveryContent = (item.type === 'control' && !isSlashCommand) ? `Meanwhile, ${rawContent}` : rawContent;
   const result = await sendToTmux(deliveryContent, {
-    strictVerify: item.type === 'conversation'
+    strictVerify: item.type === 'conversation',
+    acceptShutdownAfterSubmit: isCodexExitLifecycleControl(item)
   });
 
   if (result === 'submitted') {

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -326,6 +326,13 @@ Write the YAML frontmatter with `name` and `description`:
   - Include both what the Skill does and specific triggers/contexts for when to use it.
   - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
   - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+  - YAML safety: if the description contains `:` followed by a space, quotes, brackets, braces, `#`, or other YAML-significant characters, wrap it in quotes or use a folded block scalar:
+    ```yaml
+    description: >-
+      Use when reviewing technical solution documents. Applies the standard:
+      one top-level solution document plus module-level implementation docs.
+    ```
+  - Always run `node scripts/validate.js <skill-directory>` after creating or editing SKILL.md.
 
 Additional optional frontmatter fields for advanced control:
 


### PR DESCRIPTION
## Summary
- Treat only exact Codex control content `/exit` as a runtime lifecycle shutdown control.
- When `/exit` paste+Enter succeeds and verification then sees the runtime dead/offline, mark the control submitted instead of retrying as `VERIFY_FAILED`.
- Leave `/clear`, Claude `/exit`, conversations, and non-exact `/exit` text on existing verification semantics.

## Tests
- `node --check skills/comm-bridge/scripts/c4-dispatcher.js`
- `node --test skills/comm-bridge/scripts/__tests__/c4-dispatcher-pure.test.js`
- `npm test` in `skills/comm-bridge` currently has unrelated pre-existing `c4-send-cli.test.js` failures around two-arg CLI invocation with piped stdin; isolated failure reproduces without touching dispatcher behavior.