### PR TITLE
feat(upgrade): run post-upgrade hook automatically

### DIFF
--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -673,6 +673,7 @@ async function handleUpgradeFlow(component, { jsonOutput, skipConfirm, skipEval,
       tempDir,
       newVersion: check.latest,
       mode,
+      jsonOutput,
       onStep: !jsonOutput ? printStep : undefined,
     });
 

--- a/cli/lib/__tests__/upgrade-restart.test.js
+++ b/cli/lib/__tests__/upgrade-restart.test.js
@@ -4,20 +4,20 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-const { rollback, step7_startService } = await import('../upgrade.js');
+const { rollback, step8_startService } = await import('../upgrade.js');
 const { step11_startCoreServices } = await import('../self-upgrade.js');
 const { restartRuntimeServices } = await import('../../commands/runtime.js');
 
-describe('step7_startService', () => {
+describe('step8_startService', () => {
   it('retries deleted services through ecosystem restart instead of pm2 start <name>', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-upgrade-step7-'));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-upgrade-step8-'));
     const skillDir = path.join(tmpDir, 'demo');
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `---\nname: demo\nlifecycle:\n  service:\n    name: zylos-demo\n---\n`, 'utf8');
     fs.writeFileSync(path.join(skillDir, 'ecosystem.config.cjs'), 'module.exports = { apps: [] };\n', 'utf8');
 
     const calls = [];
-    const result = step7_startService({
+    const result = step8_startService({
       component: 'demo',
       skillDir,
       serviceWasRunning: true,

--- a/cli/lib/__tests__/upgrade-restart.test.js
+++ b/cli/lib/__tests__/upgrade-restart.test.js
@@ -139,6 +139,28 @@ describe('step7_runPostUpgradeHook', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('skips hook symlinks that resolve outside the skill directory', () => {
+    const { tmpDir, skillDir } = makeSkillDir('lifecycle:\n  hooks:\n    post-upgrade: hooks/outside.js\n');
+    const outsideHook = path.join(tmpDir, 'outside.js');
+    const hookPath = path.join(skillDir, 'hooks', 'outside.js');
+    fs.mkdirSync(path.dirname(hookPath), { recursive: true });
+    fs.writeFileSync(outsideHook, 'console.log("outside");\n', 'utf8');
+    fs.symlinkSync(outsideHook, hookPath);
+
+    try {
+      const result = step7_runPostUpgradeHook({ component: 'demo', skillDir }, {
+        spawnSync: () => {
+          throw new Error('should not run hook');
+        },
+      });
+
+      assert.equal(result.status, 'skipped');
+      assert.match(result.message, /escapes skill directory/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('step8_startService', () => {

--- a/cli/lib/__tests__/upgrade-restart.test.js
+++ b/cli/lib/__tests__/upgrade-restart.test.js
@@ -4,9 +4,142 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-const { rollback, step8_startService } = await import('../upgrade.js');
+const { rollback, step7_runPostUpgradeHook, step8_startService } = await import('../upgrade.js');
 const { step11_startCoreServices } = await import('../self-upgrade.js');
 const { restartRuntimeServices } = await import('../../commands/runtime.js');
+
+function makeSkillDir(frontmatter) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-upgrade-hook-'));
+  const skillDir = path.join(tmpDir, 'demo');
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `---\nname: demo\n${frontmatter}---\n`, 'utf8');
+  return { tmpDir, skillDir };
+}
+
+describe('step7_runPostUpgradeHook', () => {
+  it('skips when no post-upgrade hook is declared', () => {
+    const { tmpDir, skillDir } = makeSkillDir('');
+
+    try {
+      const result = step7_runPostUpgradeHook({ component: 'demo', skillDir }, {
+        spawnSync: () => {
+          throw new Error('should not run hook');
+        },
+      });
+
+      assert.equal(result.status, 'skipped');
+      assert.equal(result.message, 'no post-upgrade hook');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips when the declared hook file is missing', () => {
+    const { tmpDir, skillDir } = makeSkillDir('lifecycle:\n  hooks:\n    post-upgrade: hooks/post-upgrade.js\n');
+
+    try {
+      const result = step7_runPostUpgradeHook({ component: 'demo', skillDir });
+
+      assert.equal(result.status, 'skipped');
+      assert.equal(result.message, 'hook not found: hooks/post-upgrade.js');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('runs an existing hook and returns captured output', () => {
+    const { tmpDir, skillDir } = makeSkillDir('lifecycle:\n  hooks:\n    post-upgrade: hooks/post-upgrade.js\n');
+    const hookPath = path.join(skillDir, 'hooks', 'post-upgrade.js');
+    fs.mkdirSync(path.dirname(hookPath), { recursive: true });
+    fs.writeFileSync(hookPath, 'console.log("ok");\n', 'utf8');
+    const stdoutWrites = [];
+    const stderrWrites = [];
+
+    try {
+      const result = step7_runPostUpgradeHook({ component: 'demo', skillDir, jsonOutput: false }, {
+        spawnSync: (cmd, args, opts) => {
+          assert.equal(cmd, process.execPath);
+          assert.deepEqual(args, [hookPath]);
+          assert.equal(opts.cwd, skillDir);
+          assert.deepEqual(opts.stdio, ['ignore', 'pipe', 'pipe']);
+          return { status: 0, stdout: 'hook stdout\n', stderr: 'hook stderr\n' };
+        },
+        stdout: { write: (value) => stdoutWrites.push(value) },
+        stderr: { write: (value) => stderrWrites.push(value) },
+      });
+
+      assert.equal(result.status, 'done');
+      assert.equal(result.message, 'hooks/post-upgrade.js');
+      assert.deepEqual(result.output, { stdout: 'hook stdout\n', stderr: 'hook stderr\n' });
+      assert.deepEqual(stdoutWrites, ['hook stdout\n']);
+      assert.deepEqual(stderrWrites, ['hook stderr\n']);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a failing hook as non-fatal and keeps diagnostics', () => {
+    const { tmpDir, skillDir } = makeSkillDir('lifecycle:\n  hooks:\n    post-upgrade: hooks/post-upgrade.js\n');
+    const hookPath = path.join(skillDir, 'hooks', 'post-upgrade.js');
+    fs.mkdirSync(path.dirname(hookPath), { recursive: true });
+    fs.writeFileSync(hookPath, 'process.exit(1);\n', 'utf8');
+
+    try {
+      const result = step7_runPostUpgradeHook({ component: 'demo', skillDir, jsonOutput: true }, {
+        spawnSync: () => ({ status: 1, stdout: 'before fail\n', stderr: 'bad things\n' }),
+      });
+
+      assert.equal(result.status, 'skipped');
+      assert.match(result.message, /hook had issues/);
+      assert.match(result.message, /bad things/);
+      assert.deepEqual(result.output, { stdout: 'before fail\n', stderr: 'bad things\n' });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not replay hook output when jsonOutput is enabled', () => {
+    const { tmpDir, skillDir } = makeSkillDir('lifecycle:\n  hooks:\n    post-upgrade: hooks/post-upgrade.js\n');
+    const hookPath = path.join(skillDir, 'hooks', 'post-upgrade.js');
+    fs.mkdirSync(path.dirname(hookPath), { recursive: true });
+    fs.writeFileSync(hookPath, 'console.log("json safe");\n', 'utf8');
+    const stdoutWrites = [];
+    const stderrWrites = [];
+
+    try {
+      const result = step7_runPostUpgradeHook({ component: 'demo', skillDir, jsonOutput: true }, {
+        spawnSync: () => ({ status: 0, stdout: 'hook stdout\n', stderr: 'hook stderr\n' }),
+        stdout: { write: (value) => stdoutWrites.push(value) },
+        stderr: { write: (value) => stderrWrites.push(value) },
+      });
+
+      assert.equal(result.status, 'done');
+      assert.deepEqual(result.output, { stdout: 'hook stdout\n', stderr: 'hook stderr\n' });
+      assert.deepEqual(stdoutWrites, []);
+      assert.deepEqual(stderrWrites, []);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips hook paths that escape the skill directory', () => {
+    const { tmpDir, skillDir } = makeSkillDir('lifecycle:\n  hooks:\n    post-upgrade: ../outside.js\n');
+
+    try {
+      const result = step7_runPostUpgradeHook({ component: 'demo', skillDir }, {
+        existsSync: () => true,
+        spawnSync: () => {
+          throw new Error('should not run hook');
+        },
+      });
+
+      assert.equal(result.status, 'skipped');
+      assert.match(result.message, /escapes skill directory/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('step8_startService', () => {
   it('retries deleted services through ecosystem restart instead of pm2 start <name>', () => {

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -7,7 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { SKILLS_DIR, COMPONENTS_DIR } from './config.js';
 import { loadComponents } from './components.js';
 import { loadLocalRegistry } from './registry.js';
@@ -316,7 +316,7 @@ export function cleanupTemp(tempDir) {
 // Internal: create upgrade context
 // ---------------------------------------------------------------------------
 
-function createContext(component, { tempDir, newVersion, mode } = {}) {
+function createContext(component, { tempDir, newVersion, mode, jsonOutput } = {}) {
   const skillDir = path.join(SKILLS_DIR, component);
   const dataDir = path.join(COMPONENTS_DIR, component);
 
@@ -327,6 +327,7 @@ function createContext(component, { tempDir, newVersion, mode } = {}) {
     tempDir: tempDir || null,
     newVersion: newVersion || null,
     mode: mode || 'merge',
+    jsonOutput: Boolean(jsonOutput),
     // State tracking
     backupDir: null,
     serviceStopped: false,
@@ -504,8 +505,10 @@ function step6_updateCaddyRoutes(ctx) {
  */
 export function step7_runPostUpgradeHook(ctx, deps = {}) {
   const startTime = Date.now();
-  const exec = deps.execSync ?? execSync;
+  const spawn = deps.spawnSync ?? spawnSync;
   const exists = deps.existsSync ?? fs.existsSync;
+  const stdout = deps.stdout ?? process.stdout;
+  const stderr = deps.stderr ?? process.stderr;
 
   const parsed = parseSkillMd(ctx.skillDir);
   const hookRel = parsed?.frontmatter?.lifecycle?.hooks?.['post-upgrade'];
@@ -514,16 +517,45 @@ export function step7_runPostUpgradeHook(ctx, deps = {}) {
   }
 
   const hookPath = path.resolve(ctx.skillDir, hookRel);
+  const hookRelativePath = path.relative(ctx.skillDir, hookPath);
+  if (hookRelativePath.startsWith('..') || path.isAbsolute(hookRelativePath)) {
+    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: `hook path escapes skill directory: ${hookRel}`, duration: Date.now() - startTime };
+  }
   if (!exists(hookPath)) {
     return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: `hook not found: ${hookRel}`, duration: Date.now() - startTime };
   }
 
-  try {
-    exec(`node "${hookPath}"`, { cwd: ctx.skillDir, stdio: 'inherit' });
-    return { step: 7, name: 'post_upgrade_hook', status: 'done', message: hookRel, duration: Date.now() - startTime };
-  } catch {
-    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: 'hook had issues (non-fatal)', duration: Date.now() - startTime };
+  const child = spawn(process.execPath, [hookPath], {
+    cwd: ctx.skillDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const hookStdout = child.stdout || '';
+  const hookStderr = child.stderr || '';
+  if (!ctx.jsonOutput) {
+    if (hookStdout) stdout.write(hookStdout);
+    if (hookStderr) stderr.write(hookStderr);
   }
+
+  const output = {
+    stdout: truncateHookOutput(hookStdout),
+    stderr: truncateHookOutput(hookStderr),
+  };
+
+  if (child.error) {
+    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: `hook had issues (non-fatal): ${child.error.message}`, output, duration: Date.now() - startTime };
+  }
+  if (child.status !== 0) {
+    const detail = hookStderr.trim() || hookStdout.trim() || `exit code ${child.status}`;
+    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: `hook had issues (non-fatal): ${truncateHookOutput(detail)}`, output, duration: Date.now() - startTime };
+  }
+  return { step: 7, name: 'post_upgrade_hook', status: 'done', message: hookRel, output, duration: Date.now() - startTime };
+}
+
+function truncateHookOutput(value, maxLength = 1000) {
+  if (!value) return '';
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
 }
 
 /**
@@ -628,8 +660,8 @@ export function rollback(ctx) {
  * @param {{ tempDir: string, newVersion: string }} opts
  * @returns {object} Upgrade result
  */
-export function runUpgrade(component, { tempDir, newVersion, mode, onStep } = {}) {
-  const ctx = createContext(component, { tempDir, newVersion, mode });
+export function runUpgrade(component, { tempDir, newVersion, mode, jsonOutput, onStep } = {}) {
+  const ctx = createContext(component, { tempDir, newVersion, mode, jsonOutput });
 
   if (!fs.existsSync(ctx.skillDir)) {
     return {

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -525,6 +525,13 @@ export function step7_runPostUpgradeHook(ctx, deps = {}) {
     return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: `hook not found: ${hookRel}`, duration: Date.now() - startTime };
   }
 
+  const realSkillDir = fs.realpathSync(ctx.skillDir);
+  const realHookPath = fs.realpathSync(hookPath);
+  const realHookRelativePath = path.relative(realSkillDir, realHookPath);
+  if (realHookRelativePath.startsWith('..') || path.isAbsolute(realHookRelativePath)) {
+    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: `hook path escapes skill directory: ${hookRel}`, duration: Date.now() - startTime };
+  }
+
   const child = spawn(process.execPath, [hookPath], {
     cwd: ctx.skillDir,
     encoding: 'utf8',

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -496,9 +496,40 @@ function step6_updateCaddyRoutes(ctx) {
 }
 
 /**
- * Step 7: restart PM2 service (if it was running before upgrade)
+ * Step 7: run post-upgrade hook (non-fatal).
+ *
+ * Mirrors the post-install soft-failure pattern in cli/commands/add.js: hook
+ * problems are reported as 'skipped' (not 'failed') so they never trigger a
+ * rollback of an otherwise-successful upgrade.
  */
-export function step7_startService(ctx, deps = {}) {
+export function step7_runPostUpgradeHook(ctx, deps = {}) {
+  const startTime = Date.now();
+  const exec = deps.execSync ?? execSync;
+  const exists = deps.existsSync ?? fs.existsSync;
+
+  const parsed = parseSkillMd(ctx.skillDir);
+  const hookRel = parsed?.frontmatter?.lifecycle?.hooks?.['post-upgrade'];
+  if (!hookRel) {
+    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: 'no post-upgrade hook', duration: Date.now() - startTime };
+  }
+
+  const hookPath = path.resolve(ctx.skillDir, hookRel);
+  if (!exists(hookPath)) {
+    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: `hook not found: ${hookRel}`, duration: Date.now() - startTime };
+  }
+
+  try {
+    exec(`node "${hookPath}"`, { cwd: ctx.skillDir, stdio: 'inherit' });
+    return { step: 7, name: 'post_upgrade_hook', status: 'done', message: hookRel, duration: Date.now() - startTime };
+  } catch {
+    return { step: 7, name: 'post_upgrade_hook', status: 'skipped', message: 'hook had issues (non-fatal)', duration: Date.now() - startTime };
+  }
+}
+
+/**
+ * Step 8: restart PM2 service (if it was running before upgrade)
+ */
+export function step8_startService(ctx, deps = {}) {
   const startTime = Date.now();
   const exec = deps.execSync ?? execSync;
   const exists = deps.existsSync ?? fs.existsSync;
@@ -506,7 +537,7 @@ export function step7_startService(ctx, deps = {}) {
   const restartViaEcosystem = deps.restartFromEcosystem ?? restartFromEcosystem;
 
   if (!ctx.serviceWasRunning) {
-    return { step: 7, name: 'start_service', status: 'skipped', message: 'was not running', duration: Date.now() - startTime };
+    return { step: 8, name: 'start_service', status: 'skipped', message: 'was not running', duration: Date.now() - startTime };
   }
 
   const parsed = parseSkillMd(ctx.skillDir);
@@ -515,9 +546,9 @@ export function step7_startService(ctx, deps = {}) {
 
   try {
     restartManaged(serviceName, { ecosystemPath, stdio: 'pipe' });
-    return { step: 7, name: 'start_service', status: 'done', message: serviceName, duration: Date.now() - startTime };
+    return { step: 8, name: 'start_service', status: 'done', message: serviceName, duration: Date.now() - startTime };
   } catch {
-    // If the process disappeared from PM2 between step1 and step7, retry via
+    // If the process disappeared from PM2 between step1 and step8, retry via
     // the component ecosystem so PM2 reloads the current service definition.
     try {
       if (!exists(ecosystemPath)) {
@@ -525,9 +556,9 @@ export function step7_startService(ctx, deps = {}) {
       }
       try { exec(`pm2 delete "${serviceName}" 2>/dev/null`, { stdio: 'pipe' }); } catch {}
       restartViaEcosystem([serviceName], { ecosystemPath, stdio: 'pipe' });
-      return { step: 7, name: 'start_service', status: 'done', message: `${serviceName} (restarted from ecosystem)`, duration: Date.now() - startTime };
+      return { step: 8, name: 'start_service', status: 'done', message: `${serviceName} (restarted from ecosystem)`, duration: Date.now() - startTime };
     } catch {
-      return { step: 7, name: 'start_service', status: 'failed', error: `Failed to restart ${serviceName}`, duration: Date.now() - startTime };
+      return { step: 8, name: 'start_service', status: 'failed', error: `Failed to restart ${serviceName}`, duration: Date.now() - startTime };
     }
   }
 }
@@ -590,8 +621,7 @@ export function rollback(ctx) {
 // ---------------------------------------------------------------------------
 
 /**
- * Run the 7-step upgrade pipeline (mechanical operations only).
- * Post-upgrade hooks are handled by Claude after this completes.
+ * Run the 8-step upgrade pipeline (mechanical operations only).
  * Lock must be acquired by caller (component.js).
  *
  * @param {string} component
@@ -625,7 +655,8 @@ export function runUpgrade(component, { tempDir, newVersion, mode, onStep } = {}
     step4_npmInstall,
     step5_generateManifest,
     step6_updateCaddyRoutes,
-    step7_startService,
+    step7_runPostUpgradeHook,
+    step8_startService,
   ];
 
   const total = steps.length;


### PR DESCRIPTION
Insert step7_runPostUpgradeHook before service restart in the component upgrade pipeline, mirroring the post-install soft-failure pattern in cli/commands/add.js. Hook errors are reported as 'skipped' so they never trigger a rollback of an otherwise-successful upgrade. Service restart becomes step 8.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
