### PR TITLE
fix: restart zylos-dashboard on runtime switch

### DIFF
--- a/cli/commands/runtime.js
+++ b/cli/commands/runtime.js
@@ -303,6 +303,13 @@ async function switchRuntime(target, flags) {
   console.log('\nRestarting services...');
   restartRuntimeServices();
 
+  // Step 8: Restart zylos-dashboard if running (component, not in core ecosystem).
+  // Dashboard reads runtime config to decide which collectors and panels to show.
+  try {
+    execSync('pm2 restart zylos-dashboard 2>/dev/null', { stdio: 'pipe' });
+    console.log(`  ${green('✓')} zylos-dashboard`);
+  } catch {}
+
   const targetLabel = target === 'codex' ? 'Codex (OpenAI)' : 'Claude Code (Anthropic)';
   console.log(`\n${green(`Switched to ${bold(targetLabel)}.`)}`);
   console.log(dim('The new runtime session will be ready in ~10 seconds.'));


### PR DESCRIPTION
## Summary
- `zylos runtime <name>` now restarts `zylos-dashboard` after core services (activity-monitor, c4-dispatcher)
- Dashboard reads runtime config to decide which collectors/panels to show — without restart it served stale runtime state
- Silent error handling: no-op if dashboard component isn't installed

## Test plan
- [ ] Run `zylos runtime codex` — verify dashboard auto-restarts and shows Codex degraded mode
- [ ] Run `zylos runtime claude` — verify dashboard auto-restarts and shows full Claude mode
- [ ] Run on a system without zylos-dashboard installed — verify no error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)