### PR TITLE
fix: guard against duplicate memory-sync subagents

### DIFF
--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -47,7 +47,9 @@ When triggered, run it before handling queued user messages.
 1. Session init: if C4 unsummarized count is over threshold, launch memory sync.
 2. Scheduled context check: if context usage is high, launch memory sync.
 
-Both launch a background subagent using the current runtime's supported subagent mechanism with this file's Sync Flow as the prompt.
+**Before spawning a new memory-sync subagent, check if one is already running** (use `TaskList` on Claude, or the equivalent on other runtimes). Look for any task whose description contains "memory sync" or "zylos-memory". If a memory-sync subagent is already in progress, do NOT spawn another one — let the existing one finish. Spawning duplicates risks a deadlock where the main loop and multiple subagents contend for resources.
+
+Both trigger paths launch a background subagent using the current runtime's supported subagent mechanism with this file's Sync Flow as the prompt.
 
 ### Sync Flow
 


### PR DESCRIPTION
## Summary

- Adds a duplicate-check guard to the memory sync trigger paths in zylos-memory SKILL.md
- Before spawning a new memory-sync subagent, check `TaskList` for an already-running one; if found, skip
- Prevents the deadlock where repeated context-monitor triggers create multiple contending memory-sync subagents

## Context

Forensic analysis of a customer instance deadlock (btwlei): context-monitor fires new-session every 6 min while context stays above threshold. Each trigger eventually spawns a memory-sync subagent, but previous ones are still running. Multiple concurrent syncs + user message handling caused a 35-min main loop hang.

Replaces closed PR #543 (which incorrectly put the guard in new-session skill — memory sync is no longer triggered from there).

## Test plan

- [ ] Verify memory sync triggers normally when no sync is already running
- [ ] Verify duplicate sync is skipped when one is already in progress
- [ ] Confirm no deadlock under repeated context-monitor triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)