### PR TITLE
Test caddy stripped route upgrade markers

### DIFF
--- a/cli/lib/caddy.js
+++ b/cli/lib/caddy.js
@@ -213,6 +213,29 @@ function findPrimaryBlockEnd(content) {
   return -1;
 }
 
+export function generateCaddyfileWithComponentRoutes(originalContent, componentName, httpRoutes) {
+  const beginMarker = `# BEGIN zylos-component:${componentName}`;
+  const endMarker = `# END zylos-component:${componentName}`;
+
+  let content = originalContent;
+  if (content.includes(beginMarker)) {
+    content = stripMarkerBlock(content, beginMarker, endMarker);
+  }
+
+  const markedBlock = generateManualRouteSnippet(componentName, httpRoutes);
+  const primaryBrace = findPrimaryBlockEnd(content);
+  if (primaryBrace === -1) {
+    return { success: false, error: 'Cannot find domain block in Caddyfile' };
+  }
+
+  const before = content.slice(0, primaryBrace).trimEnd();
+  const after = content.slice(primaryBrace);
+  return {
+    success: true,
+    content: `${before}\n\n${markedBlock}\n${after}`,
+  };
+}
+
 /**
  * Apply Caddy routes for a component.
  * Reads Caddyfile, removes existing markers for this component (if any),
@@ -242,9 +265,6 @@ export function applyCaddyRoutes(componentName, httpRoutes, deps = {}) {
     };
   }
 
-  const beginMarker = `# BEGIN zylos-component:${componentName}`;
-  const endMarker = `# END zylos-component:${componentName}`;
-
   let original;
   try {
     original = fs.readFileSync(CADDYFILE, 'utf8');
@@ -252,32 +272,14 @@ export function applyCaddyRoutes(componentName, httpRoutes, deps = {}) {
     return { success: false, action: 'skipped', error: `Cannot read Caddyfile: ${err.message}` };
   }
 
-  // Remove existing marker block for this component (if any)
-  let content = original;
-  const isUpdate = content.includes(beginMarker);
-  if (isUpdate) {
-    content = stripMarkerBlock(content, beginMarker, endMarker);
+  const isUpdate = original.includes(`# BEGIN zylos-component:${componentName}`);
+  const generated = generateCaddyfileWithComponentRoutes(original, componentName, httpRoutes);
+  if (!generated.success) {
+    return { success: false, action: 'skipped', error: generated.error };
   }
-
-  // Generate new route block with component markers.
-  const markedBlock = generateManualRouteSnippet(componentName, httpRoutes);
-
-  // Find the closing `}` of the primary (first) server block.
-  // The Caddyfile may contain multiple server blocks (e.g. user-added
-  // reverse proxies for other services). Component routes must be
-  // inserted into the first block, which is always the zylos-managed one.
-  const primaryBrace = findPrimaryBlockEnd(content);
-  if (primaryBrace === -1) {
-    return { success: false, action: 'skipped', error: 'Cannot find domain block in Caddyfile' };
-  }
-
-  // Insert marked block before the closing brace, with proper spacing
-  const before = content.slice(0, primaryBrace).trimEnd();
-  const after = content.slice(primaryBrace);
-  const newContent = `${before}\n\n${markedBlock}\n${after}`;
 
   // Write to temp file, validate, then deploy
-  const result = validateAndDeploy(newContent, original);
+  const result = validateAndDeploy(generated.content, original);
   if (!result.success) {
     return { success: false, action: isUpdate ? 'updated' : 'added', error: result.error };
   }

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import { isLocalAddress } from '../cli/commands/init.js';
-import { applyCaddyRoutes, generateManualRouteSnippet, generateRouteBlocks } from '../cli/lib/caddy.js';
+import { applyCaddyRoutes, generateCaddyfileWithComponentRoutes, generateManualRouteSnippet, generateRouteBlocks } from '../cli/lib/caddy.js';
 
 describe('isLocalAddress', () => {
   // Positive cases — should return true
@@ -172,5 +172,24 @@ describe('applyCaddyRoutes', () => {
     });
 
     expect(result).toEqual({ success: true, action: 'skipped' });
+  });
+});
+
+describe('generateCaddyfileWithComponentRoutes', () => {
+  test('upgrades stale stripped route markers to include X-Forwarded-Prefix', () => {
+    const original = `# Zylos Caddyfile\nexample.com {\n    reverse_proxy /console/* localhost:3456\n\n    # BEGIN zylos-component:dashboard\n    redir /dashboard /dashboard/ permanent\n    handle /dashboard/* {\n        uri strip_prefix /dashboard\n        reverse_proxy 127.0.0.1:3470\n    }\n    # END zylos-component:dashboard\n}\n`;
+
+    const result = generateCaddyfileWithComponentRoutes(original, 'dashboard', [{
+      path: '/dashboard/*',
+      type: 'reverse_proxy',
+      target: '127.0.0.1:3470',
+      strip_prefix: '/dashboard',
+    }]);
+
+    expect(result.success).toBe(true);
+    expect(result.content).toContain('        reverse_proxy 127.0.0.1:3470 {');
+    expect(result.content).toContain('            header_up X-Forwarded-Prefix /dashboard');
+    expect(result.content).not.toContain('        reverse_proxy 127.0.0.1:3470\n    }');
+    expect(result.content.match(/BEGIN zylos-component:dashboard/g)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- extract Caddy route marker generation into a pure helper used by `applyCaddyRoutes`
- add a regression test for replacing an existing stale Dashboard marker that has `uri strip_prefix /dashboard` but lost `header_up X-Forwarded-Prefix /dashboard`
- assert regenerated stripped-prefix routes use the reverse_proxy block form with `X-Forwarded-Prefix`, drop the stale single-line proxy, and keep only one component marker

## Validation
- `node --check cli/lib/caddy.js`
- `npm run test:jest -- --runTestsByPath test/caddy.test.js`
- `git diff --check`

Note: a mistaken broader `npm test -- --runTestsByPath test/caddy.test.js` also ran the Node full suite; Jest suites passed, but the existing environment-sensitive `cli/lib/__tests__/fs-utils.test.js` TMPDIR fallback self-copy backup assertion failed. This appears unrelated to the Caddy route change and was previously observed during PR #609 work.
