### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-02
+
+### Fixed
+- **Codex config merge**: `writeCodexConfig()` now merges with existing configuration instead of overwriting it. Uses `smol-toml` for TOML parsing with four ownership semantics: always-overwrite, backfill, conditional, and exact-replacement. Adds managed defaults for `model`, `model_reasoning_effort` (backfill), and `fast_mode` (always-overwrite). (#606)
+- **C4 status notification dedup**: repeated status notices are now throttled with a cooldown mechanism persisted to SQLite, preventing notification flooding across service restarts. (#599, #604)
+- **Caddy route configuration**: graceful fallback to manual configuration guidance when Caddy API is unavailable, instead of throwing an error. (#602)
+
 ## [0.5.1] - 2026-05-25
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.5.2
- Update CHANGELOG with changes since v0.5.1

### Changes in this release
- **Fix**: Codex config merge — `writeCodexConfig()` now merges with existing config instead of overwriting (#606)
- **Fix**: C4 status notification dedup — cooldown mechanism persisted to SQLite (#599, #604)
- **Fix**: Caddy route config — graceful fallback when API unavailable (#602)

## Test plan
- [ ] Verify CHANGELOG format
- [ ] Verify package.json/package-lock.json version bump
- [ ] Tag v0.5.2 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)