### PR TITLE
feat: support component configure hooks

### DIFF
--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -6,8 +6,10 @@
  *
  * Terminal mode (default): Full interactive setup
  *   1. Resolve target → download → npm install → manifest → register
- *   2. Collect required config (prompt user) → write to .env
- *   3. Run post-install hook → start PM2 service
+ *   2. Collect required config (prompt user)
+ *   3. If lifecycle.hooks.configure exists, pipe config JSON to it
+ *      Otherwise, write to .env for legacy components
+ *   4. Run post-install hook → start PM2 service
  *
  * JSON mode (--json): Mechanical installation only
  *   1. Resolve target → download → npm install → manifest → register
@@ -27,6 +29,7 @@ import { linkBins } from '../lib/bin.js';
 import { applyCaddyRoutes } from '../lib/caddy.js';
 import { promptYesNo, prompt, promptSecret } from '../lib/prompts.js';
 import { writeEnvEntries } from '../lib/env.js';
+import { hasConfigureHook, runConfigureHook } from '../lib/configure-hook.js';
 import { registerService } from '../lib/service.js';
 import { bold, dim, green, red, yellow, cyan, success, error, warn, heading } from '../lib/colors.js';
 
@@ -297,6 +300,8 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
   const lifecycle = fm.lifecycle || {};
   const config = fm.config || {};
   const hooks = lifecycle.hooks || {};
+  const configureHook = hasConfigureHook(hooks) ? hooks.configure : null;
+  let configureResult = null;
 
   // Resolve version: prefer resolved tag, then SKILL.md frontmatter, then package.json
   // When installing from branch, skip resolved.version (it may be auto-populated
@@ -413,6 +418,14 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
       dataDir,
       skill: {
         hooks: Object.keys(hooks).length > 0 ? hooks : null,
+        configure: configureHook ? {
+          hook: configureHook,
+          input: 'stdin_json',
+          legacyEnvFallback: false,
+          runAfterConfigCollection: true,
+          fatalOnFailure: false,
+        } : null,
+        configureResult,
         config: Object.keys(config).length > 0 ? config : null,
         service: lifecycle.service || null,
         bin: binResult || null,
@@ -431,7 +444,7 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
   const requiredConfig = config.required;
   if (Array.isArray(requiredConfig) && requiredConfig.length > 0) {
     console.log(`\n${heading('Configuration:')}`);
-    const envEntries = {};
+    const collectedEntries = {};
 
     for (const item of requiredConfig) {
       const name = typeof item === 'string' ? item : item.name;
@@ -446,17 +459,34 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
         value = await prompt(`  ${name}${hint}: `);
       }
       if (value) {
-        envEntries[name] = value;
+        collectedEntries[name] = value;
       }
     }
 
-    if (Object.keys(envEntries).length > 0) {
-      const envResult = writeEnvEntries(envEntries, resolved.name);
-      if (envResult.written.length > 0) {
-        console.log(`  ${success(`Saved ${envResult.written.length} variable(s) to .env`)}`);
-      }
-      if (envResult.skipped.length > 0) {
-        console.log(`  ${dim(`Skipped existing: ${envResult.skipped.join(', ')}`)}`);
+    if (Object.keys(collectedEntries).length > 0) {
+      if (configureHook) {
+        console.log(`  ${cyan('Running configure hook...')}`);
+        configureResult = runConfigureHook({
+          componentName: resolved.name,
+          skillDir,
+          dataDir,
+          hookRef: configureHook,
+          configValues: collectedEntries,
+        });
+        if (!configureResult.success) {
+          console.log(`  ${warn(`Configure hook failed: ${configureResult.error}`)}`);
+          console.log(`  ${dim('Installation will continue; the component may need manual configuration before it can run.')}`);
+        } else {
+          console.log(`  ${success('Configure hook complete.')}`);
+        }
+      } else {
+        const envResult = writeEnvEntries(collectedEntries, resolved.name);
+        if (envResult.written.length > 0) {
+          console.log(`  ${success(`Saved ${envResult.written.length} variable(s) to .env`)}`);
+        }
+        if (envResult.skipped.length > 0) {
+          console.log(`  ${dim(`Skipped existing: ${envResult.skipped.join(', ')}`)}`);
+        }
       }
     }
   }

--- a/cli/lib/__tests__/configure-hook.test.js
+++ b/cli/lib/__tests__/configure-hook.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { describe, it } from 'node:test';
 
 const {
+  CONFIGURE_HOOK_TIMEOUT_MS,
   hasConfigureHook,
   resolveHookPath,
   runConfigureHook,
@@ -15,6 +16,10 @@ function makeTempDir() {
 }
 
 describe('configure-hook', () => {
+  it('uses a bounded timeout for configure hooks', () => {
+    assert.equal(CONFIGURE_HOOK_TIMEOUT_MS, 30_000);
+  });
+
   it('detects non-empty configure hook declarations', () => {
     assert.equal(hasConfigureHook({ configure: 'hooks/configure.js' }), true);
     assert.equal(hasConfigureHook({ configure: '  ' }), false);

--- a/cli/lib/__tests__/configure-hook.test.js
+++ b/cli/lib/__tests__/configure-hook.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+const {
+  hasConfigureHook,
+  resolveHookPath,
+  runConfigureHook,
+} = await import('../configure-hook.js');
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-configure-hook-'));
+}
+
+describe('configure-hook', () => {
+  it('detects non-empty configure hook declarations', () => {
+    assert.equal(hasConfigureHook({ configure: 'hooks/configure.js' }), true);
+    assert.equal(hasConfigureHook({ configure: '  ' }), false);
+    assert.equal(hasConfigureHook({ 'post-install': 'hooks/post-install.js' }), false);
+    assert.equal(hasConfigureHook(null), false);
+  });
+
+  it('resolves configure hook paths relative to the skill directory', () => {
+    assert.equal(
+      resolveHookPath('/tmp/component', 'hooks/configure.js'),
+      path.resolve('/tmp/component/hooks/configure.js')
+    );
+    assert.equal(resolveHookPath('/tmp/component', ''), null);
+  });
+
+  it('pipes collected config as stdin JSON with component env vars', () => {
+    const root = makeTempDir();
+    const skillDir = path.join(root, 'skill');
+    const dataDir = path.join(root, 'data');
+    const hookDir = path.join(skillDir, 'hooks');
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.mkdirSync(dataDir, { recursive: true });
+
+    const outputPath = path.join(dataDir, 'captured.json');
+    fs.writeFileSync(path.join(hookDir, 'configure.js'), `
+      import fs from 'node:fs';
+      const input = await new Promise((resolve) => {
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', chunk => { data += chunk; });
+        process.stdin.on('end', () => resolve(data));
+      });
+      fs.writeFileSync(process.env.ZYLOS_DATA_DIR + '/captured.json', JSON.stringify({
+        component: process.env.ZYLOS_COMPONENT,
+        skillDir: process.env.ZYLOS_SKILL_DIR,
+        dataDir: process.env.ZYLOS_DATA_DIR,
+        input: JSON.parse(input)
+      }, null, 2));
+    `);
+
+    const result = runConfigureHook({
+      componentName: 'example',
+      skillDir,
+      dataDir,
+      hookRef: 'hooks/configure.js',
+      configValues: { EXAMPLE_API_KEY: 'secret' },
+      stdio: 'pipe',
+    });
+
+    assert.equal(result.success, true);
+    const captured = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    assert.equal(captured.component, 'example');
+    assert.equal(captured.skillDir, skillDir);
+    assert.equal(captured.dataDir, dataDir);
+    assert.deepEqual(captured.input, { EXAMPLE_API_KEY: 'secret' });
+  });
+
+  it('fails when configure hook is declared but missing', () => {
+    const root = makeTempDir();
+    const result = runConfigureHook({
+      componentName: 'missing',
+      skillDir: root,
+      dataDir: root,
+      hookRef: 'hooks/configure.js',
+      configValues: {},
+      stdio: 'pipe',
+    });
+
+    assert.equal(result.success, false);
+    assert.match(result.error, /configure hook not found/);
+  });
+});

--- a/cli/lib/configure-hook.js
+++ b/cli/lib/configure-hook.js
@@ -1,0 +1,73 @@
+/**
+ * Component configure hook runner.
+ *
+ * New components may declare lifecycle.hooks.configure in SKILL.md. Zylos
+ * collects config.required values, then passes them to the hook as stdin JSON.
+ * Legacy components without this hook continue to receive values through .env.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export function hasConfigureHook(hooks) {
+  return typeof hooks?.configure === 'string' && hooks.configure.trim() !== '';
+}
+
+export function resolveHookPath(skillDir, hookRef) {
+  if (!hookRef || typeof hookRef !== 'string') return null;
+  return path.resolve(skillDir, hookRef);
+}
+
+export function runConfigureHook({
+  componentName,
+  skillDir,
+  dataDir,
+  hookRef,
+  configValues,
+  stdio = 'inherit',
+}) {
+  const hookPath = resolveHookPath(skillDir, hookRef);
+  if (!hookPath || !fs.existsSync(hookPath)) {
+    return {
+      success: false,
+      error: `configure hook not found: ${hookRef}`,
+      hookPath,
+    };
+  }
+
+  const child = spawnSync(process.execPath, [hookPath], {
+    cwd: skillDir,
+    input: JSON.stringify(configValues || {}) + '\n',
+    encoding: 'utf8',
+    stdio: ['pipe', stdio, stdio],
+    env: {
+      ...process.env,
+      ZYLOS_COMPONENT: componentName,
+      ZYLOS_SKILL_DIR: skillDir,
+      ZYLOS_DATA_DIR: dataDir,
+    },
+  });
+
+  if (child.error) {
+    return {
+      success: false,
+      error: child.error.message,
+      hookPath,
+    };
+  }
+
+  if (child.status !== 0) {
+    return {
+      success: false,
+      error: `configure hook exited with code ${child.status}`,
+      hookPath,
+      status: child.status,
+    };
+  }
+
+  return {
+    success: true,
+    hookPath,
+  };
+}

--- a/cli/lib/configure-hook.js
+++ b/cli/lib/configure-hook.js
@@ -10,6 +10,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
+export const CONFIGURE_HOOK_TIMEOUT_MS = 30_000;
+
 export function hasConfigureHook(hooks) {
   return typeof hooks?.configure === 'string' && hooks.configure.trim() !== '';
 }
@@ -41,6 +43,7 @@ export function runConfigureHook({
     input: JSON.stringify(configValues || {}) + '\n',
     encoding: 'utf8',
     stdio: ['pipe', stdio, stdio],
+    timeout: CONFIGURE_HOOK_TIMEOUT_MS,
     env: {
       ...process.env,
       ZYLOS_COMPONENT: componentName,

--- a/skills/component-management/SKILL.md
+++ b/skills/component-management/SKILL.md
@@ -75,7 +75,17 @@ config:
 ---
 ```
 
-When `sensitive: true`, the value should be handled carefully (not logged, stored in .env).
+When `sensitive: true`, the value should be handled carefully and not logged.
+
+New components may declare a non-interactive configure hook:
+
+```yaml
+lifecycle:
+  hooks:
+    configure: hooks/configure.js
+```
+
+When present, collect `config.required` values and pipe them as stdin JSON to the hook. The component owns how those values are stored, usually in `~/zylos/components/<name>/config.json`. Components without `hooks.configure` are legacy-compatible and still receive collected values through `~/zylos/.env`.
 
 ---
 

--- a/skills/component-management/references/install.md
+++ b/skills/component-management/references/install.md
@@ -38,7 +38,18 @@ Please provide API_KEY (Your API key):
 ```
 
 For sensitive values, remind user it will be stored securely.
-Write collected values to `~/zylos/.env`.
+
+After collecting values:
+
+- If `skill.configure` or `skill.hooks.configure` exists, pipe the collected values as stdin JSON to that hook:
+
+```bash
+printf '%s\n' '{"API_KEY":"value"}' | ZYLOS_COMPONENT=<component> ZYLOS_SKILL_DIR=~/zylos/.claude/skills/<component> ZYLOS_DATA_DIR=~/zylos/components/<component> node ~/zylos/.claude/skills/<component>/hooks/configure.js
+```
+
+- If the configure hook succeeds, continue.
+- If the configure hook fails, clearly report the failure and continue the install flow. The component may need manual configuration before service start succeeds.
+- If no configure hook exists, write collected values to `~/zylos/.env` for legacy components.
 
 ### Step 4: Set Up PATH for Bin Commands
 
@@ -91,6 +102,9 @@ After `zylos add <name> --json` succeeds, the JSON `skill` field tells you what 
 
 1. **Bin PATH**: If `skill.bin` exists, prefix all subsequent commands with `export PATH="$HOME/zylos/bin:$PATH" && `.
 2. **Config**: If `skill.config.required` exists, inform user which config values are needed. In C4 mode, user provides values via follow-up messages.
+   - If `skill.configure` or `skill.hooks.configure` exists, pipe collected values as stdin JSON to the configure hook with `ZYLOS_COMPONENT`, `ZYLOS_SKILL_DIR`, and `ZYLOS_DATA_DIR` set.
+   - If the configure hook fails, report the failure and continue; do not roll back the installation solely because configuration failed.
+   - If no configure hook exists, write collected values to `~/zylos/.env` for backward compatibility.
 3. **Hooks**: If `skill.hooks.post-install` exists, run it (with PATH prefix if step 1 applied).
 4. **Service**: If `skill.service` exists, start it and verify.
 5. **Next Steps**: If `skill.nextSteps` exists, execute it — see [Next Steps Handling](#next-steps-handling) below.

--- a/skills/component-management/references/install.md
+++ b/skills/component-management/references/install.md
@@ -41,7 +41,7 @@ For sensitive values, remind user it will be stored securely.
 
 After collecting values:
 
-- If `skill.configure` or `skill.hooks.configure` exists, pipe the collected values as stdin JSON to that hook:
+- If `skill.hooks.configure` exists, pipe the collected values as stdin JSON to that hook:
 
 ```bash
 printf '%s\n' '{"API_KEY":"value"}' | ZYLOS_COMPONENT=<component> ZYLOS_SKILL_DIR=~/zylos/.claude/skills/<component> ZYLOS_DATA_DIR=~/zylos/components/<component> node ~/zylos/.claude/skills/<component>/hooks/configure.js
@@ -102,7 +102,7 @@ After `zylos add <name> --json` succeeds, the JSON `skill` field tells you what 
 
 1. **Bin PATH**: If `skill.bin` exists, prefix all subsequent commands with `export PATH="$HOME/zylos/bin:$PATH" && `.
 2. **Config**: If `skill.config.required` exists, inform user which config values are needed. In C4 mode, user provides values via follow-up messages.
-   - If `skill.configure` or `skill.hooks.configure` exists, pipe collected values as stdin JSON to the configure hook with `ZYLOS_COMPONENT`, `ZYLOS_SKILL_DIR`, and `ZYLOS_DATA_DIR` set.
+   - If `skill.hooks.configure` exists, pipe collected values as stdin JSON to the configure hook with `ZYLOS_COMPONENT`, `ZYLOS_SKILL_DIR`, and `ZYLOS_DATA_DIR` set.
    - If the configure hook fails, report the failure and continue; do not roll back the installation solely because configuration failed.
    - If no configure hook exists, write collected values to `~/zylos/.env` for backward compatibility.
 3. **Hooks**: If `skill.hooks.post-install` exists, run it (with PATH prefix if step 1 applied).


### PR DESCRIPTION
## Summary
- add a configure hook runner that pipes collected config values as stdin JSON with component env vars
- bound configure hook execution with a 30s timeout
- update zylos add terminal mode to use lifecycle.hooks.configure when present, while preserving .env writes for legacy components
- expose configure hook metadata in --json output for agent/C4 install flows and update component-management docs

## Compatibility
- components without lifecycle.hooks.configure continue using writeEnvEntries() and ~/zylos/.env
- configure hook failures are reported as warnings and do not roll back or abort installation
- hook runs after npm install/registration/data-dir setup and before post-install/service start

## Related
- Pairs with zylos-component-template PR #25: https://github.com/zylos-ai/zylos-component-template/pull/25

## Tests
- npm test
- node --test cli/lib/__tests__/configure-hook.test.js cli/lib/__tests__/skill.test.js
- git diff --check