### PR TITLE
fix: increase npm install timeout and show progress

### DIFF
--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -319,8 +319,8 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
       try {
         execSync('npm install --omit=dev', {
           cwd: skillDir,
-          stdio: 'pipe',
-          timeout: 120000,
+          stdio: jsonOutput ? 'pipe' : 'inherit',
+          timeout: 300000,
         });
         if (!jsonOutput) console.log(`  ${success('npm install complete.')}`);
       } catch (err) {

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -864,8 +864,8 @@ function installSkillDependencies() {
       console.log(`  ${cyan(`Installing ${bold(entry.name)} dependencies...`)}`);
       execSync('npm install --production', {
         cwd: skillDir,
-        stdio: 'pipe',
-        timeout: 120000,
+        stdio: 'inherit',
+        timeout: 300000,
       });
     } catch {
       console.log(`  ${warn(`Failed to install ${bold(entry.name)} dependencies`)}`);


### PR DESCRIPTION
## Summary
- Bump `npm install` timeout from 120s to 300s in `add.js` and `init.js`
- Switch `stdio` from `pipe` to `inherit` so users see real-time npm download progress
- In `add.js`, respect `--json` mode: use `pipe` when JSON output is requested (to keep output clean), `inherit` otherwise

## Why
On fresh servers with empty npm cache, `zylos add` fails with `spawnSync /bin/sh ETIMEDOUT` because 120s is not enough to download all dependencies. Users also get no progress feedback during the install, making it look like the command is stuck.

## Files changed
- `cli/commands/add.js` — npm install during `zylos add`
- `cli/commands/init.js` — npm install during `zylos init` skill dependency setup

## Verification
- `node --check cli/commands/add.js`
- `node --check cli/commands/init.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)