### PR TITLE
refactor(activity-monitor): translate user messages to English

### DIFF
--- a/skills/activity-monitor/scripts/__tests__/message-router.test.js
+++ b/skills/activity-monitor/scripts/__tests__/message-router.test.js
@@ -41,10 +41,10 @@ function routeRequest(overrides = {}) {
 
 describe('messageForRoute', () => {
   it('maps reason prefixes and health fallbacks', () => {
-    assert.match(messageForRoute({ health: 'unavailable', reason: 'tool_timeout_exec' }), /工具执行卡住/);
-    assert.match(messageForRoute({ health: 'unavailable', reason: 'sticky_context_restart' }), /上下文异常/);
-    assert.match(messageForRoute({ health: 'rate_limited', reason: '' }), /限流/);
-    assert.match(messageForRoute({ health: 'auth_failed', reason: '' }), /认证不可用/);
+    assert.match(messageForRoute({ health: 'unavailable', reason: 'tool_timeout_exec' }), /tool execution got stuck/i);
+    assert.match(messageForRoute({ health: 'unavailable', reason: 'sticky_context_restart' }), /session context/i);
+    assert.match(messageForRoute({ health: 'rate_limited', reason: '' }), /rate-limited/i);
+    assert.match(messageForRoute({ health: 'auth_failed', reason: '' }), /authentication/i);
   });
 });
 
@@ -96,7 +96,7 @@ describe('MessageRouter route', () => {
     assert.equal(probeCalls, 1);
     assert.equal(decision.recovered, false);
     assert.equal(decision.health, 'rate_limited');
-    assert.match(decision.userMessage, /限流/);
+    assert.match(decision.userMessage, /rate-limited/i);
   });
 
   it('returns cached negative decisions without probing', async () => {

--- a/skills/activity-monitor/scripts/message-router.js
+++ b/skills/activity-monitor/scripts/message-router.js
@@ -6,25 +6,25 @@ export const ROUTE_PROBE_TIMEOUT_MS = 25000;
 
 const USER_MESSAGE_CATALOG = {
   rate_limit_detected:
-    '我现在被上游服务限流了，稍后会自动恢复。你的消息已收到，但暂时不会进入处理队列。',
+    'I am currently being rate-limited by the upstream service and will recover automatically. Your message has been received but will not enter the processing queue for now.',
   rate_limit_cooldown_expired:
-    '我正在从限流状态恢复，请稍后再试。',
+    'I am recovering from rate-limiting, please try again later.',
   auth_still_failed:
-    '我当前认证不可用，需要管理员处理后才能继续。',
+    'Authentication is currently unavailable. An administrator needs to resolve this before I can continue.',
   auth_check_failed:
-    '我当前认证不可用，需要管理员处理后才能继续。',
+    'Authentication is currently unavailable. An administrator needs to resolve this before I can continue.',
   heartbeat_timeout:
-    '我现在暂时没有响应，正在尝试恢复。请稍后再发一次。',
+    'I am temporarily unresponsive and attempting to recover. Please resend your message shortly.',
   heartbeat_failed:
-    '我现在暂时没有响应，正在尝试恢复。请稍后再发一次。',
+    'I am temporarily unresponsive and attempting to recover. Please resend your message shortly.',
   sticky_context_restart:
-    '我检测到当前会话上下文异常，正在切换到新会话恢复。请稍后再发一次。',
+    'I detected an issue with the current session context and am switching to a new session to recover. Please resend your message shortly.',
   tool_timeout:
-    '我刚才的工具执行卡住了，正在重启会话恢复。请稍后再发一次。',
+    'A tool execution got stuck. I am restarting the session to recover. Please resend your message shortly.',
   unavailable:
-    '我现在暂时不可用，正在尝试恢复。请稍后再发一次。',
+    'I am temporarily unavailable and attempting to recover. Please resend your message shortly.',
   unknown:
-    '我现在暂时不可用，正在尝试恢复。请稍后再发一次。',
+    'I am temporarily unavailable and attempting to recover. Please resend your message shortly.',
 };
 
 function nowMs() {

--- a/skills/activity-monitor/scripts/monitor.js
+++ b/skills/activity-monitor/scripts/monitor.js
@@ -517,7 +517,7 @@ function startMessageRouterServer(activeEngine) {
           recovered: false,
           health: 'unavailable',
           reason: 'message_router_error',
-          userMessage: '我现在暂时不可用，正在尝试恢复。请稍后再发一次。',
+          userMessage: 'I am temporarily unavailable and attempting to recover. Please resend your message shortly.',
           error: err.message
         })}\n`);
       }


### PR DESCRIPTION
## Summary
- Replace all Chinese user-facing messages in `USER_MESSAGE_CATALOG` with English equivalents
- Update the hardcoded fallback message in `monitor.js` to English
- Update test assertions to match the new English messages

## Test plan
- [x] All 7 message-router tests pass (`node --test scripts/__tests__/message-router.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)