### PR TITLE
fix(c4): cooldown repeated status notices

### DIFF
--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -61,6 +61,10 @@ function openDb(tmpDir) {
   return new Database(path.join(tmpDir, 'comm-bridge', 'c4.db'));
 }
 
+function readCooldowns(tmpDir) {
+  return JSON.parse(fs.readFileSync(path.join(tmpDir, 'activity-monitor', 'status-notice-cooldowns.json'), 'utf8'));
+}
+
 function createChannelSendScript(tmpDir, channel, { exitCode = 0 } = {}) {
   const scriptDir = path.join(tmpDir, '.claude', 'skills', channel, 'scripts');
   fs.mkdirSync(scriptDir, { recursive: true });
@@ -360,6 +364,49 @@ describe('c4-receive health gating', () => {
       assert.equal(fs.existsSync(pendingPath), false);
     });
   });
+
+  it('fallback suppresses repeated status notices by normalized endpoint and public health', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      fs.writeFileSync(path.join(tmpDir, 'activity-monitor', 'agent-status.json'), JSON.stringify({ health: 'down' }));
+      createChannelSendScript(tmpDir, 'test-chan');
+
+      const first = cliRaw([
+        '--channel', 'test-chan',
+        '--endpoint', 'oc_123|type:group|root:om_root|parent:om_a|msg:om_a',
+        '--json',
+        '--content', 'first'
+      ], env);
+      assert.equal(first.status, 0);
+      assert.equal(parseJsonStdout(first.stdout).action, 'delivered');
+
+      const second = cliRaw([
+        '--channel', 'test-chan',
+        '--endpoint', 'oc_123|type:group|root:om_root|parent:om_b|msg:om_b',
+        '--json',
+        '--content', 'second'
+      ], env);
+      assert.equal(second.status, 0);
+      const out = parseJsonStdout(second.stdout);
+      assert.equal(out.action, 'suppressed');
+
+      const cooldowns = readCooldowns(tmpDir);
+      const entries = Object.values(cooldowns);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].endpoint, 'oc_123|type:group|root:om_root');
+      assert.equal(entries[0].status_type, 'unavailable');
+      assert.equal(entries[0].reason, 'unavailable');
+
+      const db = openDb(tmpDir);
+      const inboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'in'").get();
+      const outboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'out'").get();
+      const suppressed = db.prepare("SELECT content FROM conversations WHERE id = ?").get(Number(out.id));
+      db.close();
+
+      assert.equal(inboundCount.count, 2);
+      assert.equal(outboundCount.count, 1);
+      assert.match(suppressed.content, /Status notification suppressed by cooldown/);
+    });
+  });
 });
 
 describe('c4-receive MessageRouter IPC route', () => {
@@ -410,6 +457,54 @@ describe('c4-receive MessageRouter IPC route', () => {
         db.close();
         assert.equal(inbound.status, 'delivered');
         assert.ok(inbound.content.includes('blocked msg'));
+      });
+    });
+  });
+
+  it('suppresses repeated router unhealthy status notices', async () => {
+    await withTmpDirAsync(async ({ tmpDir, env }) => {
+      createChannelSendScript(tmpDir, 'test-chan');
+      await withRouteServer(tmpDir, (request) => ({
+        version: 1,
+        requestId: request.requestId,
+        recovered: false,
+        health: 'unavailable',
+        reason: 'heartbeat_timeout',
+        userMessage: 'router says unavailable'
+      }), async () => {
+        const first = await cliRawAsync([
+          '--channel', 'test-chan',
+          '--endpoint', 'oc_123|type:group|root:om_root|parent:om_a|msg:om_a',
+          '--json',
+          '--content', 'first'
+        ], env);
+        assert.equal(first.status, 0);
+        assert.equal(parseJsonStdout(first.stdout).action, 'delivered');
+
+        const second = await cliRawAsync([
+          '--channel', 'test-chan',
+          '--endpoint', 'oc_123|type:group|root:om_root|parent:om_b|msg:om_b',
+          '--json',
+          '--content', 'second'
+        ], env);
+        assert.equal(second.status, 0);
+        const out = parseJsonStdout(second.stdout);
+        assert.equal(out.action, 'suppressed');
+
+        const cooldowns = readCooldowns(tmpDir);
+        const entries = Object.values(cooldowns);
+        assert.equal(entries.length, 1);
+        assert.equal(entries[0].endpoint, 'oc_123|type:group|root:om_root');
+        assert.equal(entries[0].status_type, 'unavailable');
+        assert.equal(entries[0].reason, 'heartbeat_timeout');
+
+        const db = openDb(tmpDir);
+        const outboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'out'").get();
+        const suppressed = db.prepare("SELECT content FROM conversations WHERE id = ?").get(Number(out.id));
+        db.close();
+
+        assert.equal(outboundCount.count, 1);
+        assert.match(suppressed.content, /Status notification suppressed by cooldown/);
       });
     });
   });

--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -77,6 +77,18 @@ process.exit(${exitCode});
 `);
 }
 
+function createSlowAppendChannelSendScript(tmpDir, channel) {
+  const scriptDir = path.join(tmpDir, '.claude', 'skills', channel, 'scripts');
+  fs.mkdirSync(scriptDir, { recursive: true });
+  fs.writeFileSync(path.join(scriptDir, 'send.js'), `
+import fs from 'node:fs';
+import path from 'node:path';
+const outPath = path.join(process.env.ZYLOS_DIR, '${channel}-send.jsonl');
+await new Promise((resolve) => setTimeout(resolve, 500));
+fs.appendFileSync(outPath, JSON.stringify({ args: process.argv.slice(2), pid: process.pid }) + '\\n');
+`);
+}
+
 async function withRouteServer(tmpDir, handler, fn) {
   const socketPath = path.join(tmpDir, 'activity-monitor', 'am.sock');
   await fs.promises.rm(socketPath, { force: true });
@@ -405,6 +417,47 @@ describe('c4-receive health gating', () => {
       assert.equal(inboundCount.count, 2);
       assert.equal(outboundCount.count, 1);
       assert.match(suppressed.content, /Status notification suppressed by cooldown/);
+    });
+  });
+
+  it('fallback reserves status notice cooldown before sending so concurrent receives suppress duplicates', async () => {
+    await withTmpDirAsync(async ({ tmpDir, env }) => {
+      fs.writeFileSync(path.join(tmpDir, 'activity-monitor', 'agent-status.json'), JSON.stringify({ health: 'down' }));
+      createSlowAppendChannelSendScript(tmpDir, 'test-chan');
+
+      const argsA = [
+        '--channel', 'test-chan',
+        '--endpoint', 'oc_123|type:group|root:om_root|parent:om_a|msg:om_a',
+        '--json',
+        '--content', 'first concurrent'
+      ];
+      const argsB = [
+        '--channel', 'test-chan',
+        '--endpoint', 'oc_123|type:group|root:om_root|parent:om_b|msg:om_b',
+        '--json',
+        '--content', 'second concurrent'
+      ];
+
+      const results = await Promise.all([
+        cliRawAsync(argsA, env),
+        cliRawAsync(argsB, env)
+      ]);
+      assert.deepEqual(results.map((r) => r.status), [0, 0]);
+      const actions = results.map((r) => parseJsonStdout(r.stdout).action).sort();
+      assert.deepEqual(actions, ['delivered', 'suppressed']);
+
+      const sendLog = fs.readFileSync(path.join(tmpDir, 'test-chan-send.jsonl'), 'utf8').trim().split('\n');
+      assert.equal(sendLog.length, 1);
+
+      const db = openDb(tmpDir);
+      const inboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'in'").get();
+      const outboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'out'").get();
+      const suppressedCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE content LIKE '%Status notification suppressed by cooldown%'").get();
+      db.close();
+
+      assert.equal(inboundCount.count, 2);
+      assert.equal(outboundCount.count, 1);
+      assert.equal(suppressedCount.count, 1);
     });
   });
 

--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -407,6 +407,53 @@ describe('c4-receive health gating', () => {
       assert.match(suppressed.content, /Status notification suppressed by cooldown/);
     });
   });
+
+  it('prunes expired status notice cooldown entries when recording a notification', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      const monitorDir = path.join(tmpDir, 'activity-monitor');
+      const cooldownPath = path.join(monitorDir, 'status-notice-cooldowns.json');
+      const now = Math.floor(Date.now() / 1000);
+      fs.writeFileSync(path.join(monitorDir, 'agent-status.json'), JSON.stringify({ health: 'down' }));
+      fs.writeFileSync(cooldownPath, JSON.stringify({
+        'old::ep::unavailable::old': {
+          channel: 'old',
+          endpoint: 'ep',
+          status_type: 'unavailable',
+          reason: 'old',
+          last_notified_at: now - 9999
+        },
+        'recent::ep::unavailable::recent': {
+          channel: 'recent',
+          endpoint: 'ep',
+          status_type: 'unavailable',
+          reason: 'recent',
+          last_notified_at: now
+        },
+        'malformed::ep::unavailable::bad': {
+          channel: 'malformed',
+          endpoint: 'ep',
+          status_type: 'unavailable',
+          reason: 'bad',
+          last_notified_at: 'not-a-number'
+        }
+      }));
+      createChannelSendScript(tmpDir, 'test-chan');
+
+      const r = cliRaw(['--channel', 'test-chan', '--endpoint', 'ep1', '--json', '--content', 'new notice'], env);
+      assert.equal(r.status, 0);
+      assert.equal(parseJsonStdout(r.stdout).action, 'delivered');
+
+      const cooldowns = readCooldowns(tmpDir);
+      assert.equal(cooldowns['old::ep::unavailable::old'], undefined);
+      assert.equal(cooldowns['malformed::ep::unavailable::bad'], undefined);
+      assert.ok(cooldowns['recent::ep::unavailable::recent']);
+      assert.ok(cooldowns['test-chan::ep1::unavailable::unavailable']);
+      assert.deepEqual(
+        fs.readdirSync(monitorDir).filter((name) => name.includes('status-notice-cooldowns.json.tmp')),
+        []
+      );
+    });
+  });
 });
 
 describe('c4-receive MessageRouter IPC route', () => {

--- a/skills/comm-bridge/scripts/c4-config.js
+++ b/skills/comm-bridge/scripts/c4-config.js
@@ -51,6 +51,7 @@ export const AGENT_STATUS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'agent-status.j
 export const PROC_STATE_FILE = path.join(ACTIVITY_MONITOR_DIR, 'proc-state.json');
 export const API_ACTIVITY_FILE = path.join(ACTIVITY_MONITOR_DIR, 'api-activity.json');
 export const PENDING_CHANNELS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'pending-channels.jsonl');
+export const STATUS_NOTICE_COOLDOWNS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'status-notice-cooldowns.json');
 export const ATTACHMENTS_DIR = path.join(DATA_DIR, 'attachments');
 export const SKILLS_DIR = path.join(ZYLOS_DIR, '.claude', 'skills');
 

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -287,10 +287,23 @@ function readStatusNoticeCooldowns() {
 function writeStatusNoticeCooldowns(cooldowns) {
   try {
     fs.mkdirSync(path.dirname(STATUS_NOTICE_COOLDOWNS_FILE), { recursive: true });
-    fs.writeFileSync(STATUS_NOTICE_COOLDOWNS_FILE, JSON.stringify(cooldowns, null, 2), 'utf8');
+    const tmp = `${STATUS_NOTICE_COOLDOWNS_FILE}.tmp.${process.pid}.${Date.now()}`;
+    fs.writeFileSync(tmp, `${JSON.stringify(cooldowns, null, 2)}\n`, 'utf8');
+    fs.renameSync(tmp, STATUS_NOTICE_COOLDOWNS_FILE);
   } catch (err) {
     console.error(`[C4] Warning: failed to write status cooldowns (${err.message})`);
   }
+}
+
+function pruneStatusNoticeCooldowns(cooldowns, ttl, now = Math.floor(Date.now() / 1000)) {
+  const pruned = {};
+  for (const [key, entry] of Object.entries(cooldowns || {})) {
+    const lastNotifiedAt = Number(entry?.last_notified_at);
+    if (!Number.isFinite(lastNotifiedAt)) continue;
+    if ((now - lastNotifiedAt) >= ttl) continue;
+    pruned[key] = entry;
+  }
+  return pruned;
 }
 
 function getStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
@@ -310,7 +323,10 @@ function getStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date
 
 function recordStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
   const key = statusNoticeCooldownKey(channel, endpoint, route);
-  const cooldowns = readStatusNoticeCooldowns();
+  const ttl = Number.isFinite(STATUS_NOTICE_COOLDOWN_SECONDS) && STATUS_NOTICE_COOLDOWN_SECONDS > 0
+    ? STATUS_NOTICE_COOLDOWN_SECONDS
+    : 600;
+  const cooldowns = pruneStatusNoticeCooldowns(readStatusNoticeCooldowns(), ttl, now);
   cooldowns[key] = {
     channel,
     endpoint: normalizeStatusEndpoint(endpoint),

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -16,13 +16,15 @@ import {
   ATTACHMENTS_DIR,
   CONTENT_PREVIEW_CHARS,
   AGENT_STATUS_FILE,
-  ACTIVITY_MONITOR_DIR
+  ACTIVITY_MONITOR_DIR,
+  STATUS_NOTICE_COOLDOWNS_FILE
 } from './c4-config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const AM_SOCKET_PATH = path.join(ACTIVITY_MONITOR_DIR, 'am.sock');
 const ROUTER_IPC_TIMEOUT_MS = 30000;
+const STATUS_NOTICE_COOLDOWN_SECONDS = Number.parseInt(process.env.C4_STATUS_NOTICE_COOLDOWN_SECONDS || '600', 10);
 
 function printUsage() {
   console.log('Usage: node c4-receive.js --channel <channel> [--endpoint <endpoint_id>] [--priority <1-3>] [--no-reply] [--block-queue-until-idle] [--json] --content "<message>"');
@@ -251,6 +253,74 @@ function sendUnhealthyMessage(channel, endpoint, message) {
   return result;
 }
 
+function normalizeStatusEndpoint(endpoint) {
+  if (!endpoint) return '';
+  return endpoint.replace(/\|(msg|req|parent):[^|]+/g, '');
+}
+
+function statusNoticeType(route) {
+  return publicHealth(route?.health);
+}
+
+function statusNoticeReason(route) {
+  return String(route?.reason || statusNoticeType(route) || 'default');
+}
+
+function statusNoticeCooldownKey(channel, endpoint, route) {
+  return [
+    channel || 'unknown',
+    normalizeStatusEndpoint(endpoint),
+    statusNoticeType(route),
+    statusNoticeReason(route)
+  ].join('::');
+}
+
+function readStatusNoticeCooldowns() {
+  try {
+    if (!fs.existsSync(STATUS_NOTICE_COOLDOWNS_FILE)) return {};
+    return JSON.parse(fs.readFileSync(STATUS_NOTICE_COOLDOWNS_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeStatusNoticeCooldowns(cooldowns) {
+  try {
+    fs.mkdirSync(path.dirname(STATUS_NOTICE_COOLDOWNS_FILE), { recursive: true });
+    fs.writeFileSync(STATUS_NOTICE_COOLDOWNS_FILE, JSON.stringify(cooldowns, null, 2), 'utf8');
+  } catch (err) {
+    console.error(`[C4] Warning: failed to write status cooldowns (${err.message})`);
+  }
+}
+
+function getStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
+  const ttl = Number.isFinite(STATUS_NOTICE_COOLDOWN_SECONDS) && STATUS_NOTICE_COOLDOWN_SECONDS > 0
+    ? STATUS_NOTICE_COOLDOWN_SECONDS
+    : 600;
+  const key = statusNoticeCooldownKey(channel, endpoint, route);
+  const cooldowns = readStatusNoticeCooldowns();
+  const previous = cooldowns[key];
+
+  if (previous && Number.isFinite(previous.last_notified_at) && (now - previous.last_notified_at) < ttl) {
+    return { suppressed: true, key, ttl, previous };
+  }
+
+  return { suppressed: false, key, ttl };
+}
+
+function recordStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
+  const key = statusNoticeCooldownKey(channel, endpoint, route);
+  const cooldowns = readStatusNoticeCooldowns();
+  cooldowns[key] = {
+    channel,
+    endpoint: normalizeStatusEndpoint(endpoint),
+    status_type: statusNoticeType(route),
+    reason: statusNoticeReason(route),
+    last_notified_at: now
+  };
+  writeStatusNoticeCooldowns(cooldowns);
+}
+
 function buildFullMessage(content, channel, endpoint, noReply) {
   let replyViaSuffix = '';
   if (!noReply) {
@@ -323,8 +393,24 @@ async function main() {
   }
 
   const route = await queryRoute(channel, endpoint, noReply);
-  const dbContent = buildFullMessage(content, channel, endpoint, noReply);
+  let dbContent = buildFullMessage(content, channel, endpoint, noReply);
   const dbStatus = route.recovered ? 'pending' : 'delivered';
+
+  if (!route.recovered && !noReply) {
+    const cooldown = getStatusNoticeCooldown(channel, endpoint, route);
+    if (cooldown.suppressed) {
+      dbContent += `\n\n[C4] Status notification suppressed by cooldown while health=${statusNoticeType(route)} reason=${statusNoticeReason(route)}.`;
+      try {
+        const record = insertConversation('in', channel, endpoint, dbContent, dbStatus, priority, requireIdle);
+        emitSuccess(json, record.id, 'suppressed');
+        return;
+      } catch (err) {
+        emitError(json, 'INTERNAL_ERROR', `failed to record suppressed unhealthy message: ${err.message}`);
+      } finally {
+        close();
+      }
+    }
+  }
 
   try {
     const record = insertConversation('in', channel, endpoint, dbContent, dbStatus, priority, requireIdle);
@@ -335,6 +421,7 @@ async function main() {
 
     const sendResult = sendUnhealthyMessage(channel, endpoint, route.userMessage);
     if (sendResult.status === 0) {
+      recordStatusNoticeCooldown(channel, endpoint, route);
       emitSuccess(json, record.id, 'delivered');
       return;
     }

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -25,6 +25,9 @@ const __dirname = path.dirname(__filename);
 const AM_SOCKET_PATH = path.join(ACTIVITY_MONITOR_DIR, 'am.sock');
 const ROUTER_IPC_TIMEOUT_MS = 30000;
 const STATUS_NOTICE_COOLDOWN_SECONDS = Number.parseInt(process.env.C4_STATUS_NOTICE_COOLDOWN_SECONDS || '600', 10);
+const STATUS_NOTICE_COOLDOWNS_LOCK_DIR = `${STATUS_NOTICE_COOLDOWNS_FILE}.lock`;
+const STATUS_NOTICE_LOCK_TIMEOUT_MS = 5000;
+const STATUS_NOTICE_LOCK_STALE_MS = 30000;
 
 function printUsage() {
   console.log('Usage: node c4-receive.js --channel <channel> [--endpoint <endpoint_id>] [--priority <1-3>] [--no-reply] [--block-queue-until-idle] [--json] --content "<message>"');
@@ -284,6 +287,41 @@ function readStatusNoticeCooldowns() {
   }
 }
 
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function acquireStatusNoticeCooldownLock() {
+  const start = Date.now();
+  while (true) {
+    try {
+      fs.mkdirSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR);
+      return () => {
+        try {
+          fs.rmdirSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR);
+        } catch { /* best-effort */ }
+      };
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+
+      try {
+        const stats = fs.statSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR);
+        if ((Date.now() - stats.mtimeMs) > STATUS_NOTICE_LOCK_STALE_MS) {
+          fs.rmSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      if ((Date.now() - start) >= STATUS_NOTICE_LOCK_TIMEOUT_MS) {
+        throw new Error('timed out waiting for status cooldown lock');
+      }
+      sleepSync(25);
+    }
+  }
+}
+
 function writeStatusNoticeCooldowns(cooldowns) {
   try {
     fs.mkdirSync(path.dirname(STATUS_NOTICE_COOLDOWNS_FILE), { recursive: true });
@@ -306,35 +344,48 @@ function pruneStatusNoticeCooldowns(cooldowns, ttl, now = Math.floor(Date.now() 
   return pruned;
 }
 
-function getStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
+function reserveStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
+  const key = statusNoticeCooldownKey(channel, endpoint, route);
   const ttl = Number.isFinite(STATUS_NOTICE_COOLDOWN_SECONDS) && STATUS_NOTICE_COOLDOWN_SECONDS > 0
     ? STATUS_NOTICE_COOLDOWN_SECONDS
     : 600;
-  const key = statusNoticeCooldownKey(channel, endpoint, route);
-  const cooldowns = readStatusNoticeCooldowns();
-  const previous = cooldowns[key];
+  const release = acquireStatusNoticeCooldownLock();
+  try {
+    const cooldowns = pruneStatusNoticeCooldowns(readStatusNoticeCooldowns(), ttl, now);
+    const previous = cooldowns[key];
 
-  if (previous && Number.isFinite(previous.last_notified_at) && (now - previous.last_notified_at) < ttl) {
-    return { suppressed: true, key, ttl, previous };
+    if (previous && Number.isFinite(previous.last_notified_at) && (now - previous.last_notified_at) < ttl) {
+      writeStatusNoticeCooldowns(cooldowns);
+      return { suppressed: true, key, ttl, previous };
+    }
+
+    cooldowns[key] = {
+      channel,
+      endpoint: normalizeStatusEndpoint(endpoint),
+      status_type: statusNoticeType(route),
+      reason: statusNoticeReason(route),
+      last_notified_at: now
+    };
+    writeStatusNoticeCooldowns(cooldowns);
+    return { suppressed: false, key, ttl, reservedAt: now };
+  } finally {
+    release();
   }
-
-  return { suppressed: false, key, ttl };
 }
 
-function recordStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
-  const key = statusNoticeCooldownKey(channel, endpoint, route);
-  const ttl = Number.isFinite(STATUS_NOTICE_COOLDOWN_SECONDS) && STATUS_NOTICE_COOLDOWN_SECONDS > 0
-    ? STATUS_NOTICE_COOLDOWN_SECONDS
-    : 600;
-  const cooldowns = pruneStatusNoticeCooldowns(readStatusNoticeCooldowns(), ttl, now);
-  cooldowns[key] = {
-    channel,
-    endpoint: normalizeStatusEndpoint(endpoint),
-    status_type: statusNoticeType(route),
-    reason: statusNoticeReason(route),
-    last_notified_at: now
-  };
-  writeStatusNoticeCooldowns(cooldowns);
+function clearStatusNoticeCooldownReservation(key, reservedAt) {
+  const release = acquireStatusNoticeCooldownLock();
+  try {
+    const cooldowns = readStatusNoticeCooldowns();
+    if (cooldowns[key]?.last_notified_at === reservedAt) {
+      delete cooldowns[key];
+      writeStatusNoticeCooldowns(cooldowns);
+    }
+  } catch (err) {
+    console.error(`[C4] Warning: failed to clear status cooldown reservation (${err.message})`);
+  } finally {
+    release();
+  }
 }
 
 function buildFullMessage(content, channel, endpoint, noReply) {
@@ -411,9 +462,14 @@ async function main() {
   const route = await queryRoute(channel, endpoint, noReply);
   let dbContent = buildFullMessage(content, channel, endpoint, noReply);
   const dbStatus = route.recovered ? 'pending' : 'delivered';
+  let cooldown = null;
 
   if (!route.recovered && !noReply) {
-    const cooldown = getStatusNoticeCooldown(channel, endpoint, route);
+    try {
+      cooldown = reserveStatusNoticeCooldown(channel, endpoint, route);
+    } catch (err) {
+      emitError(json, 'INTERNAL_ERROR', `failed to reserve status cooldown: ${err.message}`);
+    }
     if (cooldown.suppressed) {
       dbContent += `\n\n[C4] Status notification suppressed by cooldown while health=${statusNoticeType(route)} reason=${statusNoticeReason(route)}.`;
       try {
@@ -437,9 +493,11 @@ async function main() {
 
     const sendResult = sendUnhealthyMessage(channel, endpoint, route.userMessage);
     if (sendResult.status === 0) {
-      recordStatusNoticeCooldown(channel, endpoint, route);
       emitSuccess(json, record.id, 'delivered');
       return;
+    }
+    if (cooldown?.key && Number.isFinite(cooldown.reservedAt)) {
+      clearStatusNoticeCooldownReservation(cooldown.key, cooldown.reservedAt);
     }
     const detail = sendResult.stderr || sendResult.stdout || `exit ${sendResult.status}`;
     emitError(json, 'UNHEALTHY_NOTIFY_FAILED', `failed to send unhealthy status message: ${detail.trim()}`);


### PR DESCRIPTION
## Summary
- add file-backed cooldown for repeated C4 unhealthy/status notices
- key cooldowns by channel, normalized endpoint, status type, and reason
- record suppressed repeated inbound messages as delivered so they do not stay pending

## Verification
- node --test scripts/__tests__/c4-receive.test.js

Note: full comm-bridge npm test still has existing unrelated c4-send CLI test failures; c4-send is unchanged from origin/main.
