### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-14
+
+### Added
+- **Tmux-launcher clean env**: agent sessions launch in a minimal, allowlisted environment instead of inheriting the full parent process env. Controlled by `ZYLOS_CLEAN_ENV` (default: `true`); set to `false` to fall back to compat mode. Includes `runtime-env.manifest` for declarative env var injection. (#576)
+- **Component configure hooks**: components can declare `lifecycle.hooks.configure` in SKILL.md to receive config values via stdin JSON during installation, replacing manual `.env` injection for supported components (#578)
+- **Health check toggle**: 24h health check can be disabled via `zylos config set health_check_enabled false` (default: on) (#586)
+- **Tool watchdog**: detects Claude web tool-use hangs and hardens tool event recovery (#500)
+
+### Changed
+- **Activity Monitor v3 — modular architecture**: extracted MonitorOrchestrator, HealthEngine, Guardian, MessageRouter, ToolPipeline, ProcSampler, and UsageMonitor into standalone modules with full unit test coverage. No behavioral changes to external APIs. (#545)
+
+### Fixed
+- **PATH deduplication**: prevent PATH bloat across tmux session restarts (#499)
+- **Codex /exit treated as lifecycle control**: C4 dispatcher correctly handles Codex exit commands (#517)
+- **Caddy route prefix forwarding**: stripped route prefix now forwarded to upstream (#521)
+- **npm install timeout**: increased timeout and added progress indicator for slow networks (#522)
+- **Claude default model**: settings model defaults to Opus 4.6 on fresh installs (#567)
+- **Web console timezone**: respects TZ config for timestamp display (#568)
+- **Upgrade: activity monitor env verification**: verifies AM environment via `pm2 jlist` after restart (#570)
+- **Session handoff routing**: handoff summaries routed to internal web-console channel only (#571)
+- **Upgrade: post-install from new package**: self-upgrade runs post-install steps from the newly installed package (#572)
+- **Upgrade: symlinked skills rollback**: hardened rollback for symlinked skill directories (#577)
+- **Activity monitor: image dimension errors**: detects and handles image dimension limit errors from API (#579)
+
 ### Upgrade Notes
 - If self-upgrade fails with `failed to verify activity-monitor PM2 env after restart`, first run `pm2 stop activity-monitor`, then retry with `zylos upgrade --self -y`.
+- Clean env is now the default. If your setup relies on inherited environment variables, set `ZYLOS_CLEAN_ENV=false` in `~/zylos/.env` or add needed variables to `~/.zylos/runtime-env.manifest`.
 
 ## [0.4.13] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Activity monitor: image dimension errors**: detects and handles image dimension limit errors from API (#579)
 
 ### Upgrade Notes
-- If self-upgrade fails with `failed to verify activity-monitor PM2 env after restart`: stop the activity monitor with `pm2 stop activity-monitor`, run the upgrade with `zylos upgrade --self -y`, then restart the activity monitor with `pm2 start activity-monitor`.
+- **⚠️ Upgrading from v0.4.13 or earlier**: you must stop the activity monitor before upgrading, then restart it after. Run: `pm2 stop activity-monitor`, then `zylos upgrade --self -y`, then `pm2 start activity-monitor`. Upgrading without stopping AM first will fail with `failed to verify activity-monitor PM2 env after restart`.
 - Clean env is now the default. If your setup relies on inherited environment variables, set `ZYLOS_CLEAN_ENV=false` in `~/zylos/.env` or add needed variables to `~/.zylos/runtime-env.manifest`.
 
 ## [0.4.13] - 2026-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Activity monitor: image dimension errors**: detects and handles image dimension limit errors from API (#579)
 
 ### Upgrade Notes
-- If self-upgrade fails with `failed to verify activity-monitor PM2 env after restart`, first run `pm2 stop activity-monitor`, then retry with `zylos upgrade --self -y`.
+- If self-upgrade fails with `failed to verify activity-monitor PM2 env after restart`: stop the activity monitor with `pm2 stop activity-monitor`, run the upgrade with `zylos upgrade --self -y`, then restart the activity monitor with `pm2 start activity-monitor`.
 - Clean env is now the default. If your setup relies on inherited environment variables, set `ZYLOS_CLEAN_ENV=false` in `~/zylos/.env` or add needed variables to `~/.zylos/runtime-env.manifest`.
 
 ## [0.4.13] - 2026-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Upgrade Notes
 - **⚠️ Upgrading from v0.4.13 or earlier**: you must stop the activity monitor before upgrading, then restart it after. Run: `pm2 stop activity-monitor`, then `zylos upgrade --self -y`, then `pm2 start activity-monitor`. Upgrading without stopping AM first will fail with `failed to verify activity-monitor PM2 env after restart`.
 - Clean env is now the default. If your setup relies on inherited environment variables, set `ZYLOS_CLEAN_ENV=false` in `~/zylos/.env` or add needed variables to `~/zylos/.zylos/runtime-env.manifest`.
+- **⚠️ Upgrading from v0.4.13 or earlier**: the `runtime-env.manifest` file will not be created automatically (the deploy logic runs from the old version which lacks it). After upgrading, copy the template manually: `cp $(npm root -g)/zylos/templates/runtime-env.manifest.example ~/zylos/.zylos/runtime-env.manifest`. Without this file, the agent session will lack `TZ` and any other manifest-declared variables.
 
 ## [0.4.13] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Upgrade Notes
 - **⚠️ Upgrading from v0.4.13 or earlier**: you must stop the activity monitor before upgrading, then restart it after. Run: `pm2 stop activity-monitor`, then `zylos upgrade --self -y`, then `pm2 start activity-monitor`. Upgrading without stopping AM first will fail with `failed to verify activity-monitor PM2 env after restart`.
-- Clean env is now the default. If your setup relies on inherited environment variables, set `ZYLOS_CLEAN_ENV=false` in `~/zylos/.env` or add needed variables to `~/.zylos/runtime-env.manifest`.
+- Clean env is now the default. If your setup relies on inherited environment variables, set `ZYLOS_CLEAN_ENV=false` in `~/zylos/.env` or add needed variables to `~/zylos/.zylos/runtime-env.manifest`.
 
 ## [0.4.13] - 2026-04-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.4.13",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.4.13",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.4.13",
+  "version": "0.5.0",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary

Release v0.5.0 — Activity Monitor v3, tmux-launcher clean env, component configure hooks, health check toggle, and 11 bug fixes.

### Highlights
- **Tmux-launcher clean env** (#576): agent sessions launch in minimal allowlisted env (default on)
- **Activity Monitor v3** (#545): modular architecture extraction (MonitorOrchestrator, HealthEngine, Guardian, MessageRouter, ToolPipeline, ProcSampler, UsageMonitor)
- **Component configure hooks** (#578): SKILL.md lifecycle hooks for component installation
- **Health check toggle** (#586): `zylos config set health_check_enabled false`

### Changes
- 4 features, 1 refactor, 11 fixes
- See CHANGELOG.md for full details

## Test plan
- [x] Jest: 79/79 pass
- [x] Node tests: 455/455 pass
- [ ] After merge: tag v0.5.0 and create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)