### PR TITLE
fix: guard against duplicate memory-sync subagents in new-session

### DIFF
--- a/skills/new-session/SKILL.md
+++ b/skills/new-session/SKILL.md
@@ -20,7 +20,14 @@ Use runtime-specific switch commands:
 
 Before sending the session switch command, complete these steps **in order**:
 
-### 1. Inventory running background tasks
+### 1. Check for running memory-sync subagents
+
+Before doing anything else, check if a memory-sync subagent is already running (use `TaskList` on Claude, or the equivalent on other runtimes). Look for any task whose description contains "memory sync" or "zylos-memory".
+
+- **If a memory-sync subagent is already running:** Do NOT trigger a new memory sync. Skip straight to step 2 (inventory). The running sync will complete on its own — spawning a second one risks a deadlock where the main loop and multiple subagents contend for resources.
+- **If no memory-sync subagent is running:** Proceed normally (memory sync may be triggered as part of the session handoff if needed).
+
+### 2. Inventory running background tasks
 
 Check for running background agents using the current runtime's available agent/task listing capability. For Claude, this is `TaskList`.
 
@@ -33,17 +40,17 @@ For each running task, note:
 - **What it's doing** (brief description)
 - **Output file path** (so the new session can check on it)
 
-This information goes into the handoff summary (step 2).
+This information goes into the handoff summary (step 3).
 
-### 2. Write a session handoff summary
+### 3. Write a session handoff summary
 
 Write a brief message covering:
 - **What was being worked on** (active tasks, user requests in progress)
 - **Current state** (what's done, what's pending, any blockers)
-- **Running background tasks** (from step 1 — include agent/task IDs and any output file paths or result handles so the new session can check on them with the runtime-appropriate output mechanism)
+- **Running background tasks** (from step 2 — include agent/task IDs and any output file paths or result handles so the new session can check on them with the runtime-appropriate output mechanism)
 - **What the next session should pick up** (if anything)
 
-### 3. Send the handoff summary
+### 4. Send the handoff summary
 
 Determine who to notify:
 - **If actively collaborating with a user:** Send the summary to that user's channel via C4 (their `reply via` path). This keeps the user informed AND records the context into C4 conversation history.
@@ -51,7 +58,7 @@ Determine who to notify:
 
 The goal is twofold: (a) the user knows what's happening, and (b) the handoff summary appears in C4 conversation history, so the new session can seamlessly continue the work.
 
-### 4. Enqueue Session Switch Command
+### 5. Enqueue Session Switch Command
 
 For Codex:
 ```bash


### PR DESCRIPTION
## Summary

- Adds step 1 to the new-session pre-switch checklist: check `TaskList` for running memory-sync subagents before triggering a new one
- If a memory-sync is already running, skip spawning another — prevents the deadlock where repeated context-monitor triggers create contending subagents
- Re-numbered existing steps (1→2, 2→3, 3→4, 4→5) and fixed internal cross-references

## Context

Forensic analysis of a btwlei instance deadlock showed: context-monitor fires `new-session` every 6 min when context stays above threshold, but each trigger spawns a new memory-sync subagent while the previous one is still running. Multiple concurrent syncs + user message handling caused the main loop to hang for 35 min until Claude's internal watchdog killed the process.

Howard's direction: check for running memory-sync subagents in the new-session prompt, don't add ack/debounce mechanisms.

## Test plan

- [ ] Verify new-session skill triggers correctly when no memory-sync is running
- [ ] Verify duplicate memory-sync is skipped when one is already in progress
- [ ] Confirm step numbering and cross-references are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)