### PR TITLE
fix(web-console): respect TZ config for timestamp display

### DIFF
--- a/skills/web-console/public/app.js
+++ b/skills/web-console/public/app.js
@@ -3,7 +3,7 @@
  */
 
 class ZylosConsole {
-  constructor() {
+  constructor(timezone) {
     this.messagesContainer = document.getElementById('messages');
     this.messageForm = document.getElementById('message-form');
     this.messageInput = document.getElementById('message-input');
@@ -16,6 +16,7 @@ class ZylosConsole {
     this.reconnectAttempts = 0;
     this.maxReconnectAttempts = 10;
     this.pendingMessages = new Map(); // Track messages being sent
+    this.timezone = timezone || null;
 
     // Detect base path for API/WS calls (handles /console/ proxy)
     this.basePath = this.detectBasePath();
@@ -391,8 +392,11 @@ class ZylosConsole {
   }
 
   formatTime(timestamp) {
-    const date = new Date(timestamp);
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const ts = timestamp.endsWith('Z') ? timestamp : timestamp + 'Z';
+    const date = new Date(ts);
+    const opts = { hour: '2-digit', minute: '2-digit' };
+    if (this.timezone) opts.timeZone = this.timezone;
+    return date.toLocaleTimeString([], opts);
   }
 }
 
@@ -424,7 +428,7 @@ async function checkAuth() {
       // No password set, or already authenticated
       chatScreen.style.display = '';
       if (auth.required) showLogoutButton(basePath);
-      new ZylosConsole();
+      new ZylosConsole(auth.timezone);
       return;
     }
 
@@ -448,7 +452,7 @@ async function checkAuth() {
         loginScreen.style.display = 'none';
         chatScreen.style.display = '';
         showLogoutButton(basePath);
-        new ZylosConsole();
+        new ZylosConsole(result.timezone);
       } else {
         loginError.textContent = result.error || 'Login failed';
       }

--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -40,14 +40,19 @@ const SKILL_ROOT = path.join(__dirname, '..');
 // --- Authentication ---
 import { parse as parseDotenv } from 'dotenv';
 
-function readEnvPassword() {
+function readEnv() {
   const envPath = path.join(ZYLOS_DIR, '.env');
   try {
-    const env = parseDotenv(fs.readFileSync(envPath, 'utf8'));
-    return env.ZYLOS_WEB_PASSWORD || env.WEB_CONSOLE_PASSWORD || '';
+    return parseDotenv(fs.readFileSync(envPath, 'utf8'));
   } catch {
-    return '';
+    return {};
   }
+}
+
+const ENV = readEnv();
+
+function readEnvPassword() {
+  return ENV.ZYLOS_WEB_PASSWORD || ENV.WEB_CONSOLE_PASSWORD || '';
 }
 
 const AUTH_PASSWORD = readEnvPassword();
@@ -391,7 +396,8 @@ app.get('/api/poll', (req, res) => {
 app.get('/api/auth', (req, res) => {
   res.json({
     required: AUTH_ENABLED,
-    authenticated: isAuthenticated(req)
+    authenticated: isAuthenticated(req),
+    timezone: ENV.TZ || null
   });
 });
 
@@ -400,7 +406,7 @@ app.get('/api/auth', (req, res) => {
  */
 app.post('/api/auth', (req, res) => {
   if (!AUTH_ENABLED) {
-    return res.json({ success: true });
+    return res.json({ success: true, timezone: ENV.TZ || null });
   }
 
   const { password } = req.body;
@@ -411,7 +417,7 @@ app.post('/api/auth', (req, res) => {
   const token = crypto.randomBytes(32).toString('hex');
   sessions.add(token);
   res.setHeader('Set-Cookie', `wc_session=${token}; Path=/; HttpOnly; SameSite=Strict; Max-Age=86400`);
-  res.json({ success: true });
+  res.json({ success: true, timezone: ENV.TZ || null });
 });
 
 /**


### PR DESCRIPTION
## Summary

Fix web console timestamps ignoring the `TZ` setting from `.env`, always displaying UTC time instead of the configured timezone (e.g. `Asia/Shanghai`).

**Root cause:** SQLite `CURRENT_TIMESTAMP` stores UTC times without a `Z` suffix (e.g. `2026-05-08 06:30:00`). The browser parses this as local time, so `toLocaleTimeString` produces the same value regardless of `timeZone` — no conversion happens.

**Fix:**
- **server.js**: Parse `.env` once into a cached `ENV` object. Include `timezone` field (from `TZ`) in `GET /api/auth` and `POST /api/auth` responses, piggybacking on the existing auth flow to avoid an extra authenticated endpoint.
- **app.js**: Pass `timezone` from the auth response into `ZylosConsole`. In `formatTime`, append `Z` to timestamps that lack it so the browser correctly interprets them as UTC before converting to the configured timezone.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Code follows the project's ESM-only style
- [x] Self-review completed
- [x] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [x] No secrets or internal references included
