### PR TITLE
fix: route handoff summaries to internal channel

### DIFF
--- a/cli/lib/__tests__/session-handoff.test.js
+++ b/cli/lib/__tests__/session-handoff.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-session-handoff-test-'));
+const fakeZylosDir = path.join(tmpRoot, 'zylos');
+const argvPath = path.join(tmpRoot, 'argv.json');
+
+const originalZylosDir = process.env.ZYLOS_DIR;
+const originalArgvPath = process.env.SESSION_HANDOFF_TEST_ARGV_PATH;
+
+process.env.ZYLOS_DIR = fakeZylosDir;
+process.env.SESSION_HANDOFF_TEST_ARGV_PATH = argvPath;
+
+const c4ControlDir = path.join(fakeZylosDir, '.claude', 'skills', 'comm-bridge', 'scripts');
+fs.mkdirSync(c4ControlDir, { recursive: true });
+fs.writeFileSync(
+  path.join(c4ControlDir, 'c4-control.js'),
+  [
+    'import fs from "node:fs";',
+    'fs.writeFileSync(process.env.SESSION_HANDOFF_TEST_ARGV_PATH, JSON.stringify(process.argv.slice(2)), "utf8");',
+  ].join('\n'),
+  'utf8'
+);
+
+const { enqueueNewSession } = await import('../runtime/session-handoff.js');
+
+before(() => {
+  fs.rmSync(argvPath, { force: true });
+});
+
+after(() => {
+  if (originalZylosDir === undefined) delete process.env.ZYLOS_DIR;
+  else process.env.ZYLOS_DIR = originalZylosDir;
+
+  if (originalArgvPath === undefined) delete process.env.SESSION_HANDOFF_TEST_ARGV_PATH;
+  else process.env.SESSION_HANDOFF_TEST_ARGV_PATH = originalArgvPath;
+
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('enqueueNewSession', () => {
+  it('tells Codex to send handoff summaries to the internal web console', () => {
+    const result = enqueueNewSession({
+      ratio: 0.75,
+      used: 75_000,
+      ceiling: 100_000,
+      runtime: 'codex',
+      maxRetries: 1,
+    });
+
+    assert.equal(result, true);
+
+    const args = JSON.parse(fs.readFileSync(argvPath, 'utf8'));
+    const content = args[args.indexOf('--content') + 1];
+
+    assert.match(content, /do not skip checklist steps/);
+    assert.match(content, /internal web-console channel/);
+    assert.match(content, /do not post it to the active external user channel/);
+  });
+});

--- a/cli/lib/runtime/session-handoff.js
+++ b/cli/lib/runtime/session-handoff.js
@@ -41,7 +41,7 @@ export function enqueueNewSession({ ratio = 0, used = 0, ceiling = 0, runtime = 
     `(${used.toLocaleString()} / ${ceiling.toLocaleString()} tokens), ` +
     'exceeding threshold.';
   const content = runtime === 'codex'
-    ? `${base} Run $new-session now and follow SKILL.md in order. Write/send the session handoff summary before the final session-switch command; do not skip checklist steps.`
+    ? `${base} Run $new-session now and follow SKILL.md in order. Write/send the session handoff summary before the final session-switch command; do not skip checklist steps. Send the full session handoff summary only to the internal web-console channel; do not post it to the active external user channel.`
     : `${base} Use the new-session skill to start a fresh session.`;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {

--- a/skills/new-session/SKILL.md
+++ b/skills/new-session/SKILL.md
@@ -45,11 +45,23 @@ Write a brief message covering:
 
 ### 3. Send the handoff summary
 
-Determine who to notify:
-- **If actively collaborating with a user:** Send the summary to that user's channel via C4 (their `reply via` path). This keeps the user informed AND records the context into C4 conversation history.
-- **If no active user conversation:** Send the summary to the web console channel. This still records it into C4 so the new session's startup hook (c4-session-init) will include it in the conversation context.
+Send the full handoff summary to the internal web console channel via C4:
 
-The goal is twofold: (a) the user knows what's happening, and (b) the handoff summary appears in C4 conversation history, so the new session can seamlessly continue the work.
+```bash
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "web-console" "session-handoff"
+<handoff summary>
+EOF
+```
+
+This records the handoff in C4 conversation history so the new session's
+startup hook (`c4-session-init`) can include it in startup context.
+
+Do not send the full handoff summary to the active external user channel
+(Telegram, Lark, Feishu, HXA, etc.). Handoff summaries are operational context
+for the next agent session and may contain task state from outside the current
+conversation. If the user is actively waiting, send only a short user-facing
+notice to their current `reply via` path, without internal task inventory or
+cross-channel context.
 
 ### 4. Enqueue Session Switch Command
 

--- a/skills/restart-claude/SKILL.md
+++ b/skills/restart-claude/SKILL.md
@@ -35,11 +35,23 @@ Write a brief message covering:
 
 ### 4. Send the handoff summary
 
-Determine who to notify:
-- **If actively collaborating with a user:** Send the summary to that user's channel via C4 (their `reply via` path). This keeps the user informed AND records the context into C4 conversation history.
-- **If no active user conversation:** Send the summary to the web console channel. This still records it into C4 so the new session's startup hook (c4-session-init) will include it in the conversation context.
+Send the full handoff summary to the internal web console channel via C4:
 
-The goal is twofold: (a) the user knows what's happening, and (b) the handoff summary appears in C4 conversation history, so the new session can seamlessly continue the work.
+```bash
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "web-console" "session-handoff"
+<handoff summary>
+EOF
+```
+
+This records the handoff in C4 conversation history so the restarted session's
+startup hook (`c4-session-init`) can include it in startup context.
+
+Do not send the full handoff summary to the active external user channel
+(Telegram, Lark, Feishu, HXA, etc.). Handoff summaries are operational context
+for the next agent session and may contain task state from outside the current
+conversation. If the user is actively waiting, send only a short user-facing
+notice to their current `reply via` path, without internal task inventory or
+cross-channel context.
 
 ### 5. Enqueue /exit
 

--- a/skills/upgrade-claude/SKILL.md
+++ b/skills/upgrade-claude/SKILL.md
@@ -34,11 +34,23 @@ Write a brief message covering:
 
 ### 4. Send the handoff summary
 
-Determine who to notify:
-- **If actively collaborating with a user:** Send the summary to that user's channel via C4 (their `reply via` path). This keeps the user informed AND records the context into C4 conversation history.
-- **If no active user conversation:** Send the summary to the web console channel. This still records it into C4 so the new session's startup hook (c4-session-init) will include it in the conversation context.
+Send the full handoff summary to the internal web console channel via C4:
 
-The goal is twofold: (a) the user knows what's happening, and (b) the handoff summary appears in C4 conversation history, so the new session can seamlessly continue the work.
+```bash
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "web-console" "session-handoff"
+<handoff summary>
+EOF
+```
+
+This records the handoff in C4 conversation history so the upgraded session's
+startup hook (`c4-session-init`) can include it in startup context.
+
+Do not send the full handoff summary to the active external user channel
+(Telegram, Lark, Feishu, HXA, etc.). Handoff summaries are operational context
+for the next agent session and may contain task state from outside the current
+conversation. If the user is actively waiting, send only a short user-facing
+notice to their current `reply via` path, without internal task inventory or
+cross-channel context.
 
 ### 5. Launch the upgrade script
 


### PR DESCRIPTION
## Summary

- route full session handoff summaries to the internal `web-console` channel instead of active external user channels
- keep external Telegram/Lark/Feishu/HXA conversations free of internal task inventory and cross-channel context
- update the Codex context-rotation prompt and add coverage for the internal-channel instruction

Fixes #569.

## Tests

- `node --test cli/lib/__tests__/session-handoff.test.js`
- `node scripts/run-node-tests.js --test-name-pattern session-handoff`
- `git diff --check`
- `npm test`