### PR TITLE
fix(activity-monitor): match "API Error" whitespace variant + JSON/stale-model patterns

### DIFF
--- a/cli/lib/__tests__/heartbeat-api-error-patterns.test.js
+++ b/cli/lib/__tests__/heartbeat-api-error-patterns.test.js
@@ -28,4 +28,30 @@ describe('heartbeat API error patterns', () => {
 
     assert.equal(result.detected, false);
   });
+
+  it('detects "API Error: 400" with the whitespace variant emitted by current Claude Code', () => {
+    const pane = `
+      ⎿  API Error: 400 {"error":{"code":"400","message":"Param Incorrect",
+                                   "param":"Not supported model claude-opus-4-7"}}
+    `;
+
+    const result = detectApiErrorText(pane);
+
+    assert.equal(result.detected, true);
+    assert.match(result.pattern, /API\s*Error:\s*400/);
+  });
+
+  it('detects raw JSON-format Anthropic errors', () => {
+    const result = detectApiErrorText('error response: {"error":{"code":"400","message":"..."}}');
+
+    assert.equal(result.detected, true);
+    assert.match(result.pattern, /"code"\s*:\s*"400"/);
+  });
+
+  it('detects stale-model-alias rejection text', () => {
+    const result = detectApiErrorText('Not supported model claude-opus-4-7');
+
+    assert.equal(result.detected, true);
+    assert.match(result.pattern, /Not supported model/i);
+  });
 });

--- a/cli/lib/heartbeat/api-error-patterns.js
+++ b/cli/lib/heartbeat/api-error-patterns.js
@@ -2,12 +2,21 @@
 // Keep these specific to CLI/runtime error displays to avoid matching normal
 // conversation text.
 const API_ERROR_PATTERNS = [
-  /APIError:\s*\d{3}/,                                    // "APIError: 400 ..."
+  // Claude Code displays "API Error: 400 ..." (with space) on recent versions;
+  // older releases used "APIError: 400". Allow either form so the proactive
+  // scan keeps firing if the chrome flips again.
+  /API\s*Error:\s*\d{3}/,
   /\b(400|422)\b.*(?:bad request|invalid request)/i,      // "400 Bad Request"
   /invalid_request_error/,                                 // Anthropic error type
   /overloaded_error/,                                      // Anthropic overloaded
   /an image in the conversation exceeds the dimension limit for many-image requests/i,
   /dimension limit for many-image requests\s*\(\s*2000px\s*\)/i,
+  // JSON-format Anthropic error: {"error":{"code":"400",...}} — catches cases
+  // where the pretty error chrome is missing but the raw JSON leaks in.
+  /"code"\s*:\s*"4\d{2}"/,
+  // Stale model alias rejected — surfaced as the "Not supported model ..."
+  // message after a Claude Code model-ID requirement change.
+  /Not supported model/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary

The proactive API-error scan was silently failing on current Claude Code releases because Claude Code v2.1.x renders errors as `API Error: 400 ...` (with a space) while `API_ERROR_PATTERNS[0]` requires `APIError:` (no space). This change relaxes the regex and adds two extra defensive patterns.

## What broke

On 2026-05-12 a long-running runtime hit:

```
API Error: 400 {"error":{"code":"400","message":"Param Incorrect","param":"Not supported model claude-opus-4-7"}}
```

…and stayed unresponsive for **13 hours**:

- The process was alive (`/proc` ok)
- Hooks reported `health=ok` (status hook does not touch the API)
- `c4-dispatcher` auto-acked heartbeats based on the healthy hook state, so they never round-tripped through the broken API
- The Guardian / `detectApiErrorText` scan that exists for exactly this case did not fire, because `/APIError:\s*\d{3}/` does not match `API Error: 400`

13 scheduled tasks + a user DM were dispatcher-marked `delivered` but silently dropped.

## Changes

`cli/lib/heartbeat/api-error-patterns.js`:

- `/APIError:\s*\d{3}/` → `/API\s*Error:\s*\d{3}/` (matches both `API Error` and `APIError`)
- Add `/"code"\s*:\s*"4\d{2}"/` — catches raw Anthropic JSON when the pretty chrome is missing
- Add `/Not supported model/i` — direct catch for the stale-model-alias surface text

`cli/lib/__tests__/heartbeat-api-error-patterns.test.js`:

- Three new regression cases covering the whitespace variant, the raw JSON form, and the stale-model-alias text
- All 6 tests in this file pass (3 new + 3 existing)

## Verification

```
$ node --test cli/lib/__tests__/heartbeat-api-error-patterns.test.js
✔ detects many-image dimension limit errors
✔ detects existing API error patterns
✔ does not match ordinary image discussion text
✔ detects "API Error: 400" with the whitespace variant emitted by current Claude Code
✔ detects raw JSON-format Anthropic errors
✔ detects stale-model-alias rejection text
ℹ pass 6   ℹ fail 0
```

`npm test` shows three pre-existing failures on `main` (fs-utils TMPDIR + two c4-receive/dispatcher module-resolution issues) — unrelated to this patch, present on a clean `upstream/main` checkout as well.

## False-positive risk

- `/API\s*Error:\s*\d{3}/` — same shape as the original, just allows a space; can only match runtime error chrome
- `/"code":"4\d{2}"/` — requires the exact JSON shape Anthropic returns
- `/Not supported model/i` — could appear in conversation text, but the proactive scan already requires **2 consecutive detections 15s apart** before triggering recovery (`activity-monitor.js`), so a single mention in chat is harmless

## Related

Adjacent to #579 (image dimension limit patterns) — same file, same defense-in-depth motivation.