### PR TITLE
Fix upgrade restart for non-stopped services

### DIFF
--- a/cli/lib/__tests__/upgrade-restart.test.js
+++ b/cli/lib/__tests__/upgrade-restart.test.js
@@ -4,7 +4,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 
-const { rollback, step7_runPostUpgradeHook, step8_startService } = await import('../upgrade.js');
+const {
+  rollback,
+  shouldRestartServiceAfterUpgrade,
+  step7_runPostUpgradeHook,
+  step8_startService,
+} = await import('../upgrade.js');
 const { step11_startCoreServices } = await import('../self-upgrade.js');
 const { restartRuntimeServices } = await import('../../commands/runtime.js');
 
@@ -164,6 +169,75 @@ describe('step7_runPostUpgradeHook', () => {
 });
 
 describe('step8_startService', () => {
+  it('restarts declared services unless PM2 status shows an intentional stop', () => {
+    assert.equal(shouldRestartServiceAfterUpgrade('online'), true);
+    assert.equal(shouldRestartServiceAfterUpgrade('errored'), true);
+    assert.equal(shouldRestartServiceAfterUpgrade('launching'), true);
+    assert.equal(shouldRestartServiceAfterUpgrade('waiting restart'), true);
+    assert.equal(shouldRestartServiceAfterUpgrade('unknown'), true);
+    assert.equal(shouldRestartServiceAfterUpgrade('stopped'), false);
+    assert.equal(shouldRestartServiceAfterUpgrade('stopping'), false);
+  });
+
+  for (const status of ['errored', 'launching', 'waiting restart', 'unexpected']) {
+    it(`restarts services that were ${status} before upgrade`, () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-upgrade-step8-restart-'));
+      const skillDir = path.join(tmpDir, 'demo');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `---\nname: demo\nlifecycle:\n  service:\n    name: zylos-demo\n---\n`, 'utf8');
+      fs.writeFileSync(path.join(skillDir, 'ecosystem.config.cjs'), 'module.exports = { apps: [] };\n', 'utf8');
+
+      const calls = [];
+      try {
+        const result = step8_startService({
+          component: 'demo',
+          skillDir,
+          serviceInitialStatus: status,
+          serviceShouldRestart: true,
+          serviceWasRunning: false,
+        }, {
+          restartManagedProcess: (name, opts) => {
+            calls.push({ name, opts });
+          },
+        });
+
+        assert.equal(result.status, 'done');
+        assert.equal(result.message, 'zylos-demo');
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].name, 'zylos-demo');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const status of ['stopped', 'stopping']) {
+    it(`skips services that were intentionally ${status} before upgrade`, () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-upgrade-step8-stopped-'));
+      const skillDir = path.join(tmpDir, 'demo');
+      fs.mkdirSync(skillDir, { recursive: true });
+
+      try {
+        const result = step8_startService({
+          component: 'demo',
+          skillDir,
+          serviceInitialStatus: status,
+          serviceShouldRestart: false,
+          serviceWasRunning: false,
+        }, {
+          restartManagedProcess: () => {
+            throw new Error('should not restart');
+          },
+        });
+
+        assert.equal(result.status, 'skipped');
+        assert.equal(result.message, `was not running (${status})`);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  }
+
   it('retries deleted services through ecosystem restart instead of pm2 start <name>', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-upgrade-step8-'));
     const skillDir = path.join(tmpDir, 'demo');

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -332,6 +332,8 @@ function createContext(component, { tempDir, newVersion, mode, jsonOutput } = {}
     backupDir: null,
     serviceStopped: false,
     serviceExists: true,
+    serviceInitialStatus: null,
+    serviceShouldRestart: false,
     serviceWasRunning: false,
     mergeConflicts: [],
     mergedFiles: [],
@@ -342,6 +344,10 @@ function createContext(component, { tempDir, newVersion, mode, jsonOutput } = {}
     success: false,
     error: null,
   };
+}
+
+export function shouldRestartServiceAfterUpgrade(status) {
+  return status !== 'stopped' && status !== 'stopping';
 }
 
 // ---------------------------------------------------------------------------
@@ -367,10 +373,12 @@ function step1_stopService(ctx) {
     }
 
     ctx.serviceExists = true;
-    ctx.serviceWasRunning = service.pm2_env?.status === 'online';
+    ctx.serviceInitialStatus = service.pm2_env?.status || 'unknown';
+    ctx.serviceWasRunning = ctx.serviceInitialStatus === 'online';
+    ctx.serviceShouldRestart = shouldRestartServiceAfterUpgrade(ctx.serviceInitialStatus);
 
     if (!ctx.serviceWasRunning) {
-      return { step: 1, name: 'stop_service', status: 'skipped', message: 'not running', duration: Date.now() - startTime };
+      return { step: 1, name: 'stop_service', status: 'skipped', message: `not running (${ctx.serviceInitialStatus})`, duration: Date.now() - startTime };
     }
 
     execSync(`pm2 stop ${serviceName} 2>/dev/null`, { stdio: 'pipe' });
@@ -576,7 +584,7 @@ function truncateHookOutput(value, maxLength = 1000) {
 }
 
 /**
- * Step 8: restart PM2 service (if it was running before upgrade)
+ * Step 8: restart PM2 service (unless it was intentionally stopped before upgrade)
  */
 export function step8_startService(ctx, deps = {}) {
   const startTime = Date.now();
@@ -585,8 +593,10 @@ export function step8_startService(ctx, deps = {}) {
   const restartManaged = deps.restartManagedProcess ?? restartManagedProcess;
   const restartViaEcosystem = deps.restartFromEcosystem ?? restartFromEcosystem;
 
-  if (!ctx.serviceWasRunning) {
-    return { step: 8, name: 'start_service', status: 'skipped', message: 'was not running', duration: Date.now() - startTime };
+  const shouldRestart = ctx.serviceShouldRestart ?? ctx.serviceWasRunning;
+  if (!shouldRestart) {
+    const status = ctx.serviceInitialStatus ? ` (${ctx.serviceInitialStatus})` : '';
+    return { step: 8, name: 'start_service', status: 'skipped', message: `was not running${status}`, duration: Date.now() - startTime };
   }
 
   const parsed = parseSkillMd(ctx.skillDir);
@@ -649,8 +659,8 @@ export function rollback(ctx) {
     }
   }
 
-  // Restart service if it was running
-  if (ctx.serviceWasRunning) {
+  // Restart service if it was meant to be running before the failed upgrade.
+  if (ctx.serviceShouldRestart ?? ctx.serviceWasRunning) {
     const parsed = parseSkillMd(ctx.skillDir);
     const serviceName = parsed?.frontmatter?.lifecycle?.service?.name || `zylos-${ctx.component}`;
     const ecosystemPath = path.join(ctx.skillDir, 'ecosystem.config.cjs');


### PR DESCRIPTION
## Summary
- capture the initial PM2 service status during component upgrade step1
- restart declared/present services after upgrade unless PM2 reported `stopped` or `stopping`
- apply the same restart intent during rollback and add focused coverage for errored, transient, unknown, stopped, and stopping states

## Verification
- `node --test cli/lib/__tests__/upgrade-restart.test.js`
- `git diff --check`
- `npm test` was run: Jest passed 82/82 and Node tests passed 477/478; the single failure is the pre-existing/environmental `cli/lib/__tests__/fs-utils.test.js` TMPDIR fallback test, which also fails when rerun by itself on this host.