### PR TITLE
fix: pin PM2 services to managed Node path

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -40,6 +40,7 @@ import {
   saveCodexBaseUrlToEnv,
   writeCodexConfig,
 } from '../lib/runtime-setup.js';
+import { buildManagedPm2Env } from '../lib/pm2-env.js';
 
 // Source directories (shipped with zylos package)
 const PACKAGE_ROOT = path.join(import.meta.dirname, '..', '..');
@@ -596,7 +597,7 @@ async function guideBypassAcceptance() {
   console.log(`\n${heading('Setting up Claude Code...')}`);
 
   // Stop activity-monitor to prevent restart loop
-  try { execSync('pm2 stop activity-monitor', { stdio: 'pipe' }); } catch {}
+  try { execSync('pm2 stop activity-monitor', { stdio: 'pipe', env: buildManagedPm2Env() }); } catch {}
 
   // Kill existing session if stuck
   try { execSync(`tmux kill-session -t ${CLAUDE_SESSION} 2>/dev/null`, { stdio: 'pipe' }); } catch {}
@@ -630,7 +631,7 @@ async function guideBypassAcceptance() {
     } catch {}
   } catch (err) {
     console.log(`  ${warn(`Failed to create tmux session: ${err.message}`)}`);
-    try { execSync('pm2 start activity-monitor', { stdio: 'pipe' }); } catch {}
+    try { execSync('pm2 start activity-monitor', { stdio: 'pipe', env: buildManagedPm2Env() }); } catch {}
     return;
   }
 
@@ -642,7 +643,7 @@ async function guideBypassAcceptance() {
   await promptYesNo('Press Enter after you have accepted the prompt: ', true);
 
   // Restart activity-monitor
-  try { execSync('pm2 start activity-monitor', { stdio: 'pipe' }); } catch {}
+  try { execSync('pm2 start activity-monitor', { stdio: 'pipe', env: buildManagedPm2Env() }); } catch {}
   console.log(`  ${success('Claude Code configured')}`);
 }
 
@@ -674,7 +675,7 @@ function resetManagedState() {
   // Stop PM2 services managed by zylos
   const serviceNames = getCoreServiceNames();
   for (const name of serviceNames) {
-    try { execSync(`pm2 delete "${name}" 2>/dev/null`, { stdio: 'pipe' }); } catch { /* */ }
+    try { execSync(`pm2 delete "${name}" 2>/dev/null`, { stdio: 'pipe', env: buildManagedPm2Env() }); } catch { /* */ }
   }
 
   // Remove managed directories
@@ -1066,10 +1067,10 @@ function startCoreServices(webPassword = null) {
     // (--update-env does NOT re-execute the JS, so env changes like SYSTEM_PATH won't apply)
     const serviceNames = getCoreServiceNames();
     for (const name of serviceNames) {
-      try { execSync(`pm2 delete "${name}"`, { stdio: 'pipe' }); } catch {}
+      try { execSync(`pm2 delete "${name}"`, { stdio: 'pipe', env: buildManagedPm2Env() }); } catch {}
     }
-    execSync(`pm2 start "${ecosystemPath}"`, { stdio: 'pipe', timeout: 30000 });
-    execSync('pm2 save', { stdio: 'pipe' });
+    execSync(`pm2 start "${ecosystemPath}"`, { stdio: 'pipe', timeout: 30000, env: buildManagedPm2Env() });
+    execSync('pm2 save', { stdio: 'pipe', env: buildManagedPm2Env() });
   } catch (err) {
     console.log(`  ${warn(`Failed to start services: ${err.message}`)}`);
     return 0;
@@ -1078,7 +1079,7 @@ function startCoreServices(webPassword = null) {
   // Report status of core services only
   try {
     const serviceNames = getCoreServiceNames();
-    const list = execSync('pm2 jlist', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const list = execSync('pm2 jlist', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], env: buildManagedPm2Env() });
     const procs = JSON.parse(list);
     let started = 0;
     for (const proc of procs) {

--- a/cli/commands/service.js
+++ b/cli/commands/service.js
@@ -11,6 +11,7 @@ import { bold, dim, green, red, yellow, cyan, success, error, warn, heading } fr
 import { commandExists } from '../lib/shell-utils.js';
 import { getActiveAdapter } from '../lib/runtime/index.js';
 import { getCoreEcosystemPath, restartFromEcosystem, restartManagedProcess } from '../lib/pm2.js';
+import { buildManagedPm2Env } from '../lib/pm2-env.js';
 
 function shellQuote(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`;
@@ -53,7 +54,7 @@ export function restartServicesWithDeps({
         saveNeeded = true;
       } catch {
         if (saveNeeded) {
-          execSyncFn('pm2 save 2>/dev/null', { stdio: 'inherit' });
+          execSyncFn('pm2 save 2>/dev/null', { stdio: 'inherit', env: buildManagedPm2Env() });
         }
         logError(error('Failed to restart services'));
         return false;
@@ -62,7 +63,7 @@ export function restartServicesWithDeps({
   }
 
   if (saveNeeded) {
-    execSyncFn('pm2 save 2>/dev/null', { stdio: 'inherit' });
+    execSyncFn('pm2 save 2>/dev/null', { stdio: 'inherit', env: buildManagedPm2Env() });
   }
   if (fallbackServices.length > 0) {
     logSuccess(success(`Services restarted. Plain PM2 fallback used for: ${fallbackServices.join(', ')}.`));
@@ -159,7 +160,7 @@ export async function showStatus() {
   // Check PM2 services
   console.log(heading('Services (PM2):'));
   try {
-    const pm2Output = execSync('pm2 jlist 2>/dev/null', { encoding: 'utf8' });
+    const pm2Output = execSync('pm2 jlist 2>/dev/null', { encoding: 'utf8', env: buildManagedPm2Env() });
     const processes = JSON.parse(pm2Output);
     if (processes.length === 0) {
       console.log(`  ${dim('No services running')}`);
@@ -228,8 +229,8 @@ export function startServices() {
   const ecosystemPath = getCoreEcosystemPath();
   if (fs.existsSync(ecosystemPath)) {
     try {
-      execSync(`pm2 start "${ecosystemPath}"`, { stdio: 'pipe' });
-      execSync('pm2 save 2>/dev/null', { stdio: 'pipe' });
+      execSync(`pm2 start "${ecosystemPath}"`, { stdio: 'pipe', env: buildManagedPm2Env() });
+      execSync('pm2 save 2>/dev/null', { stdio: 'pipe', env: buildManagedPm2Env() });
       console.log(`  ${success('Started services from ecosystem.config.cjs')}`);
       console.log(`\n${green('Services started.')} Run ${dim('"zylos status"')} to check.`);
       return;
@@ -254,14 +255,14 @@ export function startServices() {
     }
     try {
       const envOpts = buildPm2EnvFlags(svc.env);
-      execSync(`pm2 start ${shellQuote(svc.script)} --name ${shellQuote(svc.name)} ${envOpts} 2>/dev/null`, { stdio: 'pipe' });
+      execSync(`pm2 start ${shellQuote(svc.script)} --name ${shellQuote(svc.name)} ${envOpts} 2>/dev/null`, { stdio: 'pipe', env: buildManagedPm2Env() });
       console.log(`  ${success(bold(svc.name))}`);
       started++;
     } catch (e) {
       try {
-        try { execSync(`pm2 delete "${svc.name}" 2>/dev/null`, { stdio: 'pipe' }); } catch {}
+        try { execSync(`pm2 delete "${svc.name}" 2>/dev/null`, { stdio: 'pipe', env: buildManagedPm2Env() }); } catch {}
         const envOpts = buildPm2EnvFlags(svc.env);
-        execSync(`pm2 start ${shellQuote(svc.script)} --name ${shellQuote(svc.name)} ${envOpts} 2>/dev/null`, { stdio: 'pipe' });
+        execSync(`pm2 start ${shellQuote(svc.script)} --name ${shellQuote(svc.name)} ${envOpts} 2>/dev/null`, { stdio: 'pipe', env: buildManagedPm2Env() });
         console.log(`  ${success(`${bold(svc.name)} ${dim('(started after cleanup)')}`)}`);
         started++;
       } catch (e2) {
@@ -271,7 +272,7 @@ export function startServices() {
   }
 
   if (started > 0) {
-    execSync('pm2 save 2>/dev/null', { stdio: 'pipe' });
+    execSync('pm2 save 2>/dev/null', { stdio: 'pipe', env: buildManagedPm2Env() });
     console.log(`\n${green(started + ' services started.')} Run ${dim('"zylos status"')} to check.`);
   } else {
     console.log('\n' + warn('No services started.'));
@@ -282,7 +283,7 @@ export function stopServices() {
   console.log(heading('Stopping Zylos services...'));
   const services = ['activity-monitor', 'scheduler', 'c4-dispatcher', 'web-console'];
   try {
-    execSync(`pm2 stop ${services.join(' ')} 2>/dev/null || true`, { stdio: 'inherit' });
+    execSync(`pm2 stop ${services.join(' ')} 2>/dev/null || true`, { stdio: 'inherit', env: buildManagedPm2Env() });
     console.log(success('Services stopped.'));
   } catch (e) {
     console.error(error('Failed to stop services'));

--- a/cli/lib/__tests__/pm2-env.test.js
+++ b/cli/lib/__tests__/pm2-env.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildManagedPath, buildManagedPm2Env } from '../pm2-env.js';
+
+describe('PM2 managed environment', () => {
+  it('places SYSTEM_PATH before the ambient PATH and deduplicates entries', () => {
+    assert.equal(
+      buildManagedPath({
+        systemPath: '/nvm/bin:/opt/homebrew/bin',
+        envPath: '/opt/homebrew/bin:/usr/bin',
+      }),
+      '/nvm/bin:/opt/homebrew/bin:/usr/bin'
+    );
+  });
+
+  it('returns a process environment with the managed PATH', () => {
+    const env = buildManagedPm2Env({
+      PATH: '/opt/homebrew/bin:/usr/bin',
+      SYSTEM_PATH: '/nvm/bin:/opt/homebrew/bin',
+      KEEP_ME: 'yes',
+    });
+
+    assert.equal(env.PATH, '/nvm/bin:/opt/homebrew/bin:/usr/bin');
+    assert.equal(env.KEEP_ME, 'yes');
+  });
+});

--- a/cli/lib/__tests__/pm2.test.js
+++ b/cli/lib/__tests__/pm2.test.js
@@ -9,6 +9,7 @@ describe('PM2 ecosystem restart helpers', () => {
     const { restartFromEcosystem } = createPm2Helpers({
       exists: (file) => file === '/tmp/ecosystem.config.cjs',
       exec: (cmd, opts) => calls.push({ cmd, opts }),
+      execOptions: (stdio) => ({ stdio }),
     });
 
     restartFromEcosystem(['activity-monitor', 'c4-dispatcher'], {
@@ -36,6 +37,7 @@ describe('PM2 ecosystem restart helpers', () => {
   it('throws when ecosystem restart is requested without a valid config file', () => {
     const { restartFromEcosystem } = createPm2Helpers({
       exists: () => false,
+      execOptions: (stdio) => ({ stdio }),
       exec: () => {
         throw new Error('should not execute');
       },
@@ -52,6 +54,7 @@ describe('PM2 ecosystem restart helpers', () => {
     const { restartManagedProcess } = createPm2Helpers({
       exists: (file) => file === '/tmp/component-ecosystem.config.cjs',
       exec: (cmd, opts) => calls.push({ cmd, opts }),
+      execOptions: (stdio) => ({ stdio }),
     });
 
     restartManagedProcess('zylos-wecom', {
@@ -72,6 +75,7 @@ describe('PM2 ecosystem restart helpers', () => {
     const { restartManagedProcess } = createPm2Helpers({
       exists: () => false,
       exec: (cmd, opts) => calls.push({ cmd, opts }),
+      execOptions: (stdio) => ({ stdio }),
     });
 
     restartManagedProcess('zylos-custom', {
@@ -106,6 +110,7 @@ describe('PM2 ecosystem restart helpers', () => {
           throw new Error('bad ecosystem');
         }
       },
+      execOptions: (stdio) => ({ stdio }),
     });
 
     restartManagedProcess('activity-monitor', {
@@ -128,5 +133,22 @@ describe('PM2 ecosystem restart helpers', () => {
         opts: { stdio: 'inherit' },
       },
     ]);
+  });
+
+  it('executes pm2 commands with the managed environment by default', () => {
+    const calls = [];
+    const { restartFromEcosystem } = createPm2Helpers({
+      exists: (file) => file === '/tmp/ecosystem.config.cjs',
+      exec: (cmd, opts) => calls.push({ cmd, opts }),
+    });
+
+    restartFromEcosystem(['zylos-dashboard'], {
+      ecosystemPath: '/tmp/ecosystem.config.cjs',
+    });
+
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].cmd, /pm2 start/);
+    assert.equal(calls[0].opts.stdio, 'pipe');
+    assert.equal(typeof calls[0].opts.env.PATH, 'string');
   });
 });

--- a/cli/lib/__tests__/service-restart.test.js
+++ b/cli/lib/__tests__/service-restart.test.js
@@ -36,10 +36,10 @@ describe('restartServicesWithDeps', () => {
         fallbackToPlainRestartOnError: true,
       },
     }]);
-    assert.deepStrictEqual(execCalls, [{
-      cmd: 'pm2 save 2>/dev/null',
-      opts: { stdio: 'inherit' },
-    }]);
+    assert.equal(execCalls.length, 1);
+    assert.equal(execCalls[0].cmd, 'pm2 save 2>/dev/null');
+    assert.equal(execCalls[0].opts.stdio, 'inherit');
+    assert.equal(typeof execCalls[0].opts.env.PATH, 'string');
     assert.equal(messages.some((msg) => String(msg).includes('scheduler')), true);
   });
 
@@ -65,10 +65,10 @@ describe('restartServicesWithDeps', () => {
     });
 
     assert.equal(ok, false);
-    assert.deepStrictEqual(execCalls, [{
-      cmd: 'pm2 save 2>/dev/null',
-      opts: { stdio: 'inherit' },
-    }]);
+    assert.equal(execCalls.length, 1);
+    assert.equal(execCalls[0].cmd, 'pm2 save 2>/dev/null');
+    assert.equal(execCalls[0].opts.stdio, 'inherit');
+    assert.equal(typeof execCalls[0].opts.env.PATH, 'string');
     assert.equal(messages.some((msg) => String(msg).includes('Failed to restart services')), true);
   });
 });

--- a/cli/lib/__tests__/upgrade-restart.test.js
+++ b/cli/lib/__tests__/upgrade-restart.test.js
@@ -115,12 +115,14 @@ describe('step11_startCoreServices', () => {
     const ecosystemPath = path.join(tmpDir, 'ecosystem.config.cjs');
     const pm2Path = path.join(binDir, 'pm2');
     const originalPath = process.env.PATH;
+    const originalSystemPath = process.env.SYSTEM_PATH;
 
     fs.mkdirSync(binDir, { recursive: true });
     fs.writeFileSync(ecosystemPath, 'module.exports = { apps: [] };\n', 'utf8');
     fs.writeFileSync(pm2Path, `#!/bin/sh\necho "$@" >> "${logPath}"\nif [ "$1" = "jlist" ]; then echo '[{"name":"activity-monitor","pm_id":3,"pm2_env":{"status":"online","ZYLOS_PACKAGE_ROOT":"${tmpDir}"}}]'; fi\n`, { mode: 0o755 });
 
     process.env.PATH = `${binDir}:${originalPath}`;
+    process.env.SYSTEM_PATH = binDir;
 
     try {
       const result = step11_startCoreServices({
@@ -143,6 +145,11 @@ describe('step11_startCoreServices', () => {
       assert.match(fs.readFileSync(logPath, 'utf8'), /save/);
     } finally {
       process.env.PATH = originalPath;
+      if (originalSystemPath === undefined) {
+        delete process.env.SYSTEM_PATH;
+      } else {
+        process.env.SYSTEM_PATH = originalSystemPath;
+      }
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/cli/lib/pm2-env.js
+++ b/cli/lib/pm2-env.js
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ENV_FILE } from './config.js';
+
+function readEnvValue(key) {
+  try {
+    const content = fs.readFileSync(ENV_FILE, 'utf8');
+    const match = content.match(new RegExp(`^\\s*${key}\\s*=\\s*(.+)$`, 'm'));
+    if (match) return match[1].trim().replace(/^(['"])(.*)\1$/, '$2');
+  } catch {}
+  return '';
+}
+
+export function buildManagedPath({
+  envPath = process.env.PATH || '',
+  systemPath = process.env.SYSTEM_PATH || readEnvValue('SYSTEM_PATH'),
+} = {}) {
+  return [...new Set([
+    ...(systemPath || '').split(path.delimiter).filter(Boolean),
+    ...(envPath || '').split(path.delimiter).filter(Boolean),
+  ])].join(path.delimiter);
+}
+
+export function buildManagedPm2Env(env = process.env) {
+  return {
+    ...env,
+    PATH: buildManagedPath({ envPath: env.PATH || '', systemPath: env.SYSTEM_PATH || readEnvValue('SYSTEM_PATH') }),
+  };
+}

--- a/cli/lib/pm2.js
+++ b/cli/lib/pm2.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { ZYLOS_DIR } from './config.js';
+import { buildManagedPm2Env } from './pm2-env.js';
 
 export function getCoreEcosystemPath() {
   return path.join(ZYLOS_DIR, 'pm2', 'ecosystem.config.cjs');
@@ -10,6 +11,7 @@ export function getCoreEcosystemPath() {
 export function createPm2Helpers({
   exec = execSync,
   exists = fs.existsSync,
+  execOptions = (stdio) => ({ stdio, env: buildManagedPm2Env() }),
 } = {}) {
   function restartFromEcosystem(names, {
     ecosystemPath = getCoreEcosystemPath(),
@@ -21,13 +23,13 @@ export function createPm2Helpers({
     }
 
     for (const name of names) {
-      exec(`pm2 start "${ecosystemPath}" --only "${name}" --update-env 2>/dev/null`, { stdio });
+      exec(`pm2 start "${ecosystemPath}" --only "${name}" --update-env 2>/dev/null`, execOptions(stdio));
     }
 
     // Persist only after every restart succeeded so callers don't save a
     // partially-updated PM2 process list.
     if (save) {
-      exec('pm2 save 2>/dev/null', { stdio });
+      exec('pm2 save 2>/dev/null', execOptions(stdio));
     }
   }
 
@@ -45,16 +47,16 @@ export function createPm2Helpers({
         if (!fallbackToPlainRestartOnError) {
           throw err;
         }
-        try { exec(`pm2 delete "${name}" 2>/dev/null`, { stdio }); } catch {}
+        try { exec(`pm2 delete "${name}" 2>/dev/null`, execOptions(stdio)); } catch {}
         restartFromEcosystem([name], { ecosystemPath, stdio, save });
         return;
       }
     }
 
-    exec(`pm2 restart "${name}" 2>/dev/null`, { stdio });
+    exec(`pm2 restart "${name}" 2>/dev/null`, execOptions(stdio));
 
     if (save) {
-      exec('pm2 save 2>/dev/null', { stdio });
+      exec('pm2 save 2>/dev/null', execOptions(stdio));
     }
   }
 

--- a/cli/lib/service.js
+++ b/cli/lib/service.js
@@ -5,6 +5,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { buildManagedPm2Env } from './pm2-env.js';
 
 /**
  * Register and start a PM2 service for a component.
@@ -31,7 +32,7 @@ export function registerService({ name, entry, skillDir, type }) {
   try {
     // Stop existing service if running (ignore errors)
     try {
-      execSync(`pm2 delete "${serviceName}" 2>/dev/null`, { stdio: 'pipe' });
+      execSync(`pm2 delete "${serviceName}" 2>/dev/null`, { stdio: 'pipe', env: buildManagedPm2Env() });
     } catch {
       // Not running — fine
     }
@@ -42,16 +43,18 @@ export function registerService({ name, entry, skillDir, type }) {
       execSync(`pm2 start "${ecosystemPath}"`, {
         stdio: 'pipe',
         timeout: 30000,
+        env: buildManagedPm2Env(),
       });
     } else {
       execSync(`pm2 start "${scriptPath}" --name "${serviceName}"`, {
         stdio: 'pipe',
         timeout: 30000,
+        env: buildManagedPm2Env(),
       });
     }
 
     // Save PM2 process list
-    execSync('pm2 save 2>/dev/null', { stdio: 'pipe' });
+    execSync('pm2 save 2>/dev/null', { stdio: 'pipe', env: buildManagedPm2Env() });
 
     return { success: true };
   } catch (err) {

--- a/templates/pm2/ecosystem.config.cjs
+++ b/templates/pm2/ecosystem.config.cjs
@@ -39,6 +39,21 @@ const ENHANCED_PATH = [...new Set([
   ...(process.env.PATH || '').split(':').filter(Boolean),
 ])].join(':');
 
+function resolveManagedNode() {
+  try {
+    const { execSync } = require('child_process');
+    const nodePath = execSync(
+      'command -v node 2>/dev/null || true',
+      { encoding: 'utf8', env: { ...process.env, PATH: ENHANCED_PATH }, stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    return nodePath || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const MANAGED_NODE = resolveManagedNode();
+
 // Whether Claude should run with --dangerously-skip-permissions
 const CLAUDE_BYPASS_PERMISSIONS = readEnvValue('CLAUDE_BYPASS_PERMISSIONS', 'true');
 // Whether Codex should run with --dangerously-bypass-approvals-and-sandbox
@@ -141,7 +156,11 @@ function loadComponentServices() {
                 continue;
               }
               // Copy app to avoid mutating the require() cached object
-              const safeApp = { ...app, env: { ...app.env, PATH: ENHANCED_PATH } };
+              const safeApp = {
+                ...app,
+                ...(app.interpreter ? {} : (MANAGED_NODE ? { interpreter: MANAGED_NODE } : {})),
+                env: { ...app.env, PATH: ENHANCED_PATH },
+              };
               usedNames.add(safeApp.name);
               apps.push(safeApp);
             }
@@ -166,6 +185,7 @@ function loadComponentServices() {
           name: service.name,
           script: service.entry,
           cwd: skillDir,
+          ...(MANAGED_NODE ? { interpreter: MANAGED_NODE } : {}),
           env: {
             PATH: ENHANCED_PATH,
             NODE_ENV: 'production',
@@ -194,6 +214,7 @@ module.exports = {
       name: 'scheduler',
       script: path.join(SKILLS_DIR, 'scheduler', 'scripts', 'daemon.js'),
       cwd: ZYLOS_DIR,
+      ...(MANAGED_NODE ? { interpreter: MANAGED_NODE } : {}),
       env: {
         PATH: ENHANCED_PATH,
         NODE_ENV: 'production'
@@ -206,6 +227,7 @@ module.exports = {
       name: 'web-console',
       script: path.join(SKILLS_DIR, 'web-console', 'scripts', 'server.js'),
       cwd: HOME,
+      ...(MANAGED_NODE ? { interpreter: MANAGED_NODE } : {}),
       env: {
         PATH: ENHANCED_PATH,
         NODE_ENV: 'production'
@@ -218,6 +240,7 @@ module.exports = {
       name: 'c4-dispatcher',
       script: path.join(SKILLS_DIR, 'comm-bridge', 'scripts', 'c4-dispatcher.js'),
       cwd: path.join(SKILLS_DIR, 'comm-bridge', 'scripts'),
+      ...(MANAGED_NODE ? { interpreter: MANAGED_NODE } : {}),
       env: {
         PATH: ENHANCED_PATH,
         NODE_ENV: 'production'
@@ -230,6 +253,7 @@ module.exports = {
       name: 'activity-monitor',
       script: path.join(SKILLS_DIR, 'activity-monitor', 'scripts', 'activity-monitor.js'),
       cwd: HOME,
+      ...(MANAGED_NODE ? { interpreter: MANAGED_NODE } : {}),
       env: {
         PATH: ENHANCED_PATH,
         NODE_ENV: 'production',


### PR DESCRIPTION
## Summary
- run PM2 service/restart commands with Zylos managed PATH instead of ambient shell PATH
- inject the resolved managed Node interpreter into core JS services and component services loaded by the core ecosystem
- add PM2 env coverage so SYSTEM_PATH stays ahead of Homebrew or other ambient Node paths

## Validation
- node --check templates/pm2/ecosystem.config.cjs
- node --test cli/lib/__tests__/pm2.test.js cli/lib/__tests__/pm2-env.test.js cli/lib/__tests__/service-restart.test.js
- node --test cli/lib/__tests__/upgrade-restart.test.js cli/lib/__tests__/pm2.test.js cli/lib/__tests__/pm2-env.test.js
- npm test: Jest passed, Node suite has one unrelated existing environment failure in cli/lib/__tests__/fs-utils.test.js TMPDIR fallback

## Live recovery
- Dashboard PM2 service restored under Node 24.14.0
- direct dashboard API smoke passed
- local Caddy /dashboard/, /dashboard/api/health, and asset route returned 200