### PR TITLE
Security: Command Injection via Service Name in registerService

### DIFF
--- a/cli/lib/service.js
+++ b/cli/lib/service.js
@@ -21,6 +21,10 @@ export function registerService({ name, entry, skillDir, type }) {
     return { success: false, error: `Unsupported service type: ${type}. Only "pm2" is supported.` };
   }
 
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    return { success: false, error: `Invalid service name: "${name}". Only alphanumeric characters, hyphens, and underscores are allowed.` };
+  }
+
   const serviceName = `zylos-${name}`;
   const scriptPath = path.resolve(skillDir, entry);
 


### PR DESCRIPTION
## Summary

Security: Command Injection via Service Name in registerService

## Problem

**Severity**: `Critical` | **File**: `cli/lib/service.js:L40`

In cli/lib/service.js, the registerService function uses execSync with the service name directly in shell commands without sanitization. If a component provides a malicious name, it could execute arbitrary commands.

## Solution

Add validation to ensure service name contains only safe characters (alphanumeric, hyphen, underscore). Use a whitelist regex like /^[a-zA-Z0-9_-]+$/ to validate the name parameter before using it in execSync calls.

## Changes

- `cli/lib/service.js` (modified)