### PR TITLE
fix(upgrade): harden symlinked skills rollback

### DIFF
--- a/cli/lib/__tests__/fs-utils.test.js
+++ b/cli/lib/__tests__/fs-utils.test.js
@@ -8,7 +8,7 @@ const tmpDirs = [];
 const origHome = process.env.HOME;
 const origTmpdir = process.env.TMPDIR;
 
-const { copyTree } = await import('../fs-utils.js');
+const { copyTree, syncTree } = await import('../fs-utils.js');
 
 afterEach(() => {
   if (origHome === undefined) {
@@ -33,7 +33,7 @@ function makeTmpDir() {
 }
 
 describe('copyTree', () => {
-  it('backs up a symlink root without precreating dest as a directory', () => {
+  it('backs up the directory behind a symlink root', () => {
     const tmpDir = makeTmpDir();
     const realSkillsDir = path.join(tmpDir, 'real-skills');
     const symlinkSkillsDir = path.join(tmpDir, 'skills');
@@ -46,8 +46,9 @@ describe('copyTree', () => {
     copyTree(symlinkSkillsDir, backupTarget, { excludes: ['node_modules'] });
 
     const stat = fs.lstatSync(backupTarget);
-    assert.equal(stat.isSymbolicLink(), true);
-    assert.equal(fs.readlinkSync(backupTarget), realSkillsDir);
+    assert.equal(stat.isDirectory(), true);
+    assert.equal(stat.isSymbolicLink(), false);
+    assert.equal(fs.readFileSync(path.join(backupTarget, 'manifest.json'), 'utf8'), '{}');
   });
 
   it('falls back to ~/tmp when TMPDIR is not writable during self-copy backup', () => {
@@ -65,5 +66,49 @@ describe('copyTree', () => {
 
     assert.equal(fs.existsSync(path.join(nestedBackup, 'SKILL.md')), true);
     assert.equal(fs.existsSync(path.join(tmpDir, 'tmp')), true);
+  });
+});
+
+describe('syncTree', () => {
+  it('refuses to sync a symlink backup path that resolves to the destination', () => {
+    const tmpDir = makeTmpDir();
+    const skillsDir = path.join(tmpDir, 'skills');
+    const backupDir = path.join(tmpDir, 'backup');
+    const backupSkills = path.join(backupDir, 'skills');
+
+    fs.mkdirSync(skillsDir, { recursive: true });
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(path.join(skillsDir, 'component.txt'), 'keep me', 'utf8');
+    fs.symlinkSync(skillsDir, backupSkills);
+
+    assert.throws(
+      () => syncTree(backupSkills, skillsDir, { excludes: ['node_modules'] }),
+      /Refusing to sync identical paths/
+    );
+    assert.equal(fs.readFileSync(path.join(skillsDir, 'component.txt'), 'utf8'), 'keep me');
+  });
+
+  it('restores from a nested backup while preserving excluded directories', () => {
+    const tmpDir = makeTmpDir();
+    const destDir = path.join(tmpDir, 'skills', 'demo');
+    const srcDir = path.join(destDir, '.backup', 'run-1');
+
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.mkdirSync(path.join(destDir, '.backup'), { recursive: true });
+    fs.mkdirSync(path.join(destDir, 'node_modules'), { recursive: true });
+    fs.mkdirSync(path.join(destDir, '.zylos'), { recursive: true });
+    fs.writeFileSync(path.join(srcDir, 'SKILL.md'), 'old', 'utf8');
+    fs.writeFileSync(path.join(destDir, 'SKILL.md'), 'broken', 'utf8');
+    fs.writeFileSync(path.join(destDir, 'new-file.txt'), 'remove me', 'utf8');
+    fs.writeFileSync(path.join(destDir, 'node_modules', 'keep.txt'), 'deps', 'utf8');
+    fs.writeFileSync(path.join(destDir, '.zylos', 'manifest.json'), '{}', 'utf8');
+
+    syncTree(srcDir, destDir, { excludes: ['node_modules', '.backup', '.zylos'] });
+
+    assert.equal(fs.readFileSync(path.join(destDir, 'SKILL.md'), 'utf8'), 'old');
+    assert.equal(fs.existsSync(path.join(destDir, 'new-file.txt')), false);
+    assert.equal(fs.existsSync(path.join(destDir, '.backup', 'run-1', 'SKILL.md')), true);
+    assert.equal(fs.readFileSync(path.join(destDir, 'node_modules', 'keep.txt'), 'utf8'), 'deps');
+    assert.equal(fs.readFileSync(path.join(destDir, '.zylos', 'manifest.json'), 'utf8'), '{}');
   });
 });

--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -161,6 +161,36 @@ describe('self-upgrade backup and rollback', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('backs up real skill contents when the skills root is a symlink', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-self-upgrade-symlink-backup-'));
+    const zylosDir = path.join(tmpDir, 'zylos');
+    const realSkillsDir = path.join(tmpDir, 'real-skills');
+    const skillsDir = path.join(zylosDir, '.claude', 'skills');
+    const backupDir = path.join(tmpDir, 'backup');
+
+    fs.mkdirSync(path.dirname(skillsDir), { recursive: true });
+    fs.mkdirSync(path.join(realSkillsDir, 'activity-monitor'), { recursive: true });
+    fs.mkdirSync(path.join(realSkillsDir, 'lark'), { recursive: true });
+    fs.writeFileSync(path.join(realSkillsDir, 'activity-monitor', 'SKILL.md'), '# Activity Monitor\n', 'utf8');
+    fs.writeFileSync(path.join(realSkillsDir, 'lark', 'SKILL.md'), '# Lark\n', 'utf8');
+    fs.symlinkSync(realSkillsDir, skillsDir);
+
+    const ctx = {};
+    const result = step1_backupCoreSkills(ctx, {
+      zylosDir,
+      skillsDir,
+      backupDir,
+    });
+
+    assert.equal(result.status, 'done');
+    assert.equal(fs.lstatSync(path.join(backupDir, 'skills')).isDirectory(), true);
+    assert.equal(fs.lstatSync(path.join(backupDir, 'skills')).isSymbolicLink(), false);
+    assert.equal(fs.readFileSync(path.join(backupDir, 'skills', 'activity-monitor', 'SKILL.md'), 'utf8'), '# Activity Monitor\n');
+    assert.equal(fs.readFileSync(path.join(backupDir, 'skills', 'lark', 'SKILL.md'), 'utf8'), '# Lark\n');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   it('restores the backed-up ecosystem before restarting services', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-self-upgrade-rollback-'));
     const zylosDir = path.join(tmpDir, 'zylos');

--- a/cli/lib/__tests__/upgrade-restart.test.js
+++ b/cli/lib/__tests__/upgrade-restart.test.js
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-const { step7_startService } = await import('../upgrade.js');
+const { rollback, step7_startService } = await import('../upgrade.js');
 const { step11_startCoreServices } = await import('../self-upgrade.js');
 const { restartRuntimeServices } = await import('../../commands/runtime.js');
 
@@ -37,6 +37,38 @@ describe('step7_startService', () => {
     assert.equal(result.status, 'done');
     assert.equal(calls.some((call) => call.type === 'ecosystem' && call.names[0] === 'zylos-demo'), true);
     assert.equal(calls.some((call) => call.type === 'exec' && call.cmd === 'pm2 start zylos-demo 2>/dev/null'), false);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe('component upgrade rollback', () => {
+  it('restores from skillDir/.backup/<timestamp> and preserves backup metadata', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-upgrade-rollback-'));
+    const skillDir = path.join(tmpDir, 'skills', 'demo');
+    const backupDir = path.join(skillDir, '.backup', 'run-1');
+
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.mkdirSync(path.join(skillDir, '.zylos'), { recursive: true });
+    fs.mkdirSync(path.join(skillDir, 'node_modules'), { recursive: true });
+    fs.writeFileSync(path.join(backupDir, 'SKILL.md'), 'old\n', 'utf8');
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'broken\n', 'utf8');
+    fs.writeFileSync(path.join(skillDir, 'new-file.txt'), 'remove\n', 'utf8');
+    fs.writeFileSync(path.join(skillDir, '.zylos', 'manifest.json'), '{}\n', 'utf8');
+    fs.writeFileSync(path.join(skillDir, 'node_modules', 'keep.txt'), 'deps\n', 'utf8');
+
+    const results = rollback({
+      backupDir,
+      skillDir,
+      serviceWasRunning: false,
+    });
+
+    assert.equal(results.some((item) => item.action === 'restore_files' && item.success), true);
+    assert.equal(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'), 'old\n');
+    assert.equal(fs.existsSync(path.join(skillDir, 'new-file.txt')), false);
+    assert.equal(fs.readFileSync(path.join(skillDir, '.backup', 'run-1', 'SKILL.md'), 'utf8'), 'old\n');
+    assert.equal(fs.readFileSync(path.join(skillDir, '.zylos', 'manifest.json'), 'utf8'), '{}\n');
+    assert.equal(fs.readFileSync(path.join(skillDir, 'node_modules', 'keep.txt'), 'utf8'), 'deps\n');
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });

--- a/cli/lib/fs-utils.js
+++ b/cli/lib/fs-utils.js
@@ -63,12 +63,9 @@ function cpSyncFiltered(src, dest, excludes) {
  * @param {string[]} [opts.excludes=[]] - Top-level names to exclude
  */
 export function copyTree(src, dest, { excludes = [] } = {}) {
-  const srcStat = fs.lstatSync(src);
-  const destParent = srcStat.isSymbolicLink() ? path.dirname(dest) : dest;
-  fs.mkdirSync(destParent, { recursive: true });
-
-  const resolvedSrc = path.resolve(src);
+  const resolvedSrc = fs.realpathSync(src);
   const resolvedDest = path.resolve(dest);
+  fs.mkdirSync(path.dirname(resolvedDest), { recursive: true });
 
   // Detect self-copy: dest is inside src (e.g., src/.backup/timestamp)
   if (resolvedDest.startsWith(resolvedSrc + path.sep)) {
@@ -83,7 +80,7 @@ export function copyTree(src, dest, { excludes = [] } = {}) {
     return;
   }
 
-  cpSyncFiltered(src, dest, excludes);
+  cpSyncFiltered(resolvedSrc, resolvedDest, excludes);
 }
 
 /**
@@ -101,6 +98,11 @@ export function copyTree(src, dest, { excludes = [] } = {}) {
  */
 export function syncTree(src, dest, { excludes = [] } = {}) {
   fs.mkdirSync(dest, { recursive: true });
+  const resolvedSrc = fs.realpathSync(src);
+  const resolvedDest = fs.realpathSync(dest);
+  if (resolvedSrc === resolvedDest) {
+    throw new Error(`Refusing to sync identical paths: ${src} -> ${dest}`);
+  }
 
   // Remove non-excluded entries in dest (equivalent to rsync --delete)
   const normalized = excludes.map(e => e.replace(/\/+$/, ''));
@@ -110,11 +112,11 @@ export function syncTree(src, dest, { excludes = [] } = {}) {
   }
 
   // Copy from src, skipping excluded entries
-  fs.cpSync(src, dest, {
+  fs.cpSync(resolvedSrc, resolvedDest, {
     recursive: true,
     force: true,
     filter: (source) => {
-      const rel = path.relative(src, source);
+      const rel = path.relative(resolvedSrc, source);
       if (!rel) return true;
       return !isExcluded(rel, excludes);
     },


### PR DESCRIPTION
## Summary
- dereference symlinked source roots in `copyTree()` so self-upgrade backs up real skills contents instead of the live `skills` symlink
- make `syncTree()` resolve source/destination realpaths and refuse same or nested paths before deleting destination entries
- add regressions for symlinked self-upgrade skills backups and rollback/sync overlap safety

## Base
- Confirmed after `git fetch origin`: branch is based on latest `origin/main` at `b6091c7` (`fix(upgrade): run self-upgrade post-install steps from new package (#572)`)

## Tests
- `git diff --check`
- `node scripts/run-node-tests.js cli/lib/__tests__/fs-utils.test.js cli/lib/__tests__/self-upgrade.test.js` (432/432 Node tests passed)
- `npm run test:jest` (79/79 Jest tests passed)