### PR TITLE
feat: ZYLOS_TMUX_ENV manifest for tmux session env injection

### DIFF
--- a/cli/lib/__tests__/tmux-env-manifest.test.js
+++ b/cli/lib/__tests__/tmux-env-manifest.test.js
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-tmux-env-'));
+process.env.HOME = tmpRoot;
+process.env.ZYLOS_DIR = path.join(tmpRoot, 'zylos');
+fs.mkdirSync(process.env.ZYLOS_DIR, { recursive: true });
+fs.writeFileSync(path.join(process.env.ZYLOS_DIR, '.env'), '', 'utf8');
+
+const { _parseEnvValue, _readManifestEnvVars } = await import('../runtime/claude.js');
+
+describe('ZYLOS_TMUX_ENV manifest', () => {
+  test('_readManifestEnvVars returns empty array when ZYLOS_TMUX_ENV is absent', () => {
+    const result = _readManifestEnvVars('FOO=bar\nBAZ=qux\n');
+    assert.deepEqual(result, []);
+  });
+
+  test('_readManifestEnvVars resolves declared variables from .env content', () => {
+    const env = [
+      'ZYLOS_TMUX_ENV=OTEL_ENDPOINT,CLAUDE_CODE_ENABLE_TELEMETRY,MY_VAR',
+      'OTEL_ENDPOINT=http://localhost:4318',
+      'CLAUDE_CODE_ENABLE_TELEMETRY=1',
+      'MY_VAR=hello world',
+    ].join('\n');
+
+    const result = _readManifestEnvVars(env);
+    assert.deepEqual(result, [
+      { key: 'OTEL_ENDPOINT', value: 'http://localhost:4318' },
+      { key: 'CLAUDE_CODE_ENABLE_TELEMETRY', value: '1' },
+      { key: 'MY_VAR', value: 'hello world' },
+    ]);
+  });
+
+  test('_readManifestEnvVars skips variables not defined in .env', () => {
+    const env = [
+      'ZYLOS_TMUX_ENV=DEFINED_VAR,MISSING_VAR',
+      'DEFINED_VAR=present',
+    ].join('\n');
+
+    const result = _readManifestEnvVars(env);
+    assert.deepEqual(result, [
+      { key: 'DEFINED_VAR', value: 'present' },
+    ]);
+  });
+
+  test('_readManifestEnvVars handles spaces around commas', () => {
+    const env = [
+      'ZYLOS_TMUX_ENV=A , B , C',
+      'A=1',
+      'B=2',
+      'C=3',
+    ].join('\n');
+
+    const result = _readManifestEnvVars(env);
+    assert.deepEqual(result, [
+      { key: 'A', value: '1' },
+      { key: 'B', value: '2' },
+      { key: 'C', value: '3' },
+    ]);
+  });
+
+  test('_readManifestEnvVars handles quoted values', () => {
+    const env = [
+      'ZYLOS_TMUX_ENV=QUOTED_VAR',
+      'QUOTED_VAR="http://localhost:4318"',
+    ].join('\n');
+
+    const result = _readManifestEnvVars(env);
+    assert.deepEqual(result, [
+      { key: 'QUOTED_VAR', value: 'http://localhost:4318' },
+    ]);
+  });
+
+  test('_readManifestEnvVars returns empty array for empty manifest', () => {
+    const env = 'ZYLOS_TMUX_ENV=\n';
+    const result = _readManifestEnvVars(env);
+    assert.deepEqual(result, []);
+  });
+
+  test('_parseEnvValue handles standard key=value', () => {
+    assert.equal(_parseEnvValue('FOO=bar', 'FOO'), 'bar');
+  });
+
+  test('_parseEnvValue handles spaces around equals', () => {
+    assert.equal(_parseEnvValue('FOO = bar', 'FOO'), 'bar');
+  });
+
+  test('_parseEnvValue handles double-quoted values', () => {
+    assert.equal(_parseEnvValue('FOO="bar baz"', 'FOO'), 'bar baz');
+  });
+
+  test('_parseEnvValue handles single-quoted values', () => {
+    assert.equal(_parseEnvValue("FOO='bar baz'", 'FOO'), 'bar baz');
+  });
+
+  test('_parseEnvValue returns empty string for missing key', () => {
+    assert.equal(_parseEnvValue('FOO=bar', 'MISSING'), '');
+  });
+});

--- a/cli/lib/__tests__/tmux-env-manifest.test.js
+++ b/cli/lib/__tests__/tmux-env-manifest.test.js
@@ -10,7 +10,7 @@ process.env.ZYLOS_DIR = path.join(tmpRoot, 'zylos');
 fs.mkdirSync(process.env.ZYLOS_DIR, { recursive: true });
 fs.writeFileSync(path.join(process.env.ZYLOS_DIR, '.env'), '', 'utf8');
 
-const { _parseEnvValue, _readManifestEnvVars } = await import('../runtime/claude.js');
+const { _parseEnvValue, _readManifestEnvVars, _shellQuote } = await import('../runtime/claude.js');
 
 describe('ZYLOS_TMUX_ENV manifest', () => {
   test('_readManifestEnvVars returns empty array when ZYLOS_TMUX_ENV is absent', () => {
@@ -98,5 +98,27 @@ describe('ZYLOS_TMUX_ENV manifest', () => {
 
   test('_parseEnvValue returns empty string for missing key', () => {
     assert.equal(_parseEnvValue('FOO=bar', 'MISSING'), '');
+  });
+
+  test('_readManifestEnvVars skips invalid shell variable names', () => {
+    const env = [
+      'ZYLOS_TMUX_ENV=GOOD_VAR,BAD-NAME,123START,_OK',
+      'GOOD_VAR=yes',
+      'BAD-NAME=nope',
+      '123START=nope',
+      '_OK=yes',
+    ].join('\n');
+
+    const result = _readManifestEnvVars(env);
+    assert.deepEqual(result, [
+      { key: 'GOOD_VAR', value: 'yes' },
+      { key: '_OK', value: 'yes' },
+    ]);
+  });
+
+  test('_shellQuote escapes single quotes in values', () => {
+    assert.equal(_shellQuote("it's fine"), "'it'\\''s fine'");
+    assert.equal(_shellQuote("no quotes"), "'no quotes'");
+    assert.equal(_shellQuote("a'b'c"), "'a'\\''b'\\''c'");
   });
 });

--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -69,12 +69,19 @@ function _parseEnvValue(content, key) {
  * @param {string} envContent - Full .env file content
  * @returns {Array<{key: string, value: string}>} Resolved key-value pairs (skips missing/empty)
  */
+const VALID_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function _shellQuote(value) {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
 function _readManifestEnvVars(envContent) {
   const manifest = _parseEnvValue(envContent, 'ZYLOS_TMUX_ENV');
   if (!manifest) return [];
   const names = manifest.split(',').map(s => s.trim()).filter(Boolean);
   const result = [];
   for (const name of names) {
+    if (!VALID_ENV_NAME.test(name)) continue;
     const value = _parseEnvValue(envContent, name);
     if (value) result.push({ key: name, value });
   }
@@ -323,12 +330,12 @@ export class ClaudeAdapter extends RuntimeAdapter {
     // Collect env vars to inject via temp file (auth tokens + manifest vars)
     const envParts = [];
     if (baseUrlValue || (!hasNativeAuth && (apiKeyValue || oauthTokenValue))) {
-      if (apiKeyValue) envParts.push(`ANTHROPIC_API_KEY='${apiKeyValue}'`);
-      if (oauthTokenValue) envParts.push(`CLAUDE_CODE_OAUTH_TOKEN='${oauthTokenValue}'`);
-      if (baseUrlValue) envParts.push(`ANTHROPIC_BASE_URL='${baseUrlValue}'`);
+      if (apiKeyValue) envParts.push(`ANTHROPIC_API_KEY=${_shellQuote(apiKeyValue)}`);
+      if (oauthTokenValue) envParts.push(`CLAUDE_CODE_OAUTH_TOKEN=${_shellQuote(oauthTokenValue)}`);
+      if (baseUrlValue) envParts.push(`ANTHROPIC_BASE_URL=${_shellQuote(baseUrlValue)}`);
     }
     for (const { key, value } of manifestVars) {
-      envParts.push(`${key}='${value}'`);
+      envParts.push(`${key}=${_shellQuote(value)}`);
     }
 
     if (_tmuxHasSession()) {
@@ -519,4 +526,4 @@ function _approveApiKey(apiKey) {
 }
 
 // Exported for testing
-export { _parseEnvValue, _readManifestEnvVars };
+export { _parseEnvValue, _readManifestEnvVars, _shellQuote };

--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -60,6 +60,27 @@ function _parseEnvValue(content, key) {
   return m[1].trim().replace(/^(['"])(.*)\1$/, '$2');
 }
 
+/**
+ * Read ZYLOS_TMUX_ENV manifest from .env and resolve each declared variable.
+ *
+ * ZYLOS_TMUX_ENV is a comma-separated list of variable names whose values
+ * (also in .env) should be injected into the tmux session environment.
+ *
+ * @param {string} envContent - Full .env file content
+ * @returns {Array<{key: string, value: string}>} Resolved key-value pairs (skips missing/empty)
+ */
+function _readManifestEnvVars(envContent) {
+  const manifest = _parseEnvValue(envContent, 'ZYLOS_TMUX_ENV');
+  if (!manifest) return [];
+  const names = manifest.split(',').map(s => s.trim()).filter(Boolean);
+  const result = [];
+  for (const name of names) {
+    const value = _parseEnvValue(envContent, name);
+    if (value) result.push({ key: name, value });
+  }
+  return result;
+}
+
 // ── ClaudeAdapter ─────────────────────────────────────────────────────────────
 
 export class ClaudeAdapter extends RuntimeAdapter {
@@ -270,14 +291,18 @@ export class ClaudeAdapter extends RuntimeAdapter {
       } catch { }
     }
 
+    // Read .env once — used for auth tokens and manifest env vars
+    let envContent = '';
+    try { envContent = fs.readFileSync(path.join(ZYLOS_DIR, '.env'), 'utf8'); } catch { }
+
+    // ZYLOS_TMUX_ENV manifest: user-declared env vars to inject into the session
+    const manifestVars = _readManifestEnvVars(envContent);
+
     if (!hasNativeAuth) {
       // Read API tokens from .env — only when no native login
-      try {
-        const envContent = fs.readFileSync(path.join(ZYLOS_DIR, '.env'), 'utf8');
-        apiKeyValue = _parseEnvValue(envContent, 'ANTHROPIC_API_KEY');
-        oauthTokenValue = _parseEnvValue(envContent, 'CLAUDE_CODE_OAUTH_TOKEN');
-        baseUrlValue = _parseEnvValue(envContent, 'ANTHROPIC_BASE_URL');
-      } catch { }
+      apiKeyValue = _parseEnvValue(envContent, 'ANTHROPIC_API_KEY');
+      oauthTokenValue = _parseEnvValue(envContent, 'CLAUDE_CODE_OAUTH_TOKEN');
+      baseUrlValue = _parseEnvValue(envContent, 'ANTHROPIC_BASE_URL');
 
       // Pre-approve API keys to skip interactive confirmation prompts
       if (apiKeyValue) _approveApiKey(apiKeyValue);
@@ -295,9 +320,27 @@ export class ClaudeAdapter extends RuntimeAdapter {
     const exitLogFile = path.join(monitorDir, 'claude-exit.log');
     const exitLogSnippet = `_ec=$?; echo "[$(date -Iseconds)] exit_code=$_ec" >> "${exitLogFile}"`;
 
+    // Collect env vars to inject via temp file (auth tokens + manifest vars)
+    const envParts = [];
+    if (baseUrlValue || (!hasNativeAuth && (apiKeyValue || oauthTokenValue))) {
+      if (apiKeyValue) envParts.push(`ANTHROPIC_API_KEY='${apiKeyValue}'`);
+      if (oauthTokenValue) envParts.push(`CLAUDE_CODE_OAUTH_TOKEN='${oauthTokenValue}'`);
+      if (baseUrlValue) envParts.push(`ANTHROPIC_BASE_URL='${baseUrlValue}'`);
+    }
+    for (const { key, value } of manifestVars) {
+      envParts.push(`${key}='${value}'`);
+    }
+
     if (_tmuxHasSession()) {
       // Existing session — send command via tmux
-      const cmd = `cd "${ZYLOS_DIR}"; ${claudeCmd}; ${exitLogSnippet}`;
+      let cmd;
+      if (envParts.length > 0) {
+        const tmpEnv = path.join(os.tmpdir(), `.zylos-env-${process.pid}-${Date.now()}`);
+        fs.writeFileSync(tmpEnv, envParts.join('\n') + '\n', { mode: 0o600 });
+        cmd = `set -a; . "${tmpEnv}"; set +a; rm -f "${tmpEnv}"; cd "${ZYLOS_DIR}" && ${claudeCmd}; ${exitLogSnippet}`;
+      } else {
+        cmd = `cd "${ZYLOS_DIR}"; ${claudeCmd}; ${exitLogSnippet}`;
+      }
       await this.sendMessage(cmd);
     } else {
       // New tmux session
@@ -308,13 +351,7 @@ export class ClaudeAdapter extends RuntimeAdapter {
       let shellCmd;
       let tmpEnv = null;
 
-      if (baseUrlValue || (!hasNativeAuth && (apiKeyValue || oauthTokenValue))) {
-        // Write secrets to a temp file, source it, then delete it
-        // Avoids exposing secrets in ps/proc/cmdline
-        const envParts = [];
-        if (apiKeyValue) envParts.push(`ANTHROPIC_API_KEY='${apiKeyValue}'`);
-        if (oauthTokenValue) envParts.push(`CLAUDE_CODE_OAUTH_TOKEN='${oauthTokenValue}'`);
-        if (baseUrlValue) envParts.push(`ANTHROPIC_BASE_URL='${baseUrlValue}'`);
+      if (envParts.length > 0) {
         tmpEnv = path.join(os.tmpdir(), `.zylos-env-${process.pid}-${Date.now()}`);
         fs.writeFileSync(tmpEnv, envParts.join('\n') + '\n', { mode: 0o600 });
         shellCmd = `set -a; . "${tmpEnv}"; set +a; rm -f "${tmpEnv}"; cd "${ZYLOS_DIR}" && ${claudeCmd}; ${exitLogSnippet}`;
@@ -480,3 +517,6 @@ function _approveApiKey(apiKey) {
     }
   } catch { }
 }
+
+// Exported for testing
+export { _parseEnvValue, _readManifestEnvVars };

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -24,7 +24,7 @@ import { RuntimeAdapter } from './base.js';
 import { buildInstructionFile } from './instruction-builder.js';
 import { CodexContextMonitor } from './codex-context-monitor.js';
 import { createCodexProbe } from '../heartbeat/codex-probe.js';
-import { ZYLOS_DIR, SKILLS_DIR, getZylosConfig } from '../config.js';
+import { ZYLOS_DIR, SKILLS_DIR, getZylosConfig, ENV_FILE } from '../config.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -34,6 +34,25 @@ const CODEX_BIN = process.env.CODEX_BIN || 'codex';
 // When CODEX_BYPASS_PERMISSIONS=false, skip --dangerously-bypass-approvals-and-sandbox.
 // Defaults to enabled for unattended server operation.
 const DEFAULT_BYPASS = process.env.CODEX_BYPASS_PERMISSIONS !== 'false';
+
+function _parseEnvValue(content, key) {
+  const re = new RegExp(`^\\s*${key}\\s*=\\s*(.+)$`, 'm');
+  const m = content.match(re);
+  if (!m) return '';
+  return m[1].trim().replace(/^(['"])(.*)\1$/, '$2');
+}
+
+function _readManifestEnvVars(envContent) {
+  const manifest = _parseEnvValue(envContent, 'ZYLOS_TMUX_ENV');
+  if (!manifest) return [];
+  const names = manifest.split(',').map(s => s.trim()).filter(Boolean);
+  const result = [];
+  for (const name of names) {
+    const value = _parseEnvValue(envContent, name);
+    if (value) result.push({ key: name, value });
+  }
+  return result;
+}
 
 function getCodexApiBaseUrl() {
   try {
@@ -306,10 +325,27 @@ export class CodexAdapter extends RuntimeAdapter {
     const exitLogFile = path.join(monitorDir, 'codex-exit.log');
     const exitLogSnippet = `_ec=$?; echo "[$(date -Iseconds)] exit_code=$_ec" >> "${exitLogFile}"`;
 
+    // ZYLOS_TMUX_ENV manifest: user-declared env vars to inject into the session
+    let manifestVars = [];
+    try {
+      const envContent = fs.readFileSync(ENV_FILE, 'utf8');
+      manifestVars = _readManifestEnvVars(envContent);
+    } catch { }
+
+    // Build env injection prefix (sourced before codex command)
+    let envPrefix = '';
+    let tmpEnv = null;
+    if (manifestVars.length > 0) {
+      const envParts = manifestVars.map(({ key, value }) => `${key}='${value}'`);
+      tmpEnv = path.join(os.tmpdir(), `.zylos-env-${process.pid}-${Date.now()}`);
+      fs.writeFileSync(tmpEnv, envParts.join('\n') + '\n', { mode: 0o600 });
+      envPrefix = `set -a; . "${tmpEnv}"; set +a; rm -f "${tmpEnv}"; `;
+    }
+
     if (_tmuxHasSession()) {
       const cmd = tmpPrompt
-        ? `cd "${ZYLOS_DIR}"; _p=$(cat "${tmpPrompt}"); rm -f "${tmpPrompt}"; ${codexCmd} "$_p"; ${exitLogSnippet}`
-        : `cd "${ZYLOS_DIR}"; ${codexCmd}; ${exitLogSnippet}`;
+        ? `${envPrefix}cd "${ZYLOS_DIR}"; _p=$(cat "${tmpPrompt}"); rm -f "${tmpPrompt}"; ${codexCmd} "$_p"; ${exitLogSnippet}`
+        : `${envPrefix}cd "${ZYLOS_DIR}"; ${codexCmd}; ${exitLogSnippet}`;
       await this.sendMessage(cmd);
     } else {
       const dedupedPath = [...new Set((process.env.PATH || '').split(':').filter(Boolean))].join(':');
@@ -319,12 +355,13 @@ export class CodexAdapter extends RuntimeAdapter {
       const promptSnippet = tmpPrompt
         ? `_p=$(cat "${tmpPrompt}"); rm -f "${tmpPrompt}"; ${codexCmd} "$_p"`
         : codexCmd;
-      const shellCmd = `cd "${ZYLOS_DIR}" && ${promptSnippet}; ${exitLogSnippet}`;
+      const shellCmd = `${envPrefix}cd "${ZYLOS_DIR}" && ${promptSnippet}; ${exitLogSnippet}`;
       tmuxArgs.push('--', shellCmd);
 
       try {
         execFileSync('tmux', tmuxArgs);
       } catch (e) {
+        if (tmpEnv) try { fs.unlinkSync(tmpEnv); } catch { }
         if (tmpPrompt) try { fs.unlinkSync(tmpPrompt); } catch { }
         throw new Error(`Failed to create tmux session: ${e.message}`);
       }

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -42,12 +42,19 @@ function _parseEnvValue(content, key) {
   return m[1].trim().replace(/^(['"])(.*)\1$/, '$2');
 }
 
+const VALID_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function _shellQuote(value) {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
 function _readManifestEnvVars(envContent) {
   const manifest = _parseEnvValue(envContent, 'ZYLOS_TMUX_ENV');
   if (!manifest) return [];
   const names = manifest.split(',').map(s => s.trim()).filter(Boolean);
   const result = [];
   for (const name of names) {
+    if (!VALID_ENV_NAME.test(name)) continue;
     const value = _parseEnvValue(envContent, name);
     if (value) result.push({ key: name, value });
   }
@@ -336,7 +343,7 @@ export class CodexAdapter extends RuntimeAdapter {
     let envPrefix = '';
     let tmpEnv = null;
     if (manifestVars.length > 0) {
-      const envParts = manifestVars.map(({ key, value }) => `${key}='${value}'`);
+      const envParts = manifestVars.map(({ key, value }) => `${key}=${_shellQuote(value)}`);
       tmpEnv = path.join(os.tmpdir(), `.zylos-env-${process.pid}-${Date.now()}`);
       fs.writeFileSync(tmpEnv, envParts.join('\n') + '\n', { mode: 0o600 });
       envPrefix = `set -a; . "${tmpEnv}"; set +a; rm -f "${tmpEnv}"; `;


### PR DESCRIPTION
## Summary

- Adds `ZYLOS_TMUX_ENV` manifest variable support: users declare which `.env` variables should be injected into the Claude/Codex tmux session at launch time
- Both `ClaudeAdapter` and `CodexAdapter` read the manifest and inject resolved variables via sourced temp file (same secure pattern as auth tokens)
- Works for both new tmux sessions and existing session restarts

## Motivation

OTel telemetry and other Claude Code features require specific environment variables (`OTEL_*`, `CLAUDE_CODE_ENABLE_TELEMETRY`, etc.) to be present in the tmux session. Previously these had to be set in `~/.bashrc`, which:
1. Is a system-level file that zylos components shouldn't modify
2. Doesn't work for PM2-launched tmux sessions (non-interactive shell)

This PR introduces a declarative mechanism: the user lists variable names in `.env`, and zylos-core handles injection. No code changes needed to add/remove variables.

## Usage

```env
# Declare which variables to inject into the tmux session
ZYLOS_TMUX_ENV=OTEL_METRICS_EXPORTER,OTEL_EXPORTER_OTLP_ENDPOINT,CLAUDE_CODE_ENABLE_TELEMETRY

# Define the actual values
OTEL_METRICS_EXPORTER=otlp
OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
CLAUDE_CODE_ENABLE_TELEMETRY=1
```

## Implementation

- `_readManifestEnvVars(envContent)` reads `ZYLOS_TMUX_ENV`, splits by comma, resolves each variable from `.env`
- Resolved vars are written to a temp file (mode 0600), sourced with `set -a`, then deleted — no exposure in `ps`/`/proc/cmdline`
- Claude adapter: manifest vars merged with existing auth token injection path
- Codex adapter: manifest vars injected via env prefix before codex command

## Test plan

- [ ] 11 unit tests covering: manifest parsing, variable resolution, missing vars, quoted values, spaces, empty manifest
- [ ] Verify on zylos01: add `ZYLOS_TMUX_ENV` to `.env`, restart, confirm env vars are present in Claude session
- [ ] Verify OTel data flows to OTLP receiver after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)