### PR TITLE
fix: respect runtime health in scheduler and console

### DIFF
--- a/skills/scheduler/SKILL.md
+++ b/skills/scheduler/SKILL.md
@@ -11,7 +11,7 @@ Enables Claude to work autonomously by dispatching scheduled tasks via C4 comm-b
 
 1. Activity Monitor writes state to `~/zylos/activity-monitor/agent-status.json`
 2. Scheduler checks for pending tasks that are due
-3. If runtime is alive, dispatches task to C4 comm-bridge
+3. If runtime is ready (`busy`/`idle` with `health: ok`), dispatches task to C4 comm-bridge
 4. C4 handles execution control (idle waiting, priority queueing)
 5. Task sent to Claude based on priority and idle requirements
 

--- a/skills/scheduler/scripts/__tests__/runtime.test.js
+++ b/skills/scheduler/scripts/__tests__/runtime.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildC4ReceiveArgs,
+  isRuntimeReady,
+  parseC4ReceiveResult
+} from '../runtime.js';
+
+describe('isRuntimeReady', () => {
+  it('requires busy or idle state with ok health', () => {
+    assert.equal(isRuntimeReady({ state: 'idle', health: 'ok' }), true);
+    assert.equal(isRuntimeReady({ state: 'busy', health: 'ok' }), true);
+    assert.equal(isRuntimeReady({ state: 'idle', health: 'unavailable' }), false);
+    assert.equal(isRuntimeReady({ state: 'busy', health: 'rate_limited' }), false);
+    assert.equal(isRuntimeReady({ state: 'offline', health: 'ok' }), false);
+    assert.equal(isRuntimeReady(null), false);
+  });
+});
+
+describe('buildC4ReceiveArgs', () => {
+  it('requests JSON output so scheduler can inspect the C4 action', () => {
+    const args = buildC4ReceiveArgs('/tmp/c4-receive.js', 'run task', {
+      priority: 1,
+      replyChannel: 'lark',
+      replyEndpoint: 'oc_1|type:p2p',
+      requireIdle: true
+    });
+
+    assert.deepEqual(args, [
+      '/tmp/c4-receive.js',
+      '--json',
+      '--channel',
+      'lark',
+      '--endpoint',
+      'oc_1|type:p2p',
+      '--block-queue-until-idle',
+      '--priority',
+      '1',
+      '--content',
+      'run task'
+    ]);
+  });
+});
+
+describe('parseC4ReceiveResult', () => {
+  it('accepts only queued actions as successful scheduler dispatch', () => {
+    assert.deepEqual(
+      parseC4ReceiveResult('{"ok":true,"action":"queued","id":123}'),
+      { ok: true, action: 'queued', id: 123 }
+    );
+
+    assert.throws(
+      () => parseC4ReceiveResult('{"ok":true,"action":"delivered","id":123}'),
+      /did not queue message/
+    );
+    assert.throws(
+      () => parseC4ReceiveResult('{"ok":true,"action":"suppressed","id":123}'),
+      /did not queue message/
+    );
+    assert.throws(
+      () => parseC4ReceiveResult('{"ok":false,"error":{"code":"HEALTH","message":"unavailable"}}'),
+      /c4-receive failed \[HEALTH\]/
+    );
+  });
+});

--- a/skills/scheduler/scripts/daemon.js
+++ b/skills/scheduler/scripts/daemon.js
@@ -6,7 +6,7 @@
 
 import { getDb, cleanupHistory, now } from './database.js';
 import { getNextRun } from './cron-utils.js';
-import { sendViaC4, readStatusFile } from './runtime.js';
+import { sendViaC4, readStatusFile, isRuntimeReady } from './runtime.js';
 import { formatTime } from './time-utils.js';
 import { loadTimezone } from './tz.js';
 import { updateNextRunTime as _updateNextRunTime, processCompletedTasks as _processCompletedTasks, handleStaleRunningTasks as _handleStaleRunningTasks, TASK_TIMEOUT } from './daemon-tasks.js';
@@ -42,13 +42,11 @@ function getNextPendingTask() {
 }
 
 /**
- * Check if the active agent runtime is alive.
- * @returns {boolean} True if runtime is running (busy or idle state)
+ * Check if the active agent runtime is ready to accept scheduled tasks.
+ * @returns {boolean} True if runtime is running with healthy routing
  */
 function isRuntimeAlive() {
-  const status = readStatusFile();
-  if (!status) return false;
-  return status.state === 'busy' || status.state === 'idle';
+  return isRuntimeReady(readStatusFile());
 }
 
 /**

--- a/skills/scheduler/scripts/runtime.js
+++ b/skills/scheduler/scripts/runtime.js
@@ -26,6 +26,11 @@ export function readStatusFile() {
   }
 }
 
+export function isRuntimeReady(status) {
+  if (!status) return false;
+  return (status.state === 'busy' || status.state === 'idle') && status.health === 'ok';
+}
+
 /**
  * Find the c4-receive.js path, trying production location first, then development
  * @returns {string} Path to c4-receive.js
@@ -52,6 +57,55 @@ function findC4ReceivePath() {
   return productionPath;
 }
 
+export function buildC4ReceiveArgs(c4ReceivePath, message, options = {}) {
+  const {
+    priority = 3,
+    blockQueueUntilIdle = false,
+    requireIdle = false,
+    replyChannel = null,
+    replyEndpoint = null
+  } = options;
+
+  const args = [c4ReceivePath, '--json'];
+
+  if (replyChannel) {
+    args.push('--channel', replyChannel);
+    if (replyEndpoint) {
+      args.push('--endpoint', replyEndpoint);
+    }
+  } else {
+    args.push('--no-reply');
+  }
+
+  if (blockQueueUntilIdle || requireIdle) {
+    args.push('--block-queue-until-idle');
+  }
+
+  args.push('--priority', String(priority), '--content', message);
+  return args;
+}
+
+export function parseC4ReceiveResult(stdout) {
+  let result;
+  try {
+    result = JSON.parse(String(stdout || '').trim());
+  } catch {
+    throw new Error('c4-receive did not return valid JSON');
+  }
+
+  if (!result.ok) {
+    const code = result.error?.code || 'UNKNOWN';
+    const message = result.error?.message || 'unknown c4-receive error';
+    throw new Error(`c4-receive failed [${code}]: ${message}`);
+  }
+
+  if (result.action !== 'queued') {
+    throw new Error(`c4-receive did not queue message (action=${result.action || 'unknown'})`);
+  }
+
+  return result;
+}
+
 /**
  * Send a message to Claude via C4 Communication Bridge
  * @param {string} message - Message to send
@@ -76,27 +130,15 @@ export function sendViaC4(message, options = {}) {
   try {
     const c4ReceivePath = findC4ReceivePath();
 
-    // Build c4-receive.js command arguments
-    const args = [c4ReceivePath];
-
-    // Source and reply configuration from task's reply settings
-    if (replyChannel) {
-      args.push('--channel', replyChannel);
-      if (replyEndpoint) {
-        args.push('--endpoint', replyEndpoint);
-      }
-    } else {
-      args.push('--no-reply');
-    }
-
-    if (blockQueueUntilIdle || requireIdle) {
-      args.push('--block-queue-until-idle');
-    }
-
-    args.push('--priority', String(priority), '--content', message);
-
     // Use execFileSync to avoid shell injection - passes arguments directly
-    execFileSync('node', args, { stdio: 'pipe', timeout: 10000 });
+    const stdout = execFileSync('node', buildC4ReceiveArgs(c4ReceivePath, message, {
+      priority,
+      blockQueueUntilIdle,
+      requireIdle,
+      replyChannel,
+      replyEndpoint
+    }), { encoding: 'utf8', stdio: 'pipe', timeout: 10000 });
+    parseC4ReceiveResult(stdout);
     return true;
   } catch (error) {
     console.error('Failed to send via C4:', error.message);

--- a/skills/web-console/public/__tests__/status-utils.test.js
+++ b/skills/web-console/public/__tests__/status-utils.test.js
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const statusUtilsSource = fs.readFileSync(path.join(__dirname, '..', 'status-utils.js'), 'utf8');
+
+function loadBrowserStatusUtils() {
+  const sandbox = { window: {} };
+  vm.runInNewContext(statusUtilsSource, sandbox);
+  return sandbox.window.ZylosStatusUtils;
+}
+
+function assertDisplay(actual, expected) {
+  assert.equal(actual.className, expected.className);
+  assert.equal(actual.text, expected.text);
+}
+
+describe('browser status display', () => {
+  it('prioritizes unhealthy health over idle state', () => {
+    const { getStatusDisplay } = loadBrowserStatusUtils();
+    assertDisplay(
+      getStatusDisplay({ state: 'idle', health: 'unavailable' }),
+      { className: 'offline', text: 'Runtime unavailable' }
+    );
+  });
+
+  it('shows specific status for rate limit and auth failures', () => {
+    const { getStatusDisplay } = loadBrowserStatusUtils();
+    assertDisplay(
+      getStatusDisplay({ state: 'idle', health: 'rate_limited' }),
+      { className: 'busy', text: 'Runtime is rate limited' }
+    );
+    assertDisplay(
+      getStatusDisplay({ state: 'busy', health: 'auth_failed' }),
+      { className: 'offline', text: 'Runtime auth failed' }
+    );
+  });
+
+  it('uses runtime wording for healthy busy and idle states', () => {
+    const { getStatusDisplay } = loadBrowserStatusUtils();
+    assertDisplay(
+      getStatusDisplay({ state: 'busy', health: 'ok' }),
+      { className: 'busy', text: 'Runtime is busy' }
+    );
+    assertDisplay(
+      getStatusDisplay({ state: 'idle', health: 'ok' }),
+      { className: 'online', text: 'Runtime is ready' }
+    );
+  });
+});

--- a/skills/web-console/public/app.js
+++ b/skills/web-console/public/app.js
@@ -149,24 +149,11 @@ class ZylosConsole {
 
   updateStatusDisplay(status) {
     this.statusDot.className = 'status-dot';
-
-    switch (status.state) {
-      case 'busy':
-        this.statusDot.classList.add('busy');
-        this.statusText.textContent = 'Claude is busy';
-        break;
-      case 'idle':
-        this.statusDot.classList.add('online');
-        this.statusText.textContent = 'Claude is ready';
-        break;
-      case 'offline':
-      case 'stopped':
-        this.statusDot.classList.add('offline');
-        this.statusText.textContent = 'Claude is offline';
-        break;
-      default:
-        this.statusText.textContent = 'Unknown status';
+    const display = window.ZylosStatusUtils.getStatusDisplay(status);
+    if (display.className) {
+      this.statusDot.classList.add(display.className);
     }
+    this.statusText.textContent = display.text;
   }
 
   async loadConversations() {

--- a/skills/web-console/public/index.html
+++ b/skills/web-console/public/index.html
@@ -69,6 +69,7 @@
     </footer>
   </div>
 
+  <script src="status-utils.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/skills/web-console/public/status-utils.js
+++ b/skills/web-console/public/status-utils.js
@@ -1,0 +1,28 @@
+(function (root) {
+  function getStatusDisplay(status) {
+    const health = status && status.health;
+    if (health && health !== 'ok') {
+      if (health === 'rate_limited') {
+        return { className: 'busy', text: 'Runtime is rate limited' };
+      }
+      if (health === 'auth_failed') {
+        return { className: 'offline', text: 'Runtime auth failed' };
+      }
+      return { className: 'offline', text: 'Runtime unavailable' };
+    }
+
+    switch (status && status.state) {
+      case 'busy':
+        return { className: 'busy', text: 'Runtime is busy' };
+      case 'idle':
+        return { className: 'online', text: 'Runtime is ready' };
+      case 'offline':
+      case 'stopped':
+        return { className: 'offline', text: 'Runtime is offline' };
+      default:
+        return { className: '', text: 'Unknown status' };
+    }
+  }
+
+  root.ZylosStatusUtils = { getStatusDisplay };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/skills/web-console/scripts/__tests__/status-utils.test.js
+++ b/skills/web-console/scripts/__tests__/status-utils.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { hasStatusChanged } from '../status-utils.js';
+
+describe('hasStatusChanged', () => {
+  it('detects health-only changes', () => {
+    assert.equal(
+      hasStatusChanged(
+        { state: 'idle', health: 'unavailable' },
+        { state: 'idle', health: 'ok' }
+      ),
+      true
+    );
+  });
+
+  it('detects reason and cooldown changes for the same state and health', () => {
+    assert.equal(
+      hasStatusChanged(
+        { state: 'idle', health: 'unavailable', unavailable_reason: 'rate_limit' },
+        { state: 'idle', health: 'unavailable', unavailable_reason: 'restart' }
+      ),
+      true
+    );
+    assert.equal(
+      hasStatusChanged(
+        { state: 'idle', health: 'rate_limited', cooldown_until: 200 },
+        { state: 'idle', health: 'rate_limited', cooldown_until: 100 }
+      ),
+      true
+    );
+  });
+
+  it('ignores unchanged status fields used by broadcast decisions', () => {
+    assert.equal(
+      hasStatusChanged(
+        { state: 'busy', health: 'ok', idle_seconds: 10 },
+        { state: 'busy', health: 'ok', idle_seconds: 5 }
+      ),
+      false
+    );
+  });
+});

--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -17,6 +17,7 @@ import fs from 'fs';
 import { spawn } from 'child_process';
 import Database from 'better-sqlite3';
 import { fileURLToPath } from 'url';
+import { hasStatusChanged } from './status-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -192,7 +193,7 @@ function broadcast(type, data) {
 function checkUpdates() {
   // Check status changes
   const currentStatus = readStatus();
-  if (!lastStatus || currentStatus.state !== lastStatus.state) {
+  if (hasStatusChanged(currentStatus, lastStatus)) {
     lastStatus = currentStatus;
     broadcast('status', currentStatus);
   }

--- a/skills/web-console/scripts/status-utils.js
+++ b/skills/web-console/scripts/status-utils.js
@@ -1,0 +1,7 @@
+export function hasStatusChanged(current, previous) {
+  if (!previous) return true;
+  return current?.state !== previous?.state ||
+    current?.health !== previous?.health ||
+    current?.unavailable_reason !== previous?.unavailable_reason ||
+    current?.cooldown_until !== previous?.cooldown_until;
+}


### PR DESCRIPTION
## Summary
- require scheduler dispatch readiness to include runtime health ok, not just busy/idle state
- parse c4-receive --json output and only count action=queued as successful scheduled dispatch
- broadcast/display web-console status updates when health, reason, or cooldown changes

## Tests
- node --test skills/scheduler/scripts/__tests__/*.test.js skills/web-console/scripts/__tests__/*.test.js skills/web-console/public/__tests__/*.test.js
- git diff --check