### PR TITLE
fix(comm-bridge): treat "-" as stdin marker in c4-send 3-arg form

### DIFF
--- a/skills/comm-bridge/scripts/__tests__/c4-send-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-send-cli.test.js
@@ -8,11 +8,12 @@ import { fileURLToPath } from 'node:url';
 
 const CLI_PATH = fileURLToPath(new URL('../c4-send.js', import.meta.url));
 
-function cli(args, env = {}) {
+function cli(args, env = {}, stdinInput = undefined) {
   const result = spawnSync('node', [CLI_PATH, ...args], {
     env: { ...process.env, ...env },
     encoding: 'utf8',
-    timeout: 5000
+    timeout: 5000,
+    input: stdinInput
   });
   return { stdout: result.stdout, stderr: result.stderr, status: result.status };
 }
@@ -105,6 +106,36 @@ describe('c4-send validation', () => {
       const { stderr, status } = cli(['fake-channel', 'Hello'], env);
       assert.equal(status, 1);
       assert.ok(stderr.includes('Channel script not found'));
+    });
+  });
+});
+
+// -- stdin marker '-' --
+
+describe('c4-send stdin "-" marker', () => {
+  it('reads message from stdin when 3rd arg is "-" with piped stdin', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      const sentFile = setupMockChannel(tmpDir, 'mock-channel');
+
+      // 3 args (channel + endpoint + "-") + stdin content -> should read stdin
+      const { status } = cli(['mock-channel', 'endpoint1', '-'], env, 'stdin body content');
+      assert.equal(status, 0);
+
+      const sent = JSON.parse(fs.readFileSync(sentFile, 'utf8'));
+      assert.deepEqual(sent, ['endpoint1', 'stdin body content']);
+    });
+  });
+
+  it('reads multi-line stdin (heredoc-style) preserving newlines', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      const sentFile = setupMockChannel(tmpDir, 'mock-channel');
+
+      const multiline = 'line one\nline two\nline three';
+      const { status } = cli(['mock-channel', 'endpoint1', '-'], env, multiline);
+      assert.equal(status, 0);
+
+      const sent = JSON.parse(fs.readFileSync(sentFile, 'utf8'));
+      assert.deepEqual(sent, ['endpoint1', multiline]);
     });
   });
 });

--- a/skills/comm-bridge/scripts/c4-send.js
+++ b/skills/comm-bridge/scripts/c4-send.js
@@ -75,6 +75,10 @@ async function main() {
     // Unescape literal \n sequences that shell may have preserved when passing
     // multi-line content as a CLI argument (defense-in-depth; prefer stdin mode)
     message = message.replace(/\\n/g, '\n');
+  } else if (cleanArgs.length >= 3 && cleanArgs[2] === '-' && (stdinAvailable || hasStdinFlag)) {
+    // 3 args with explicit "-" stdin marker: channel + endpoint + read message from stdin
+    endpoint = cleanArgs[1];
+    message = (await readStdin()).trimEnd();
   } else {
     // 3+ args: channel + endpoint + message
     process.stderr.write('[c4-send] Deprecated: passing message as CLI argument. Use stdin/heredoc mode instead.\n');


### PR DESCRIPTION
## Summary

Before: `node c4-send.js <channel> <endpoint> -` with piped stdin would send the literal string `-` as the message, because the 3-arg branch in `main()` unconditionally read `cleanArgs[2]` as the message body and ignored stdin.

This silently broke heredoc-composed long-form messages:

```bash
node c4-send.js lark <chat_id> - <<'EOF'
<multi-line content>
EOF
```

The intent (read message from stdin) never fired — recipients on Lark / HxA Connect saw a literal `-` for what should have been a multi-paragraph briefing.

The pattern is documented elsewhere in the codebase: `lark-cli api --data -`, `--params -`, `--markdown -`, `c4-control.js` etc. all use `-` to mean "read from stdin". `c4-send.js` was the outlier.

## Fix

In `c4-send.js`, when 3 args are passed AND `cleanArgs[2] === '-'` AND stdin is available, read the message from stdin via the existing `readStdin()` helper.

The literal-`-` path remains for the no-stdin case (backward compatibility), so existing callers passing `-` as a literal message without piping still work.

## Test plan

- [x] New `c4-send stdin "-" marker` describe block in `c4-send-cli.test.js` with 2 cases:
  - 3 args + `-` + piped stdin → reads stdin (previously sent literal `-`)
  - Multi-line stdin content (heredoc-style, newlines preserved end-to-end)
- [x] Locally verified: 2 new tests pass, no regression in the 5 other tests that pass on main
- [x] 3 pre-existing test failures on main (`broadcast send`, `channel script not found`, `failed channel reports failure`) are **unrelated to this change** — they fail on main as well

## Real-world impact (already observed)

Before this fix, several real conversations on 2026-05-06 lost content:
- Two competitive-research briefings (VNTR + Sierra) on a Lark group
- One MR review request via HxA Connect DM
- Several long status updates on Lark DM

All recipients saw a literal `-` in place of the message body. Re-sends after the local hotfix went through correctly. Upstreaming so other agents using the same heredoc pattern don't keep dropping content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
