### PR TITLE
fix(upgrade): verify activity-monitor env via pm2 jlist

### DIFF
--- a/cli/lib/__tests__/upgrade-restart.test.js
+++ b/cli/lib/__tests__/upgrade-restart.test.js
@@ -86,7 +86,7 @@ describe('step11_startCoreServices', () => {
 
     fs.mkdirSync(binDir, { recursive: true });
     fs.writeFileSync(ecosystemPath, 'module.exports = { apps: [] };\n', 'utf8');
-    fs.writeFileSync(pm2Path, `#!/bin/sh\necho "$@" >> "${logPath}"\nif [ "$1" = "env" ]; then echo "ZYLOS_PACKAGE_ROOT: ${tmpDir}"; fi\n`, { mode: 0o755 });
+    fs.writeFileSync(pm2Path, `#!/bin/sh\necho "$@" >> "${logPath}"\nif [ "$1" = "jlist" ]; then echo '[{"name":"activity-monitor","pm_id":3,"pm2_env":{"status":"online","ZYLOS_PACKAGE_ROOT":"${tmpDir}"}}]'; fi\n`, { mode: 0o755 });
 
     process.env.PATH = `${binDir}:${originalPath}`;
 
@@ -106,7 +106,46 @@ describe('step11_startCoreServices', () => {
       assert.equal(result.status, 'done');
       assert.match(fs.readFileSync(logPath, 'utf8'), /start .*ecosystem\.config\.cjs.*--only activity-monitor/);
       assert.match(fs.readFileSync(logPath, 'utf8'), /--update-env/);
+      assert.match(fs.readFileSync(logPath, 'utf8'), /^jlist$/m);
+      assert.doesNotMatch(fs.readFileSync(logPath, 'utf8'), /^env activity-monitor$/m);
       assert.match(fs.readFileSync(logPath, 'utf8'), /save/);
+    } finally {
+      process.env.PATH = originalPath;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails before saving when pm2 jlist lacks activity-monitor package-root env', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-step11-jlist-missing-'));
+    const binDir = path.join(tmpDir, 'bin');
+    const logPath = path.join(tmpDir, 'pm2.log');
+    const ecosystemPath = path.join(tmpDir, 'ecosystem.config.cjs');
+    const pm2Path = path.join(binDir, 'pm2');
+    const originalPath = process.env.PATH;
+
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(ecosystemPath, 'module.exports = { apps: [] };\n', 'utf8');
+    fs.writeFileSync(pm2Path, `#!/bin/sh\necho "$@" >> "${logPath}"\nif [ "$1" = "jlist" ]; then echo '[{"name":"activity-monitor","pm_id":3,"pm2_env":{"status":"online"}}]'; fi\n`, { mode: 0o755 });
+
+    process.env.PATH = `${binDir}:${originalPath}`;
+
+    try {
+      const result = step11_startCoreServices({
+        tempDir: null,
+        servicesWereRunning: ['activity-monitor'],
+      }, {
+        fs: {
+          existsSync: (file) => file === ecosystemPath,
+          mkdirSync: () => {},
+          copyFileSync: () => {},
+        },
+        ecosystemPath,
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.match(result.error, /ZYLOS_PACKAGE_ROOT/);
+      assert.match(fs.readFileSync(logPath, 'utf8'), /^jlist$/m);
+      assert.doesNotMatch(fs.readFileSync(logPath, 'utf8'), /^save$/m);
     } finally {
       process.env.PATH = originalPath;
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -1217,19 +1217,22 @@ export function step11_startCoreServices(ctx, deps = {}) {
 
   if (started.includes('activity-monitor')) {
     const verifyActivityMonitorEnv = deps.verifyActivityMonitorEnv ?? (() => {
-      const output = exec('pm2 env "activity-monitor" 2>/dev/null', {
+      const output = exec('pm2 jlist 2>/dev/null', {
         encoding: 'utf8',
         stdio: 'pipe',
       });
-      return /(?:^|\n)\s*ZYLOS_PACKAGE_ROOT\s*(?::|=|│)\s*\S+/.test(String(output));
+      const processes = JSON.parse(String(output));
+      const activityMonitor = processes.find(process => process.name === 'activity-monitor');
+      return Boolean(activityMonitor?.pm2_env?.ZYLOS_PACKAGE_ROOT);
     });
 
     try {
       if (!verifyActivityMonitorEnv()) {
         return { step: 11, name: 'start_core_services', status: 'failed', error: 'activity-monitor PM2 env missing ZYLOS_PACKAGE_ROOT after restart', duration: Date.now() - startTime };
       }
-    } catch {
-      return { step: 11, name: 'start_core_services', status: 'failed', error: 'failed to verify activity-monitor PM2 env after restart', duration: Date.now() - startTime };
+    } catch (err) {
+      const detail = err?.message ? `: ${err.message}` : '';
+      return { step: 11, name: 'start_core_services', status: 'failed', error: `failed to verify activity-monitor PM2 env after restart${detail}`, duration: Date.now() - startTime };
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace self-upgrade step 11 activity-monitor env verification from `pm2 env "activity-monitor"` to `pm2 jlist` parsing.
- Avoid PM2 v6 behavior where `pm2 env` accepts numeric `pm_id` but rejects process names.
- Add coverage that the default verifier uses `pm2 jlist`, does not call `pm2 env activity-monitor`, and still fails before `pm2 save` when `ZYLOS_PACKAGE_ROOT` is missing.

## Validation
- `node --test cli/lib/__tests__/upgrade-restart.test.js`
- `node --test cli/lib/__tests__/pm2.test.js`
- `npm test`