### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-25
+
+### Changed
+- **Activity Monitor user-facing messages**: translated runtime-facing status and route messages to English for consistency. (#591)
+
+### Fixed
+- **Component upgrade post-upgrade hooks**: component upgrades now run `lifecycle.hooks.post-upgrade` inside the CLI upgrade pipeline before service restart, while preserving `--json` output as a single parseable JSON object. Hook stdout/stderr are captured into bounded step metadata, replayed only in human output mode, and hook failures remain non-fatal with diagnostics. Hook path validation now rejects both lexical escapes and symlink escapes outside the component directory. (#589)
+- **Web console dependencies**: updated `qs` to 6.15.2 via npm overrides to address CVE-2026-8723 / GHSA-q8mj-m7cp-5q26, and updated `ws` to 8.21.0 to clear the current web-console npm audit report.
+
 ## [0.5.0] - 2026-05-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",

--- a/skills/web-console/package-lock.json
+++ b/skills/web-console/package-lock.json
@@ -11,7 +11,7 @@
         "better-sqlite3": "^12.6.2",
         "dotenv": "^16.6.1",
         "express": "^4.18.2",
-        "ws": "^8.16.0"
+        "ws": "^8.20.1"
       }
     },
     "node_modules/accepts": {
@@ -862,9 +862,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1264,9 +1264,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/skills/web-console/package.json
+++ b/skills/web-console/package.json
@@ -11,9 +11,10 @@
     "better-sqlite3": "^12.6.2",
     "dotenv": "^16.6.1",
     "express": "^4.18.2",
-    "ws": "^8.16.0"
+    "ws": "^8.20.1"
   },
   "overrides": {
-    "path-to-regexp": "0.1.13"
+    "path-to-regexp": "0.1.13",
+    "qs": "6.15.2"
   }
 }


### PR DESCRIPTION
## Summary

Prepare zylos-core v0.5.1 release.

Changes since v0.5.0:
- #591 Activity Monitor user-facing messages translated to English
- #589 Component upgrade post-upgrade hooks run in the CLI upgrade pipeline with JSON-safe output capture, non-fatal diagnostics, and path/symlink boundary validation
- Dependabot #14 / CVE-2026-8723: web-console `qs` updated to 6.15.2 via npm override
- web-console `ws` updated to 8.21.0 to clear the current web-console npm audit report

## Verification

- `git diff --check`
- root `npm test` — 462 tests passed
- `npm audit --json` in `skills/web-console` — 0 vulnerabilities

## Release steps after merge

- Tag `v0.5.1` on the release commit
- Publish GitHub release from the changelog entry
