### PR TITLE
fix(caddy): show manual route config when unavailable

### DIFF
--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -33,6 +33,19 @@ import { hasConfigureHook, runConfigureHook } from '../lib/configure-hook.js';
 import { registerService } from '../lib/service.js';
 import { bold, dim, green, red, yellow, cyan, success, error, warn, heading } from '../lib/colors.js';
 
+function printManualCaddyRoutes(result) {
+  console.log(`  ${warn('Caddy routes: manual configuration required')}`);
+  console.log(`    ${dim(result.message || 'HTTP routes were not configured automatically.')}`);
+  if (result.caddyBin) console.log(`    ${dim(`Binary: ${result.caddyBin}`)}`);
+  if (result.caddyfile) console.log(`    ${dim(`Caddyfile: ${result.caddyfile}`)}`);
+  console.log('');
+  console.log('    If you use your own Caddy server, add this snippet inside your site block:');
+  console.log('');
+  for (const line of (result.manualConfig || '').split('\n')) {
+    console.log(line);
+  }
+}
+
 /**
  * Main entry: zylos add <target> [--check] [--yes] [--json] [--branch <name>]
  */
@@ -389,6 +402,8 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
     if (!jsonOutput) {
       if (caddyResult.success) {
         console.log(`  ${success(`Caddy routes: ${caddyResult.action}`)}`);
+      } else if (caddyResult.action === 'manual_required') {
+        printManualCaddyRoutes(caddyResult);
       } else {
         console.log(`  ${error(`Caddy routes: failed (${caddyResult.error})`)}`);
       }

--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -41,6 +41,15 @@ function printStep(step) {
   if (step.status === 'failed' && step.error) {
     console.log(`       ${red(step.error)}`);
   }
+  if (step.name === 'caddy_routes' && step.caddy?.action === 'manual_required') {
+    console.log(`       ${yellow(step.caddy.message || 'HTTP routes were not configured automatically.')}`);
+    if (step.caddy.caddyBin) console.log(`       ${dim(`Binary: ${step.caddy.caddyBin}`)}`);
+    if (step.caddy.caddyfile) console.log(`       ${dim(`Caddyfile: ${step.caddy.caddyfile}`)}`);
+    console.log('       If you use your own Caddy server, add this snippet inside your site block:');
+    for (const line of (step.caddy.manualConfig || '').split('\n')) {
+      console.log(line);
+    }
+  }
 }
 
 /**

--- a/cli/lib/caddy.js
+++ b/cli/lib/caddy.js
@@ -63,6 +63,22 @@ export function generateRouteBlocks(httpRoutes) {
 }
 
 /**
+ * Generate a copyable Caddy snippet for manual component route setup.
+ * The snippet is intended to be pasted inside an existing Caddy site block.
+ *
+ * @param {string} componentName
+ * @param {Array} httpRoutes - Array of { path, type, target, strip_prefix? }
+ * @returns {string} Caddy configuration snippet with zylos markers
+ */
+export function generateManualRouteSnippet(componentName, httpRoutes) {
+  return [
+    `    # BEGIN zylos-component:${componentName}`,
+    generateRouteBlocks(httpRoutes),
+    `    # END zylos-component:${componentName}`,
+  ].join('\n');
+}
+
+/**
  * Remove a marker block (BEGIN to END, inclusive) from content.
  * Handles leading whitespace on marker lines and cleans up blank lines.
  */
@@ -207,13 +223,23 @@ function findPrimaryBlockEnd(content) {
  * @param {Array} httpRoutes - Array of { path, type, target, strip_prefix? }
  * @returns {{ success: boolean, action: string, error?: string }}
  */
-export function applyCaddyRoutes(componentName, httpRoutes) {
-  if (!isCaddyAvailable()) {
-    return { success: false, action: 'skipped', error: 'caddy_not_available' };
-  }
-
+export function applyCaddyRoutes(componentName, httpRoutes, deps = {}) {
   if (!httpRoutes || !Array.isArray(httpRoutes) || httpRoutes.length === 0) {
     return { success: true, action: 'skipped' };
+  }
+
+  const isAvailable = deps.isCaddyAvailable || isCaddyAvailable;
+  if (!isAvailable()) {
+    return {
+      success: false,
+      action: 'manual_required',
+      error: 'caddy_not_available',
+      caddyfile: CADDYFILE,
+      caddyBin: CADDY_BIN,
+      manualConfig: generateManualRouteSnippet(componentName, httpRoutes),
+      manualConfigPlacement: 'inside_primary_site_block',
+      message: 'Zylos-managed Caddy is not available. HTTP routes were not configured automatically.',
+    };
   }
 
   const beginMarker = `# BEGIN zylos-component:${componentName}`;
@@ -233,13 +259,8 @@ export function applyCaddyRoutes(componentName, httpRoutes) {
     content = stripMarkerBlock(content, beginMarker, endMarker);
   }
 
-  // Generate new route block
-  const routeBlock = generateRouteBlocks(httpRoutes);
-  const markedBlock = [
-    `    ${beginMarker}`,
-    routeBlock,
-    `    ${endMarker}`,
-  ].join('\n');
+  // Generate new route block with component markers.
+  const markedBlock = generateManualRouteSnippet(componentName, httpRoutes);
 
   // Find the closing `}` of the primary (first) server block.
   // The Caddyfile may contain multiple server blocks (e.g. user-added

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -490,10 +490,20 @@ function step6_updateCaddyRoutes(ctx) {
 
   const result = applyCaddyRoutes(ctx.component, httpRoutes);
   if (result.success) {
-    return { step: 6, name: 'caddy_routes', status: 'done', message: result.action, duration: Date.now() - startTime };
+    return { step: 6, name: 'caddy_routes', status: 'done', message: result.action, caddy: result, duration: Date.now() - startTime };
+  }
+  if (result.action === 'manual_required') {
+    return {
+      step: 6,
+      name: 'caddy_routes',
+      status: 'skipped',
+      message: 'manual configuration required',
+      caddy: result,
+      duration: Date.now() - startTime,
+    };
   }
   // Caddy failures are non-fatal for upgrades
-  return { step: 6, name: 'caddy_routes', status: 'skipped', message: result.error, duration: Date.now() - startTime };
+  return { step: 6, name: 'caddy_routes', status: 'skipped', message: result.error, caddy: result, duration: Date.now() - startTime };
 }
 
 /**
@@ -745,7 +755,9 @@ export function runUpgrade(component, { tempDir, newVersion, mode, jsonOutput, o
 
   // Extract Caddy result from steps
   const caddyStep = ctx.steps.find(s => s.name === 'caddy_routes');
-  const caddyResult = caddyStep ? { action: caddyStep.message, status: caddyStep.status } : null;
+  const caddyResult = caddyStep?.caddy
+    ? { ...caddyStep.caddy, status: caddyStep.status }
+    : (caddyStep ? { action: caddyStep.message, status: caddyStep.status } : null);
 
   return {
     action: 'upgrade',

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import { isLocalAddress } from '../cli/commands/init.js';
-import { generateRouteBlocks } from '../cli/lib/caddy.js';
+import { applyCaddyRoutes, generateManualRouteSnippet, generateRouteBlocks } from '../cli/lib/caddy.js';
 
 describe('isLocalAddress', () => {
   // Positive cases — should return true
@@ -122,5 +122,55 @@ describe('generateRouteBlocks', () => {
     expect(block).toContain('        reverse_proxy localhost:3000');
     expect(block).not.toContain('header_up X-Forwarded-Prefix');
     expect(block).not.toContain('reverse_proxy localhost:3000 {');
+  });
+});
+
+describe('generateManualRouteSnippet', () => {
+  test('wraps route blocks in zylos component markers', () => {
+    const snippet = generateManualRouteSnippet('dashboard', [{
+      path: '/dashboard/*',
+      type: 'reverse_proxy',
+      target: 'localhost:3000',
+      strip_prefix: '/dashboard',
+    }]);
+
+    expect(snippet).toContain('    # BEGIN zylos-component:dashboard');
+    expect(snippet).toContain('    redir /dashboard /dashboard/ permanent');
+    expect(snippet).toContain('        uri strip_prefix /dashboard');
+    expect(snippet).toContain('        reverse_proxy localhost:3000 {');
+    expect(snippet).toContain('            header_up X-Forwarded-Prefix /dashboard');
+    expect(snippet).toContain('    # END zylos-component:dashboard');
+  });
+});
+
+describe('applyCaddyRoutes', () => {
+  test('returns manual configuration details when zylos-managed Caddy is unavailable', () => {
+    const result = applyCaddyRoutes('dashboard', [{
+      path: '/dashboard/*',
+      type: 'reverse_proxy',
+      target: 'localhost:3000',
+      strip_prefix: '/dashboard',
+    }], {
+      isCaddyAvailable: () => false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.action).toBe('manual_required');
+    expect(result.error).toBe('caddy_not_available');
+    expect(result.caddyfile).toBeTruthy();
+    expect(result.caddyBin).toBeTruthy();
+    expect(result.manualConfigPlacement).toBe('inside_primary_site_block');
+    expect(result.message).toBe('Zylos-managed Caddy is not available. HTTP routes were not configured automatically.');
+    expect(result.manualConfig).toContain('# BEGIN zylos-component:dashboard');
+    expect(result.manualConfig).toContain('handle /dashboard/* {');
+    expect(result.manualConfig).toContain('reverse_proxy localhost:3000 {');
+  });
+
+  test('skips empty route declarations before checking Caddy availability', () => {
+    const result = applyCaddyRoutes('dashboard', [], {
+      isCaddyAvailable: () => false,
+    });
+
+    expect(result).toEqual({ success: true, action: 'skipped' });
   });
 });


### PR DESCRIPTION
## Summary
- return a structured manual_required Caddy result when zylos-managed Caddy is unavailable for http_routes
- print English terminal guidance and copyable Caddy route snippets for add/upgrade flows
- preserve manualConfig details in JSON upgrade/add metadata for upstream consumers
- add coverage for manual Caddy snippets and caddy_not_available behavior

Fixes #594.

## Tests
- npm test
- npm run test:jest -- --runTestsByPath test/caddy.test.js