### PR TITLE
fix(claude): default settings model to opus 4.6

### DIFF
--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -160,13 +160,13 @@ describe('Claude model migration hints', () => {
 
     fs.mkdirSync(path.join(templatesDir, '.claude'), { recursive: true });
     fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
-    fs.writeFileSync(path.join(templatesDir, '.claude', 'settings.json'), JSON.stringify({ model: 'opus' }), 'utf8');
+    fs.writeFileSync(path.join(templatesDir, '.claude', 'settings.json'), JSON.stringify({ model: 'claude-opus-4-6' }), 'utf8');
     fs.writeFileSync(path.join(zylosDir, '.claude', 'settings.json'), JSON.stringify({ hooks: {} }), 'utf8');
 
     const hints = generateMigrationHints(templatesDir, { zylosDir });
     assert.deepEqual(
       hints.filter((hint) => hint.type === 'model_backfill'),
-      [{ type: 'model_backfill', value: 'opus' }]
+      [{ type: 'model_backfill', value: 'claude-opus-4-6' }]
     );
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -179,7 +179,7 @@ describe('Claude model migration hints', () => {
 
     fs.mkdirSync(path.join(templatesDir, '.claude'), { recursive: true });
     fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
-    fs.writeFileSync(path.join(templatesDir, '.claude', 'settings.json'), JSON.stringify({ model: 'opus' }), 'utf8');
+    fs.writeFileSync(path.join(templatesDir, '.claude', 'settings.json'), JSON.stringify({ model: 'claude-opus-4-6' }), 'utf8');
     fs.writeFileSync(path.join(zylosDir, '.claude', 'settings.json'), JSON.stringify({ model: 'sonnet' }), 'utf8');
 
     const hints = generateMigrationHints(templatesDir, { zylosDir });
@@ -196,13 +196,13 @@ describe('Claude model migration hints', () => {
     fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
     fs.writeFileSync(settingsPath, JSON.stringify({ hooks: {} }) + '\n', 'utf8');
 
-    const result = applyMigrationHints([{ type: 'model_backfill', value: 'opus' }], { zylosDir });
+    const result = applyMigrationHints([{ type: 'model_backfill', value: 'claude-opus-4-6' }], { zylosDir });
     const updated = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
     assert.equal(result.applied, 1);
-    assert.equal(updated.model, 'opus');
+    assert.equal(updated.model, 'claude-opus-4-6');
 
     fs.writeFileSync(settingsPath, JSON.stringify({ model: 'sonnet' }) + '\n', 'utf8');
-    const preserved = applyMigrationHints([{ type: 'model_backfill', value: 'opus' }], { zylosDir });
+    const preserved = applyMigrationHints([{ type: 'model_backfill', value: 'claude-opus-4-6' }], { zylosDir });
     const preservedSettings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
     assert.equal(preserved.applied, 0);
     assert.equal(preservedSettings.model, 'sonnet');

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -17,9 +17,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_SETTINGS_PATH = path.join(__dirname, '..', '..', '..', 'templates', '.claude', 'settings.json');
 
 describe('Claude settings template', () => {
-  it('defaults fresh installs to the Opus model', () => {
+  it('defaults fresh installs to Claude Opus 4.6', () => {
     const template = JSON.parse(fs.readFileSync(TEMPLATE_SETTINGS_PATH, 'utf8'));
-    assert.equal(template.model, 'opus');
+    assert.equal(template.model, 'claude-opus-4-6');
   });
 
   it('disables autoMemoryEnabled and autoDreamEnabled by default', () => {
@@ -52,14 +52,14 @@ describe('syncTemplateModelSetting', () => {
     const logs = [];
 
     const result = syncTemplateModelSetting({
-      templateSettings: { model: 'opus' },
+      templateSettings: { model: 'claude-opus-4-6' },
       installedSettings,
       log: (line) => logs.push(line),
     });
 
     assert.equal(result.changed, true);
-    assert.equal(installedSettings.model, 'opus');
-    assert.deepEqual(logs, ['  + model: opus']);
+    assert.equal(installedSettings.model, 'claude-opus-4-6');
+    assert.deepEqual(logs, ['  + model: claude-opus-4-6']);
   });
 
   it('preserves an existing user-configured model', () => {

--- a/scripts/e2e/issue-452-claude-default-model.sh
+++ b/scripts/e2e/issue-452-claude-default-model.sh
@@ -43,7 +43,7 @@ cat > "$ZYLOS_DIR/.claude/settings.json" <<'EOF'
 }
 EOF
 HOME="$HOME_DIR" ZYLOS_DIR="$ZYLOS_DIR" node "$ROOT_DIR/cli/lib/sync-settings-hooks.js" >/dev/null
-assert_model "opus"
+assert_model "claude-opus-4-6"
 
 echo "== preserve user model =="
 cat > "$ZYLOS_DIR/.claude/settings.json" <<'EOF'

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "opus",
+  "model": "claude-opus-4-6",
   "autoMemoryEnabled": false,
   "autoDreamEnabled": false,
   "hooks": {


### PR DESCRIPTION
## Summary
- Change the Claude settings template default model from `opus` to `claude-opus-4-6`.
- Update model backfill tests and the default-model e2e script to expect `claude-opus-4-6`.
- Preserve existing behavior that user-configured `model` values are not overwritten.

## Tests
- `node --test cli/lib/__tests__/sync-settings-hooks.test.js`
- `node --test cli/lib/__tests__/self-upgrade.test.js`
- `bash scripts/e2e/issue-452-claude-default-model.sh`
- `npm test`