### PR TITLE
fix(c4): store status cooldowns in sqlite

### DIFF
--- a/skills/comm-bridge/init-db.sql
+++ b/skills/comm-bridge/init-db.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS conversations (
     endpoint_id TEXT,               -- chat_id, can be NULL (e.g., scheduler)
     content TEXT NOT NULL,          -- message content (large messages: preview + file path)
     status TEXT DEFAULT 'pending',  -- 'pending' | 'delivered' | 'failed' (for direction='in' queue)
+    delivery_action TEXT,           -- optional action outcome, e.g. 'queued' | 'delivered' | 'suppressed'
     priority INTEGER DEFAULT 3,     -- 1=urgent, 2=high, 3=normal
     require_idle INTEGER DEFAULT 0, -- legacy/internal name for block_queue_until_idle behavior
     retry_count INTEGER DEFAULT 0   -- delivery retries for incoming queue
@@ -56,6 +57,21 @@ CREATE INDEX IF NOT EXISTS idx_control_queue_ack_deadline
   ON control_queue(ack_deadline_at);
 CREATE INDEX IF NOT EXISTS idx_control_queue_updated_at
   ON control_queue(updated_at);
+
+-- C4 unhealthy/status notice cooldowns
+CREATE TABLE IF NOT EXISTS status_notice_cooldowns (
+    cooldown_key TEXT PRIMARY KEY,
+    channel TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    status_type TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    last_notified_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_status_notice_cooldowns_expires_at
+  ON status_notice_cooldowns(expires_at);
 
 -- Create initial checkpoint
 INSERT INTO checkpoints (summary) VALUES ('initial');

--- a/skills/comm-bridge/scripts/__tests__/c4-db-control.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-db-control.test.js
@@ -25,6 +25,7 @@ else process.env.ZYLOS_DIR = ORIG_ZYLOS_DIR;
 function resetTables() {
   db.exec('DELETE FROM control_queue');
   db.exec('DELETE FROM conversations');
+  db.exec('DELETE FROM status_notice_cooldowns');
   // Reset autoincrement counters
   db.exec("DELETE FROM sqlite_sequence WHERE name IN ('control_queue', 'conversations')");
 }
@@ -543,5 +544,64 @@ describe('insertConversation', () => {
   it('sets requireIdle flag', () => {
     const conv = mod.insertConversation('in', 'scheduler', null, 'task', null, 3, true);
     assert.equal(conv.require_idle, 1);
+  });
+
+  it('records delivery action metadata', () => {
+    const conv = mod.insertConversation('in', 'telegram', '123', 'msg', 'delivered', 3, false, 'suppressed');
+    assert.equal(conv.delivery_action, 'suppressed');
+
+    const row = db.prepare('SELECT delivery_action FROM conversations WHERE id = ?').get(conv.id);
+    assert.equal(row.delivery_action, 'suppressed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// status notice cooldowns
+// ---------------------------------------------------------------------------
+describe('status notice cooldowns', () => {
+  beforeEach(() => resetTables());
+
+  it('reserves the first cooldown and suppresses repeats', () => {
+    const first = mod.reserveStatusNoticeCooldown({
+      cooldownKey: 'telegram::123::unavailable::down',
+      channel: 'telegram',
+      endpoint: '123',
+      statusType: 'unavailable',
+      reason: 'down',
+      ttl: 600,
+      now: 1000
+    });
+    const second = mod.reserveStatusNoticeCooldown({
+      cooldownKey: 'telegram::123::unavailable::down',
+      channel: 'telegram',
+      endpoint: '123',
+      statusType: 'unavailable',
+      reason: 'down',
+      ttl: 600,
+      now: 1001
+    });
+
+    assert.equal(first.suppressed, false);
+    assert.equal(first.reservedAt, 1000);
+    assert.equal(second.suppressed, true);
+    assert.equal(second.previous.last_notified_at, 1000);
+  });
+
+  it('clears only the matching reservation timestamp', () => {
+    const reserved = mod.reserveStatusNoticeCooldown({
+      cooldownKey: 'telegram::123::unavailable::down',
+      channel: 'telegram',
+      endpoint: '123',
+      statusType: 'unavailable',
+      reason: 'down',
+      ttl: 600,
+      now: 1000
+    });
+
+    mod.clearStatusNoticeCooldownReservation(reserved.key, 999);
+    assert.equal(mod.getStatusNoticeCooldowns().length, 1);
+
+    mod.clearStatusNoticeCooldownReservation(reserved.key, 1000);
+    assert.equal(mod.getStatusNoticeCooldowns().length, 0);
   });
 });

--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -61,8 +61,15 @@ function openDb(tmpDir) {
   return new Database(path.join(tmpDir, 'comm-bridge', 'c4.db'));
 }
 
-function readCooldowns(tmpDir) {
-  return JSON.parse(fs.readFileSync(path.join(tmpDir, 'activity-monitor', 'status-notice-cooldowns.json'), 'utf8'));
+function readCooldownRows(tmpDir) {
+  const db = openDb(tmpDir);
+  const rows = db.prepare(`
+    SELECT cooldown_key, channel, endpoint, status_type, reason, last_notified_at, expires_at
+    FROM status_notice_cooldowns
+    ORDER BY cooldown_key ASC
+  `).all();
+  db.close();
+  return rows;
 }
 
 function createChannelSendScript(tmpDir, channel, { exitCode = 0 } = {}) {
@@ -77,16 +84,32 @@ process.exit(${exitCode});
 `);
 }
 
-function createSlowAppendChannelSendScript(tmpDir, channel) {
+function createBlockingAppendChannelSendScript(tmpDir, channel) {
   const scriptDir = path.join(tmpDir, '.claude', 'skills', channel, 'scripts');
   fs.mkdirSync(scriptDir, { recursive: true });
   fs.writeFileSync(path.join(scriptDir, 'send.js'), `
 import fs from 'node:fs';
 import path from 'node:path';
 const outPath = path.join(process.env.ZYLOS_DIR, '${channel}-send.jsonl');
-await new Promise((resolve) => setTimeout(resolve, 500));
+const startedPath = path.join(process.env.ZYLOS_DIR, '${channel}-send-started');
+const releasePath = path.join(process.env.ZYLOS_DIR, '${channel}-send-release');
+fs.writeFileSync(startedPath, String(process.pid));
+const deadline = Date.now() + 5000;
+while (!fs.existsSync(releasePath) && Date.now() < deadline) {
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+if (!fs.existsSync(releasePath)) process.exit(9);
 fs.appendFileSync(outPath, JSON.stringify({ args: process.argv.slice(2), pid: process.pid }) + '\\n');
 `);
+}
+
+async function waitForFile(filePath, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
 }
 
 async function withRouteServer(tmpDir, handler, fn) {
@@ -401,29 +424,30 @@ describe('c4-receive health gating', () => {
       const out = parseJsonStdout(second.stdout);
       assert.equal(out.action, 'suppressed');
 
-      const cooldowns = readCooldowns(tmpDir);
-      const entries = Object.values(cooldowns);
+      const entries = readCooldownRows(tmpDir);
       assert.equal(entries.length, 1);
       assert.equal(entries[0].endpoint, 'oc_123|type:group|root:om_root');
       assert.equal(entries[0].status_type, 'unavailable');
       assert.equal(entries[0].reason, 'unavailable');
+      assert.equal(fs.existsSync(path.join(tmpDir, 'activity-monitor', 'status-notice-cooldowns.json')), false);
 
       const db = openDb(tmpDir);
       const inboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'in'").get();
       const outboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'out'").get();
-      const suppressed = db.prepare("SELECT content FROM conversations WHERE id = ?").get(Number(out.id));
+      const suppressed = db.prepare("SELECT content, delivery_action FROM conversations WHERE id = ?").get(Number(out.id));
       db.close();
 
       assert.equal(inboundCount.count, 2);
       assert.equal(outboundCount.count, 1);
       assert.match(suppressed.content, /Status notification suppressed by cooldown/);
+      assert.equal(suppressed.delivery_action, 'suppressed');
     });
   });
 
   it('fallback reserves status notice cooldown before sending so concurrent receives suppress duplicates', async () => {
     await withTmpDirAsync(async ({ tmpDir, env }) => {
       fs.writeFileSync(path.join(tmpDir, 'activity-monitor', 'agent-status.json'), JSON.stringify({ health: 'down' }));
-      createSlowAppendChannelSendScript(tmpDir, 'test-chan');
+      createBlockingAppendChannelSendScript(tmpDir, 'test-chan');
 
       const argsA = [
         '--channel', 'test-chan',
@@ -438,10 +462,13 @@ describe('c4-receive health gating', () => {
         '--content', 'second concurrent'
       ];
 
-      const results = await Promise.all([
-        cliRawAsync(argsA, env),
-        cliRawAsync(argsB, env)
-      ]);
+      const firstReceive = cliRawAsync(argsA, env);
+      await waitForFile(path.join(tmpDir, 'test-chan-send-started'));
+      const secondResult = await cliRawAsync(argsB, env);
+      fs.writeFileSync(path.join(tmpDir, 'test-chan-send-release'), 'ok');
+      const firstResult = await firstReceive;
+      const results = [firstResult, secondResult];
+
       assert.deepEqual(results.map((r) => r.status), [0, 0]);
       const actions = results.map((r) => parseJsonStdout(r.stdout).action).sort();
       assert.deepEqual(actions, ['delivered', 'suppressed']);
@@ -453,58 +480,44 @@ describe('c4-receive health gating', () => {
       const inboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'in'").get();
       const outboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'out'").get();
       const suppressedCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE content LIKE '%Status notification suppressed by cooldown%'").get();
+      const suppressedActionCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE delivery_action = 'suppressed'").get();
       db.close();
 
       assert.equal(inboundCount.count, 2);
       assert.equal(outboundCount.count, 1);
       assert.equal(suppressedCount.count, 1);
+      assert.equal(suppressedActionCount.count, 1);
     });
   });
 
   it('prunes expired status notice cooldown entries when recording a notification', () => {
     withTmpDir(({ tmpDir, env }) => {
-      const monitorDir = path.join(tmpDir, 'activity-monitor');
-      const cooldownPath = path.join(monitorDir, 'status-notice-cooldowns.json');
       const now = Math.floor(Date.now() / 1000);
-      fs.writeFileSync(path.join(monitorDir, 'agent-status.json'), JSON.stringify({ health: 'down' }));
-      fs.writeFileSync(cooldownPath, JSON.stringify({
-        'old::ep::unavailable::old': {
-          channel: 'old',
-          endpoint: 'ep',
-          status_type: 'unavailable',
-          reason: 'old',
-          last_notified_at: now - 9999
-        },
-        'recent::ep::unavailable::recent': {
-          channel: 'recent',
-          endpoint: 'ep',
-          status_type: 'unavailable',
-          reason: 'recent',
-          last_notified_at: now
-        },
-        'malformed::ep::unavailable::bad': {
-          channel: 'malformed',
-          endpoint: 'ep',
-          status_type: 'unavailable',
-          reason: 'bad',
-          last_notified_at: 'not-a-number'
-        }
-      }));
+      const init = cliRaw(['--no-reply', '--json', '--content', 'init db'], env);
+      assert.equal(init.status, 0);
+      fs.writeFileSync(path.join(tmpDir, 'activity-monitor', 'agent-status.json'), JSON.stringify({ health: 'down' }));
       createChannelSendScript(tmpDir, 'test-chan');
+      const db = openDb(tmpDir);
+      const insertCooldown = db.prepare(`
+        INSERT INTO status_notice_cooldowns (
+          cooldown_key, channel, endpoint, status_type, reason,
+          last_notified_at, expires_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      insertCooldown.run('old::ep::unavailable::old', 'old', 'ep', 'unavailable', 'old', now - 9999, now - 1, now - 9999);
+      insertCooldown.run('recent::ep::unavailable::recent', 'recent', 'ep', 'unavailable', 'recent', now, now + 600, now);
+      db.close();
 
       const r = cliRaw(['--channel', 'test-chan', '--endpoint', 'ep1', '--json', '--content', 'new notice'], env);
       assert.equal(r.status, 0);
       assert.equal(parseJsonStdout(r.stdout).action, 'delivered');
 
-      const cooldowns = readCooldowns(tmpDir);
-      assert.equal(cooldowns['old::ep::unavailable::old'], undefined);
-      assert.equal(cooldowns['malformed::ep::unavailable::bad'], undefined);
-      assert.ok(cooldowns['recent::ep::unavailable::recent']);
-      assert.ok(cooldowns['test-chan::ep1::unavailable::unavailable']);
-      assert.deepEqual(
-        fs.readdirSync(monitorDir).filter((name) => name.includes('status-notice-cooldowns.json.tmp')),
-        []
-      );
+      const cooldowns = readCooldownRows(tmpDir);
+      assert.equal(cooldowns.some((row) => row.cooldown_key === 'old::ep::unavailable::old'), false);
+      assert.equal(cooldowns.some((row) => row.cooldown_key === 'recent::ep::unavailable::recent'), true);
+      assert.equal(cooldowns.some((row) => row.cooldown_key === 'test-chan::ep1::unavailable::unavailable'), true);
+      assert.equal(fs.existsSync(path.join(tmpDir, 'activity-monitor', 'status-notice-cooldowns.json')), false);
     });
   });
 });
@@ -591,8 +604,7 @@ describe('c4-receive MessageRouter IPC route', () => {
         const out = parseJsonStdout(second.stdout);
         assert.equal(out.action, 'suppressed');
 
-        const cooldowns = readCooldowns(tmpDir);
-        const entries = Object.values(cooldowns);
+        const entries = readCooldownRows(tmpDir);
         assert.equal(entries.length, 1);
         assert.equal(entries[0].endpoint, 'oc_123|type:group|root:om_root');
         assert.equal(entries[0].status_type, 'unavailable');
@@ -600,11 +612,12 @@ describe('c4-receive MessageRouter IPC route', () => {
 
         const db = openDb(tmpDir);
         const outboundCount = db.prepare("SELECT count(*) AS count FROM conversations WHERE direction = 'out'").get();
-        const suppressed = db.prepare("SELECT content FROM conversations WHERE id = ?").get(Number(out.id));
+        const suppressed = db.prepare("SELECT content, delivery_action FROM conversations WHERE id = ?").get(Number(out.id));
         db.close();
 
         assert.equal(outboundCount.count, 1);
         assert.match(suppressed.content, /Status notification suppressed by cooldown/);
+        assert.equal(suppressed.delivery_action, 'suppressed');
       });
     });
   });

--- a/skills/comm-bridge/scripts/c4-config.js
+++ b/skills/comm-bridge/scripts/c4-config.js
@@ -51,7 +51,6 @@ export const AGENT_STATUS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'agent-status.j
 export const PROC_STATE_FILE = path.join(ACTIVITY_MONITOR_DIR, 'proc-state.json');
 export const API_ACTIVITY_FILE = path.join(ACTIVITY_MONITOR_DIR, 'api-activity.json');
 export const PENDING_CHANNELS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'pending-channels.jsonl');
-export const STATUS_NOTICE_COOLDOWNS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'status-notice-cooldowns.json');
 export const ATTACHMENTS_DIR = path.join(DATA_DIR, 'attachments');
 export const SKILLS_DIR = path.join(ZYLOS_DIR, '.claude', 'skills');
 

--- a/skills/comm-bridge/scripts/c4-db.js
+++ b/skills/comm-bridge/scripts/c4-db.js
@@ -37,7 +37,9 @@ export function getDb() {
       initSchema();
     }
 
+    ensureConversationsSchema(db);
     ensureControlQueueSchema(db);
+    ensureStatusNoticeCooldownSchema(db);
   }
   return db;
 }
@@ -89,6 +91,35 @@ function nowSeconds() {
   return Math.floor(Date.now() / 1000);
 }
 
+function getColumnNames(database, tableName) {
+  return new Set(database.prepare(`PRAGMA table_info(${tableName})`).all().map((column) => column.name));
+}
+
+function ensureConversationsSchema(database) {
+  const columnNames = getColumnNames(database, 'conversations');
+  if (!columnNames.has('delivery_action')) {
+    database.exec('ALTER TABLE conversations ADD COLUMN delivery_action TEXT');
+  }
+}
+
+function ensureStatusNoticeCooldownSchema(database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS status_notice_cooldowns (
+      cooldown_key TEXT PRIMARY KEY,
+      channel TEXT NOT NULL,
+      endpoint TEXT NOT NULL,
+      status_type TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      last_notified_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_status_notice_cooldowns_expires_at
+      ON status_notice_cooldowns(expires_at);
+  `);
+}
+
 /**
  * Insert a conversation record
  * @param {string} direction - 'in' or 'out'
@@ -100,7 +131,7 @@ function nowSeconds() {
  * @param {boolean} requireIdle - whether to wait for Claude idle state (default: false)
  * @returns {object} - inserted record with id
  */
-export function insertConversation(direction, channel, endpointId, content, status = null, priority = 3, requireIdle = false) {
+export function insertConversation(direction, channel, endpointId, content, status = null, priority = 3, requireIdle = false, deliveryAction = null) {
   const db = getDb();
 
   // Default status: 'pending' for incoming, 'delivered' for outgoing
@@ -109,11 +140,11 @@ export function insertConversation(direction, channel, endpointId, content, stat
   const requireIdleVal = requireIdle ? 1 : 0;
 
   const stmt = db.prepare(`
-    INSERT INTO conversations (direction, channel, endpoint_id, content, status, priority, require_idle)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO conversations (direction, channel, endpoint_id, content, status, delivery_action, priority, require_idle)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
-  const result = stmt.run(direction, channel, endpointId, content, finalStatus, priority, requireIdleVal);
+  const result = stmt.run(direction, channel, endpointId, content, finalStatus, deliveryAction, priority, requireIdleVal);
 
   return {
     id: result.lastInsertRowid,
@@ -122,10 +153,74 @@ export function insertConversation(direction, channel, endpointId, content, stat
     endpoint_id: endpointId,
     content,
     status: finalStatus,
+    delivery_action: deliveryAction,
     priority,
     require_idle: requireIdleVal,
     retry_count: 0
   };
+}
+
+/**
+ * Reserve or suppress an unhealthy/status notice cooldown.
+ * Uses SQLite as the comm-bridge persistence/concurrency boundary so
+ * concurrent c4-receive processes cannot both reserve the same cooldown key.
+ */
+export function reserveStatusNoticeCooldown({
+  cooldownKey,
+  channel,
+  endpoint,
+  statusType,
+  reason,
+  ttl,
+  now = nowSeconds()
+}) {
+  const database = getDb();
+  const expiresAt = now + ttl;
+
+  const tx = database.transaction(() => {
+    database.prepare('DELETE FROM status_notice_cooldowns WHERE expires_at <= ?').run(now);
+
+    const insertResult = database.prepare(`
+      INSERT OR IGNORE INTO status_notice_cooldowns (
+        cooldown_key, channel, endpoint, status_type, reason,
+        last_notified_at, expires_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(cooldownKey, channel, endpoint, statusType, reason, now, expiresAt, now);
+
+    if (insertResult.changes === 1) {
+      return { suppressed: false, key: cooldownKey, ttl, reservedAt: now, expiresAt };
+    }
+
+    const previous = database.prepare(`
+      SELECT cooldown_key, channel, endpoint, status_type, reason,
+             last_notified_at, expires_at, updated_at
+      FROM status_notice_cooldowns
+      WHERE cooldown_key = ?
+    `).get(cooldownKey);
+
+    return { suppressed: true, key: cooldownKey, ttl, previous };
+  });
+
+  return tx();
+}
+
+export function clearStatusNoticeCooldownReservation(cooldownKey, reservedAt) {
+  const database = getDb();
+  database.prepare(`
+    DELETE FROM status_notice_cooldowns
+    WHERE cooldown_key = ? AND last_notified_at = ?
+  `).run(cooldownKey, reservedAt);
+}
+
+export function getStatusNoticeCooldowns() {
+  const database = getDb();
+  return database.prepare(`
+    SELECT cooldown_key, channel, endpoint, status_type, reason,
+           last_notified_at, expires_at, updated_at
+    FROM status_notice_cooldowns
+    ORDER BY cooldown_key ASC
+  `).all();
 }
 
 /**

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -9,15 +9,19 @@ import fs from 'fs';
 import net from 'net';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { insertConversation, close } from './c4-db.js';
+import {
+  clearStatusNoticeCooldownReservation,
+  insertConversation,
+  close,
+  reserveStatusNoticeCooldown
+} from './c4-db.js';
 import { validateChannel, validateEndpoint } from './c4-validate.js';
 import {
   FILE_SIZE_THRESHOLD,
   ATTACHMENTS_DIR,
   CONTENT_PREVIEW_CHARS,
   AGENT_STATUS_FILE,
-  ACTIVITY_MONITOR_DIR,
-  STATUS_NOTICE_COOLDOWNS_FILE
+  ACTIVITY_MONITOR_DIR
 } from './c4-config.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -25,9 +29,6 @@ const __dirname = path.dirname(__filename);
 const AM_SOCKET_PATH = path.join(ACTIVITY_MONITOR_DIR, 'am.sock');
 const ROUTER_IPC_TIMEOUT_MS = 30000;
 const STATUS_NOTICE_COOLDOWN_SECONDS = Number.parseInt(process.env.C4_STATUS_NOTICE_COOLDOWN_SECONDS || '600', 10);
-const STATUS_NOTICE_COOLDOWNS_LOCK_DIR = `${STATUS_NOTICE_COOLDOWNS_FILE}.lock`;
-const STATUS_NOTICE_LOCK_TIMEOUT_MS = 5000;
-const STATUS_NOTICE_LOCK_STALE_MS = 30000;
 
 function printUsage() {
   console.log('Usage: node c4-receive.js --channel <channel> [--endpoint <endpoint_id>] [--priority <1-3>] [--no-reply] [--block-queue-until-idle] [--json] --content "<message>"');
@@ -258,6 +259,9 @@ function sendUnhealthyMessage(channel, endpoint, message) {
 
 function normalizeStatusEndpoint(endpoint) {
   if (!endpoint) return '';
+  // Group status-notice cooldowns by stable conversation root, not by each
+  // incoming message/request id. This keeps thread-specific cooldowns while
+  // suppressing repeated notices within the same root conversation.
   return endpoint.replace(/\|(msg|req|parent):[^|]+/g, '');
 }
 
@@ -278,113 +282,27 @@ function statusNoticeCooldownKey(channel, endpoint, route) {
   ].join('::');
 }
 
-function readStatusNoticeCooldowns() {
-  try {
-    if (!fs.existsSync(STATUS_NOTICE_COOLDOWNS_FILE)) return {};
-    return JSON.parse(fs.readFileSync(STATUS_NOTICE_COOLDOWNS_FILE, 'utf8'));
-  } catch {
-    return {};
-  }
-}
-
-function sleepSync(ms) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function acquireStatusNoticeCooldownLock() {
-  const start = Date.now();
-  while (true) {
-    try {
-      fs.mkdirSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR);
-      return () => {
-        try {
-          fs.rmdirSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR);
-        } catch { /* best-effort */ }
-      };
-    } catch (err) {
-      if (err.code !== 'EEXIST') throw err;
-
-      try {
-        const stats = fs.statSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR);
-        if ((Date.now() - stats.mtimeMs) > STATUS_NOTICE_LOCK_STALE_MS) {
-          fs.rmSync(STATUS_NOTICE_COOLDOWNS_LOCK_DIR, { recursive: true, force: true });
-          continue;
-        }
-      } catch {
-        continue;
-      }
-
-      if ((Date.now() - start) >= STATUS_NOTICE_LOCK_TIMEOUT_MS) {
-        throw new Error('timed out waiting for status cooldown lock');
-      }
-      sleepSync(25);
-    }
-  }
-}
-
-function writeStatusNoticeCooldowns(cooldowns) {
-  try {
-    fs.mkdirSync(path.dirname(STATUS_NOTICE_COOLDOWNS_FILE), { recursive: true });
-    const tmp = `${STATUS_NOTICE_COOLDOWNS_FILE}.tmp.${process.pid}.${Date.now()}`;
-    fs.writeFileSync(tmp, `${JSON.stringify(cooldowns, null, 2)}\n`, 'utf8');
-    fs.renameSync(tmp, STATUS_NOTICE_COOLDOWNS_FILE);
-  } catch (err) {
-    console.error(`[C4] Warning: failed to write status cooldowns (${err.message})`);
-  }
-}
-
-function pruneStatusNoticeCooldowns(cooldowns, ttl, now = Math.floor(Date.now() / 1000)) {
-  const pruned = {};
-  for (const [key, entry] of Object.entries(cooldowns || {})) {
-    const lastNotifiedAt = Number(entry?.last_notified_at);
-    if (!Number.isFinite(lastNotifiedAt)) continue;
-    if ((now - lastNotifiedAt) >= ttl) continue;
-    pruned[key] = entry;
-  }
-  return pruned;
-}
-
-function reserveStatusNoticeCooldown(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
+function reserveStatusNoticeCooldownForRoute(channel, endpoint, route, now = Math.floor(Date.now() / 1000)) {
   const key = statusNoticeCooldownKey(channel, endpoint, route);
   const ttl = Number.isFinite(STATUS_NOTICE_COOLDOWN_SECONDS) && STATUS_NOTICE_COOLDOWN_SECONDS > 0
     ? STATUS_NOTICE_COOLDOWN_SECONDS
     : 600;
-  const release = acquireStatusNoticeCooldownLock();
-  try {
-    const cooldowns = pruneStatusNoticeCooldowns(readStatusNoticeCooldowns(), ttl, now);
-    const previous = cooldowns[key];
-
-    if (previous && Number.isFinite(previous.last_notified_at) && (now - previous.last_notified_at) < ttl) {
-      writeStatusNoticeCooldowns(cooldowns);
-      return { suppressed: true, key, ttl, previous };
-    }
-
-    cooldowns[key] = {
-      channel,
-      endpoint: normalizeStatusEndpoint(endpoint),
-      status_type: statusNoticeType(route),
-      reason: statusNoticeReason(route),
-      last_notified_at: now
-    };
-    writeStatusNoticeCooldowns(cooldowns);
-    return { suppressed: false, key, ttl, reservedAt: now };
-  } finally {
-    release();
-  }
+  return reserveStatusNoticeCooldown({
+    cooldownKey: key,
+    channel,
+    endpoint: normalizeStatusEndpoint(endpoint),
+    statusType: statusNoticeType(route),
+    reason: statusNoticeReason(route),
+    ttl,
+    now
+  });
 }
 
-function clearStatusNoticeCooldownReservation(key, reservedAt) {
-  const release = acquireStatusNoticeCooldownLock();
+function clearStatusNoticeCooldownReservationForRoute(key, reservedAt) {
   try {
-    const cooldowns = readStatusNoticeCooldowns();
-    if (cooldowns[key]?.last_notified_at === reservedAt) {
-      delete cooldowns[key];
-      writeStatusNoticeCooldowns(cooldowns);
-    }
+    clearStatusNoticeCooldownReservation(key, reservedAt);
   } catch (err) {
     console.error(`[C4] Warning: failed to clear status cooldown reservation (${err.message})`);
-  } finally {
-    release();
   }
 }
 
@@ -466,14 +384,14 @@ async function main() {
 
   if (!route.recovered && !noReply) {
     try {
-      cooldown = reserveStatusNoticeCooldown(channel, endpoint, route);
+      cooldown = reserveStatusNoticeCooldownForRoute(channel, endpoint, route);
     } catch (err) {
       emitError(json, 'INTERNAL_ERROR', `failed to reserve status cooldown: ${err.message}`);
     }
     if (cooldown.suppressed) {
       dbContent += `\n\n[C4] Status notification suppressed by cooldown while health=${statusNoticeType(route)} reason=${statusNoticeReason(route)}.`;
       try {
-        const record = insertConversation('in', channel, endpoint, dbContent, dbStatus, priority, requireIdle);
+        const record = insertConversation('in', channel, endpoint, dbContent, dbStatus, priority, requireIdle, 'suppressed');
         emitSuccess(json, record.id, 'suppressed');
         return;
       } catch (err) {
@@ -497,7 +415,7 @@ async function main() {
       return;
     }
     if (cooldown?.key && Number.isFinite(cooldown.reservedAt)) {
-      clearStatusNoticeCooldownReservation(cooldown.key, cooldown.reservedAt);
+      clearStatusNoticeCooldownReservationForRoute(cooldown.key, cooldown.reservedAt);
     }
     const detail = sendResult.stderr || sendResult.stdout || `exit ${sendResult.status}`;
     emitError(json, 'UNHEALTHY_NOTIFY_FAILED', `failed to send unhealthy status message: ${detail.trim()}`);


### PR DESCRIPTION
## Summary
- move C4 unhealthy/status notice cooldown persistence from the activity-monitor JSON sidecar into `comm-bridge/c4.db`
- add automatic schema migration for `status_notice_cooldowns` and `conversations.delivery_action`
- preserve reserve-before-notify behavior, send-failure cleanup, endpoint normalization, and `--no-reply` behavior
- make suppressed status notices queryable with `delivery_action = 'suppressed'`

Fixes #603

## Implementation
- `init-db.sql` defines the new `status_notice_cooldowns` table and `conversations.delivery_action`.
- `c4-db.js` now ensures both schemas on `getDb()` so existing installs are migrated without recreating `c4.db`.
- `reserveStatusNoticeCooldown()` runs inside a SQLite transaction: prune expired rows, then `INSERT OR IGNORE` the cooldown key. A successful insert reserves send rights; an ignored insert returns `suppressed`.
- `clearStatusNoticeCooldownReservation()` deletes by `cooldown_key + last_notified_at`, so failed sends clear only the reservation they created.
- `c4-receive.js` no longer owns JSON persistence, lock dirs, stale-lock cleanup, sync sleeps, or temp-file writes. It delegates cooldown reserve/clear to the DB helpers.
- Suppressed receives still record `status = 'delivered'` to avoid queue retries, but now also record `delivery_action = 'suppressed'` for audit/querying.

## Issue Coverage
- Moves cooldown state from `activity-monitor/status-notice-cooldowns.json` to C4 SQLite state.
- Keeps old-instance migration out of `init-db.sql` only by adding schema ensures in `getDb()`.
- Keeps reserve/suppress atomic for concurrent `c4-receive` processes.
- Preserves send-failure reservation rollback from #599.
- Removes the JSON sidecar, lock directory, stale-lock handling, and sleep polling.
- Adds a comment explaining endpoint normalization: strip volatile `msg` / `req` / `parent` while preserving stable root/thread dimensions.
- Replaces the previous slow-send race test with a deterministic barrier-style concurrency test.

## Tests
- `node --test skills/comm-bridge/scripts/__tests__/c4-receive.test.js`
- `node --test skills/comm-bridge/scripts/__tests__/c4-db-control.test.js`
- `npm test`