### PR TITLE
fix(upgrade): run self-upgrade post-install steps from new package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Upgrade Notes
+- If self-upgrade fails with `failed to verify activity-monitor PM2 env after restart`, first run `pm2 stop activity-monitor`, then retry with `zylos upgrade --self -y`.
+
 ## [0.4.13] - 2026-04-12
 
 ### Fixed

--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -18,7 +18,6 @@ describe('self-upgrade finalizer handoff', () => {
     assert.deepEqual(createFinalizeState({
       tempDir: '/tmp/new-core',
       backupDir: '/tmp/backup',
-      servicesStopped: ['activity-monitor'],
       servicesWereRunning: ['activity-monitor', 'c4-dispatcher'],
       from: '0.4.12',
       to: '0.4.13',
@@ -28,7 +27,6 @@ describe('self-upgrade finalizer handoff', () => {
       schemaVersion: 1,
       tempDir: '/tmp/new-core',
       backupDir: '/tmp/backup',
-      servicesStopped: ['activity-monitor'],
       servicesWereRunning: ['activity-monitor', 'c4-dispatcher'],
       from: '0.4.12',
       to: '0.4.13',
@@ -75,8 +73,7 @@ describe('self-upgrade finalizer handoff', () => {
     }]);
   });
 
-  it('rolls back with restored state when a post-install step fails', () => {
-    const rollbackCalls = [];
+  it('fails without rollback when a post-install step fails', () => {
     const result = runSelfUpgradeFinalize({
       schemaVersion: 1,
       tempDir: '/tmp/new-core',
@@ -88,17 +85,12 @@ describe('self-upgrade finalizer handoff', () => {
       steps: [
         () => ({ step: 5, name: 'sync_core_skills', status: 'failed', error: 'sync failed' }),
       ],
-      rollbackSelf: (ctx) => {
-        rollbackCalls.push({ backupDir: ctx.backupDir, servicesWereRunning: ctx.servicesWereRunning });
-        return [{ action: 'restore_core_skills', success: true }];
-      },
     });
 
     assert.equal(result.success, false);
     assert.equal(result.failedStep, 5);
     assert.equal(result.error, 'sync failed');
-    assert.deepEqual(result.rollback.steps, [{ action: 'restore_core_skills', success: true }]);
-    assert.deepEqual(rollbackCalls, [{ backupDir: '/tmp/backup', servicesWereRunning: ['activity-monitor'] }]);
+    assert.deepEqual(result.rollback, { performed: false, steps: [] });
   });
 });
 

--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -4,8 +4,103 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-const { step1_backupCoreSkills, rollbackSelf, step10_ensureCodexConfig } = await import('../self-upgrade.js');
+const {
+  createFinalizeState,
+  runSelfUpgradeFinalize,
+  step1_backupCoreSkills,
+  rollbackSelf,
+  step10_ensureCodexConfig,
+} = await import('../self-upgrade.js');
 const { generateMigrationHints, applyMigrationHints } = await import('../self-upgrade.js');
+
+describe('self-upgrade finalizer handoff', () => {
+  it('serializes the state needed by the newly installed finalizer', () => {
+    assert.deepEqual(createFinalizeState({
+      tempDir: '/tmp/new-core',
+      backupDir: '/tmp/backup',
+      servicesStopped: ['activity-monitor'],
+      servicesWereRunning: ['activity-monitor', 'c4-dispatcher'],
+      from: '0.4.12',
+      to: '0.4.13',
+      newVersion: '0.4.13',
+      mode: 'merge',
+    }), {
+      schemaVersion: 1,
+      tempDir: '/tmp/new-core',
+      backupDir: '/tmp/backup',
+      servicesStopped: ['activity-monitor'],
+      servicesWereRunning: ['activity-monitor', 'c4-dispatcher'],
+      from: '0.4.12',
+      to: '0.4.13',
+      newVersion: '0.4.13',
+      mode: 'merge',
+    });
+  });
+
+  it('runs post-install steps with restored state and returns upgrade metadata', () => {
+    const calls = [];
+    const result = runSelfUpgradeFinalize({
+      schemaVersion: 1,
+      tempDir: '/tmp/new-core',
+      backupDir: '/tmp/backup',
+      servicesStopped: ['activity-monitor'],
+      servicesWereRunning: ['activity-monitor'],
+      from: '0.4.12',
+      to: '0.4.13',
+      mode: 'merge',
+    }, {
+      steps: [
+        (ctx) => {
+          calls.push({
+            tempDir: ctx.tempDir,
+            backupDir: ctx.backupDir,
+            servicesWereRunning: ctx.servicesWereRunning,
+            mode: ctx.mode,
+          });
+          return { step: 5, name: 'sync_core_skills', status: 'done', message: 'ok' };
+        },
+      ],
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.from, '0.4.12');
+    assert.equal(result.to, '0.4.13');
+    assert.equal(result.backupDir, '/tmp/backup');
+    assert.equal(result.steps.length, 1);
+    assert.deepEqual(calls, [{
+      tempDir: '/tmp/new-core',
+      backupDir: '/tmp/backup',
+      servicesWereRunning: ['activity-monitor'],
+      mode: 'merge',
+    }]);
+  });
+
+  it('rolls back with restored state when a post-install step fails', () => {
+    const rollbackCalls = [];
+    const result = runSelfUpgradeFinalize({
+      schemaVersion: 1,
+      tempDir: '/tmp/new-core',
+      backupDir: '/tmp/backup',
+      servicesWereRunning: ['activity-monitor'],
+      from: '0.4.12',
+      to: '0.4.13',
+    }, {
+      steps: [
+        () => ({ step: 5, name: 'sync_core_skills', status: 'failed', error: 'sync failed' }),
+      ],
+      rollbackSelf: (ctx) => {
+        rollbackCalls.push({ backupDir: ctx.backupDir, servicesWereRunning: ctx.servicesWereRunning });
+        return [{ action: 'restore_core_skills', success: true }];
+      },
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.failedStep, 5);
+    assert.equal(result.error, 'sync failed');
+    assert.deepEqual(result.rollback.steps, [{ action: 'restore_core_skills', success: true }]);
+    assert.deepEqual(rollbackCalls, [{ backupDir: '/tmp/backup', servicesWereRunning: ['activity-monitor'] }]);
+  });
+});
 
 describe('step10_ensureCodexConfig', () => {
   it('skips codex config write when non-codex runtime has no codex state', () => {

--- a/cli/lib/self-upgrade-finalize.js
+++ b/cli/lib/self-upgrade-finalize.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+/**
+ * Post-install self-upgrade finalizer.
+ *
+ * The parent upgrader process runs steps 1-4 using the currently loaded code,
+ * installs the new package, then invokes this script from the newly installed
+ * package so steps 5-12 use the new implementation.
+ */
+
+import fs from 'node:fs';
+import { runSelfUpgradeFinalize } from './self-upgrade.js';
+
+const statePath = process.argv[2];
+
+if (!statePath) {
+  console.error('Usage: node self-upgrade-finalize.js <state-file>');
+  process.exit(1);
+}
+
+try {
+  const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  const result = runSelfUpgradeFinalize(state);
+  console.log(JSON.stringify(result));
+  process.exit(result.success ? 0 : 1);
+} catch (err) {
+  console.error(err?.stack || err?.message || String(err));
+  process.exit(1);
+}

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -1385,7 +1385,7 @@ const POST_INSTALL_STEPS = [
   step12_verifyServices,
 ];
 
-function buildSelfUpgradeResult(ctx, failedStep, rollbackResults = null) {
+function buildSelfUpgradeResult(ctx, failedStep, rollbackResults = null, rollbackPerformed = Boolean(rollbackResults)) {
   if (failedStep) {
     return {
       action: 'self_upgrade',
@@ -1395,7 +1395,7 @@ function buildSelfUpgradeResult(ctx, failedStep, rollbackResults = null) {
       failedStep: failedStep.step,
       error: failedStep.error,
       steps: ctx.steps,
-      rollback: { performed: true, steps: rollbackResults || [] },
+      rollback: { performed: rollbackPerformed, steps: rollbackResults || [] },
     };
   }
 
@@ -1439,7 +1439,6 @@ export function createFinalizeState(ctx) {
     schemaVersion: 1,
     tempDir: ctx.tempDir,
     backupDir: ctx.backupDir,
-    servicesStopped: ctx.servicesStopped,
     servicesWereRunning: ctx.servicesWereRunning,
     from: ctx.from,
     to: ctx.to,
@@ -1509,7 +1508,6 @@ export function runSelfUpgradeFinalize(state = {}, deps = {}) {
     mode: state.mode,
   });
   ctx.backupDir = state.backupDir || null;
-  ctx.servicesStopped = Array.isArray(state.servicesStopped) ? [...state.servicesStopped] : [];
   ctx.servicesWereRunning = Array.isArray(state.servicesWereRunning) ? [...state.servicesWereRunning] : [];
   ctx.from = state.from || null;
   ctx.to = state.to || state.newVersion || null;
@@ -1531,9 +1529,7 @@ export function runSelfUpgradeFinalize(state = {}, deps = {}) {
   }
 
   if (failedStep) {
-    const rollbackFn = deps.rollbackSelf || rollbackSelf;
-    const rollbackResults = rollbackFn(ctx);
-    return buildSelfUpgradeResult(ctx, failedStep, rollbackResults);
+    return buildSelfUpgradeResult(ctx, failedStep, null, false);
   }
 
   return buildSelfUpgradeResult(ctx, null);
@@ -1609,8 +1605,7 @@ export function runSelfUpgrade({ tempDir, newVersion, mode, onStep } = {}) {
     };
     ctx.steps.push(failedStep);
     if (onStep) onStep(failedStep);
-    const rollbackResults = rollbackSelf(ctx);
-    return buildSelfUpgradeResult(ctx, failedStep, rollbackResults);
+    return buildSelfUpgradeResult(ctx, failedStep, null, false);
   }
 }
 

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -7,7 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { SKILLS_DIR, ZYLOS_DIR, getZylosConfig } from './config.js';
 import { downloadArchive, downloadBranch } from './download.js';
 import { generateManifest, saveManifest, saveOriginals } from './manifest.js';
@@ -372,6 +372,7 @@ function syncClaudeMd(templateDir) {
  */
 function listTemplateFiles(templatesDir) {
   const files = [];
+  if (!templatesDir) return files;
   if (!fs.existsSync(templatesDir)) return files;
 
   function walk(dir, prefix = '') {
@@ -1109,13 +1110,22 @@ function step9_syncSettingsHooks(ctx) {
  * @returns {string|null} Absolute path to the script, or null if not found.
  */
 function resolveInstalledSyncScript() {
+  return resolveInstalledPackageScript('cli', 'lib', 'sync-settings-hooks.js');
+}
+
+/**
+ * Resolve a script path in the globally installed package.
+ * Reads the package name from package.json to avoid hardcoding.
+ * @returns {string|null} Absolute path to the script, or null if not found.
+ */
+function resolveInstalledPackageScript(...parts) {
   try {
     // import.meta.dirname points to cli/lib/, go up two levels to package root
     const pkgPath = path.join(import.meta.dirname, '..', '..', 'package.json');
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
     const pkgName = pkg.name || 'zylos';
     const npmRoot = execSync('npm root -g', { encoding: 'utf8', stdio: 'pipe', timeout: 10000 }).trim();
-    const script = path.join(npmRoot, pkgName, 'cli', 'lib', 'sync-settings-hooks.js');
+    const script = path.join(npmRoot, pkgName, ...parts);
     return fs.existsSync(script) ? script : null;
   } catch {
     return null;
@@ -1364,57 +1374,19 @@ export function rollbackSelf(ctx, deps = {}) {
 // Public: runSelfUpgrade
 // ---------------------------------------------------------------------------
 
-/**
- * Run the 11-step self-upgrade pipeline.
- * Template migration and Claude restart are handled by Claude after this completes.
- * Lock must be acquired by caller.
- *
- * @param {{ tempDir: string, newVersion: string, onStep?: function }} opts
- * @returns {object} Upgrade result
- */
-export function runSelfUpgrade({ tempDir, newVersion, mode, onStep } = {}) {
-  const ctx = createContext({ tempDir, newVersion, mode });
+const POST_INSTALL_STEPS = [
+  step5_syncCoreSkills,
+  step6_installSkillDeps,
+  step7_syncClaudeMd,
+  step8_migrateStateMd,
+  step9_syncSettingsHooks,
+  step10_ensureCodexConfig,
+  step11_startCoreServices,
+  step12_verifyServices,
+];
 
-  const current = getCurrentVersion();
-  if (current.success) {
-    ctx.from = current.version;
-  }
-  ctx.to = newVersion || null;
-
-  const steps = [
-    step1_backupCoreSkills,
-    step2_preUpgradeHook,
-    step3_stopCoreServices,
-    step4_npmInstallGlobal,
-    step5_syncCoreSkills,
-    step6_installSkillDeps,
-    step7_syncClaudeMd,
-    step8_migrateStateMd,
-    step9_syncSettingsHooks,
-    step10_ensureCodexConfig,
-    step11_startCoreServices,
-    step12_verifyServices,
-  ];
-
-  const total = steps.length;
-  let failedStep = null;
-
-  for (const stepFn of steps) {
-    const result = stepFn(ctx);
-    result.total = total;
-    ctx.steps.push(result);
-    if (onStep) onStep(result);
-
-    if (result.status === 'failed') {
-      failedStep = result;
-      ctx.error = result.error;
-      break;
-    }
-  }
-
-  // If failed, rollback
+function buildSelfUpgradeResult(ctx, failedStep, rollbackResults = null) {
   if (failedStep) {
-    const rollbackResults = rollbackSelf(ctx);
     return {
       action: 'self_upgrade',
       success: false,
@@ -1423,12 +1395,12 @@ export function runSelfUpgrade({ tempDir, newVersion, mode, onStep } = {}) {
       failedStep: failedStep.step,
       error: failedStep.error,
       steps: ctx.steps,
-      rollback: { performed: true, steps: rollbackResults },
+      rollback: { performed: true, steps: rollbackResults || [] },
     };
   }
 
   // List template files for Claude to compare with local structure
-  const templatesDir = path.join(ctx.tempDir, 'templates');
+  const templatesDir = ctx.tempDir ? path.join(ctx.tempDir, 'templates') : null;
   const templates = listTemplateFiles(templatesDir);
 
   // Migration hints: step 8 already applied settings sync via the newly installed script.
@@ -1460,6 +1432,186 @@ export function runSelfUpgrade({ tempDir, newVersion, mode, onStep } = {}) {
     mergeConflicts: ctx.mergeConflicts.length > 0 ? ctx.mergeConflicts : null,
     mergedFiles: ctx.mergedFiles.length > 0 ? ctx.mergedFiles : null,
   };
+}
+
+export function createFinalizeState(ctx) {
+  return {
+    schemaVersion: 1,
+    tempDir: ctx.tempDir,
+    backupDir: ctx.backupDir,
+    servicesStopped: ctx.servicesStopped,
+    servicesWereRunning: ctx.servicesWereRunning,
+    from: ctx.from,
+    to: ctx.to,
+    newVersion: ctx.newVersion,
+    mode: ctx.mode,
+  };
+}
+
+function writeFinalizeState(ctx) {
+  const statePath = path.join(ctx.tempDir, 'self-upgrade-finalize-state.json');
+  fs.writeFileSync(statePath, `${JSON.stringify(createFinalizeState(ctx), null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  return statePath;
+}
+
+function runInstalledFinalizer(ctx) {
+  const finalizeScript = resolveInstalledPackageScript('cli', 'lib', 'self-upgrade-finalize.js');
+  if (!finalizeScript) {
+    throw new Error('newly installed self-upgrade finalizer not found');
+  }
+
+  const statePath = writeFinalizeState(ctx);
+  const result = spawnSync(process.execPath, [finalizeScript, statePath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 180000,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const output = String(result.stdout || '').trim();
+  if (!output) {
+    const err = String(result.stderr || '').trim() || `finalizer exited ${result.status}`;
+    throw new Error(err);
+  }
+
+  const parsed = JSON.parse(output);
+  if (result.status !== 0 && parsed?.success !== false) {
+    const err = String(result.stderr || '').trim() || `finalizer exited ${result.status}`;
+    throw new Error(err);
+  }
+
+  return parsed;
+}
+
+export function runSelfUpgradeFinalize(state = {}, deps = {}) {
+  if (state.schemaVersion !== undefined && state.schemaVersion !== 1) {
+    return {
+      action: 'self_upgrade',
+      success: false,
+      from: state.from || null,
+      to: null,
+      failedStep: 5,
+      error: `unsupported finalize state schemaVersion: ${state.schemaVersion}`,
+      steps: [],
+      rollback: { performed: false, steps: [] },
+    };
+  }
+
+  const ctx = createContext({
+    tempDir: state.tempDir,
+    newVersion: state.newVersion || state.to,
+    mode: state.mode,
+  });
+  ctx.backupDir = state.backupDir || null;
+  ctx.servicesStopped = Array.isArray(state.servicesStopped) ? [...state.servicesStopped] : [];
+  ctx.servicesWereRunning = Array.isArray(state.servicesWereRunning) ? [...state.servicesWereRunning] : [];
+  ctx.from = state.from || null;
+  ctx.to = state.to || state.newVersion || null;
+
+  const steps = deps.steps || POST_INSTALL_STEPS;
+  const total = deps.total || 12;
+  let failedStep = null;
+
+  for (const stepFn of steps) {
+    const result = stepFn(ctx);
+    result.total = total;
+    ctx.steps.push(result);
+
+    if (result.status === 'failed') {
+      failedStep = result;
+      ctx.error = result.error;
+      break;
+    }
+  }
+
+  if (failedStep) {
+    const rollbackFn = deps.rollbackSelf || rollbackSelf;
+    const rollbackResults = rollbackFn(ctx);
+    return buildSelfUpgradeResult(ctx, failedStep, rollbackResults);
+  }
+
+  return buildSelfUpgradeResult(ctx, null);
+}
+
+/**
+ * Run the 12-step self-upgrade pipeline.
+ * Template migration and Claude restart are handled by Claude after this completes.
+ * Lock must be acquired by caller.
+ *
+ * @param {{ tempDir: string, newVersion: string, onStep?: function }} opts
+ * @returns {object} Upgrade result
+ */
+export function runSelfUpgrade({ tempDir, newVersion, mode, onStep } = {}) {
+  const ctx = createContext({ tempDir, newVersion, mode });
+
+  const current = getCurrentVersion();
+  if (current.success) {
+    ctx.from = current.version;
+  }
+  ctx.to = newVersion || null;
+
+  const preInstallSteps = [
+    step1_backupCoreSkills,
+    step2_preUpgradeHook,
+    step3_stopCoreServices,
+    step4_npmInstallGlobal,
+  ];
+
+  const total = 12;
+  let failedStep = null;
+
+  for (const stepFn of preInstallSteps) {
+    const result = stepFn(ctx);
+    result.total = total;
+    ctx.steps.push(result);
+    if (onStep) onStep(result);
+
+    if (result.status === 'failed') {
+      failedStep = result;
+      ctx.error = result.error;
+      break;
+    }
+  }
+
+  if (failedStep) {
+    const rollbackResults = rollbackSelf(ctx);
+    return buildSelfUpgradeResult(ctx, failedStep, rollbackResults);
+  }
+
+  try {
+    const finalizeResult = runInstalledFinalizer(ctx);
+    const finalizeSteps = Array.isArray(finalizeResult.steps) ? finalizeResult.steps : [];
+    for (const step of finalizeSteps) {
+      ctx.steps.push(step);
+      if (onStep) onStep(step);
+    }
+    return {
+      ...finalizeResult,
+      from: ctx.from,
+      steps: ctx.steps,
+      backupDir: finalizeResult.backupDir || ctx.backupDir,
+    };
+  } catch (err) {
+    const error = err.stderr?.toString().trim() || err.message;
+    failedStep = {
+      step: 5,
+      name: 'run_new_upgrade_finalizer',
+      status: 'failed',
+      error,
+      total,
+      duration: 0,
+    };
+    ctx.steps.push(failedStep);
+    if (onStep) onStep(failedStep);
+    const rollbackResults = rollbackSelf(ctx);
+    return buildSelfUpgradeResult(ctx, failedStep, rollbackResults);
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary
- after `npm install -g` completes, hand off self-upgrade steps 5-12 to the newly installed package's `self-upgrade-finalize.js`
- preserve the existing `--branch` behavior: install the latest code from the branch at download time
- do not rollback after the finalizer handoff; post-install failures are reported from the new package path

## Validation
- node --test cli/lib/__tests__/self-upgrade.test.js cli/lib/__tests__/upgrade-restart.test.js
- npm test
