### PR TITLE
fix(caddy): forward stripped route prefix

### DIFF
--- a/cli/lib/caddy.js
+++ b/cli/lib/caddy.js
@@ -36,7 +36,7 @@ export function isCaddyAvailable() {
  * @param {Array} httpRoutes - Array of { path, type, target, strip_prefix? }
  * @returns {string} Caddy configuration block (indented for domain block)
  */
-function generateRouteBlocks(httpRoutes) {
+export function generateRouteBlocks(httpRoutes) {
   const lines = [];
   for (const route of httpRoutes) {
     if (route.type === 'reverse_proxy') {
@@ -49,7 +49,13 @@ function generateRouteBlocks(httpRoutes) {
       if (route.strip_prefix) {
         lines.push(`        uri strip_prefix ${route.strip_prefix}`);
       }
-      lines.push(`        reverse_proxy ${route.target}`);
+      if (route.strip_prefix) {
+        lines.push(`        reverse_proxy ${route.target} {`);
+        lines.push(`            header_up X-Forwarded-Prefix ${route.strip_prefix}`);
+        lines.push('        }');
+      } else {
+        lines.push(`        reverse_proxy ${route.target}`);
+      }
       lines.push(`    }`);
     }
   }

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import { isLocalAddress } from '../cli/commands/init.js';
+import { generateRouteBlocks } from '../cli/lib/caddy.js';
 
 describe('isLocalAddress', () => {
   // Positive cases — should return true
@@ -93,5 +94,33 @@ describe('isLocalAddress', () => {
 
   test('public IPv6', () => {
     expect(isLocalAddress('2001:db8::1')).toBe(false);
+  });
+});
+
+describe('generateRouteBlocks', () => {
+  test('adds X-Forwarded-Prefix for stripped reverse proxy routes', () => {
+    const block = generateRouteBlocks([{
+      path: '/recruit/*',
+      type: 'reverse_proxy',
+      target: 'localhost:3465',
+      strip_prefix: '/recruit',
+    }]);
+
+    expect(block).toContain('    redir /recruit /recruit/ permanent');
+    expect(block).toContain('        uri strip_prefix /recruit');
+    expect(block).toContain('        reverse_proxy localhost:3465 {');
+    expect(block).toContain('            header_up X-Forwarded-Prefix /recruit');
+  });
+
+  test('keeps simple reverse proxy routes as single-line directives', () => {
+    const block = generateRouteBlocks([{
+      path: '/api/*',
+      type: 'reverse_proxy',
+      target: 'localhost:3000',
+    }]);
+
+    expect(block).toContain('        reverse_proxy localhost:3000');
+    expect(block).not.toContain('header_up X-Forwarded-Prefix');
+    expect(block).not.toContain('reverse_proxy localhost:3000 {');
   });
 });


### PR DESCRIPTION
## Summary
- generate `X-Forwarded-Prefix` automatically for component Caddy routes that declare `strip_prefix`
- render stripped reverse proxy routes as a `reverse_proxy { ... }` block with `header_up X-Forwarded-Prefix <strip_prefix>`
- keep non-stripped reverse proxy routes as the existing single-line directive

## Why
Components like `recruit` are mounted externally at `/recruit/*` while the upstream app receives stripped root paths. Sending `X-Forwarded-Prefix` lets components infer the browser-visible base path without hardcoding their external mount prefix.

## Verification
- `node --check cli/lib/caddy.js`
- `node --experimental-vm-modules node_modules/.bin/jest test/caddy.test.js`
- `git diff --check`
