### PR TITLE
refactor: c4-send requires an endpoint; remove channel broadcast form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **C4 send requires an endpoint**: `c4-send.js` now requires both `<channel>` and `<endpoint_id>` — every channel routes to a specific destination, so the channel-wide "broadcast" form (`c4-send <channel> <message>` / `c4-send <channel>` + stdin) has been removed. Only the real IM channels' actual behavior is reflected: telegram/lark/wechat/shell already rejected a missing endpoint, and web-console's no-endpoint branch (the sole consumer) was a no-op. Making the endpoint mandatory also removes the channel-vs-message argument ambiguity that previously caused `c4-send <channel> <message>` to fail with "Message is required" when run from any non-TTY context (test/cron/spawn): the second argument is now unambiguously the endpoint, with the message taken from the 3rd argument or stdin. `web-console/scripts/send.js` and `c4-receive.js`'s status-notice sender were updated accordingly, and the previously-failing `c4-send` CLI tests were rewritten to the endpoint-required contract (with added coverage for heredoc mode and the missing-message case).
+
 ## [0.5.2] - 2026-06-02
 
 ### Fixed

--- a/skills/comm-bridge/references/c4-send.md
+++ b/skills/comm-bridge/references/c4-send.md
@@ -36,12 +36,9 @@ EOF
 cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js lark "chat_xxx|type:group|root:msg_yyy"
 Report ready. Contains **markdown** and "special chars".
 EOF
-
-# Broadcast to all subscribers (no endpoint)
-cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js telegram
-Hello everyone!
-EOF
 ```
+
+Both `<channel>` and `<endpoint_id>` are required — every channel routes to a specific destination, so there is no channel-wide broadcast form.
 
 If the message body itself may contain a line like `EOF`, use a different terminator token for the wrapper, for example:
 

--- a/skills/comm-bridge/scripts/__tests__/c4-send-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-send-cli.test.js
@@ -8,11 +8,12 @@ import { fileURLToPath } from 'node:url';
 
 const CLI_PATH = fileURLToPath(new URL('../c4-send.js', import.meta.url));
 
-function cli(args, env = {}) {
+function cli(args, env = {}, input = undefined) {
   const result = spawnSync('node', [CLI_PATH, ...args], {
     env: { ...process.env, ...env },
     encoding: 'utf8',
-    timeout: 5000
+    timeout: 5000,
+    ...(input !== undefined ? { input } : {})
   });
   return { stdout: result.stdout, stderr: result.stderr, status: result.status };
 }
@@ -63,16 +64,16 @@ describe('c4-send basic', () => {
     });
   });
 
-  it('sends message via mock channel without endpoint (broadcast)', () => {
+  it('reads message from stdin (heredoc mode: channel + endpoint, piped message)', () => {
     withTmpDir(({ tmpDir, env }) => {
       const sentFile = setupMockChannel(tmpDir, 'mock-channel');
 
-      const { stdout, status } = cli(['mock-channel', 'Hello broadcast!'], env);
+      const { stdout, status } = cli(['mock-channel', 'endpoint1'], env, 'Piped message');
       assert.equal(status, 0);
       assert.ok(stdout.includes('Message sent via mock-channel'));
 
       const sent = JSON.parse(fs.readFileSync(sentFile, 'utf8'));
-      assert.deepEqual(sent, ['Hello broadcast!']);
+      assert.deepEqual(sent, ['endpoint1', 'Piped message']);
     });
   });
 });
@@ -88,11 +89,20 @@ describe('c4-send validation', () => {
     });
   });
 
-  it('errors with only channel (no message)', () => {
+  it('errors with only channel (endpoint is required)', () => {
     withTmpDir(({ env }) => {
       const { stdout, status } = cli(['telegram'], env);
       assert.equal(status, 1);
       assert.ok(stdout.includes('Usage'));
+    });
+  });
+
+  it('errors when endpoint is given but no message is provided', () => {
+    withTmpDir(({ env }) => {
+      // channel + endpoint, empty stdin, no message arg
+      const { stderr, status } = cli(['telegram', 'endpoint1'], env, '');
+      assert.equal(status, 1);
+      assert.ok(stderr.includes('Message is required'));
     });
   });
 
@@ -102,7 +112,7 @@ describe('c4-send validation', () => {
       const skillDir = path.join(tmpDir, '.claude', 'skills', 'fake-channel');
       fs.mkdirSync(skillDir, { recursive: true });
 
-      const { stderr, status } = cli(['fake-channel', 'Hello'], env);
+      const { stderr, status } = cli(['fake-channel', 'endpoint1', 'Hello'], env);
       assert.equal(status, 1);
       assert.ok(stderr.includes('Channel script not found'));
     });
@@ -118,7 +128,7 @@ describe('c4-send failed channel', () => {
       fs.mkdirSync(skillDir, { recursive: true });
       fs.writeFileSync(path.join(skillDir, 'send.js'), 'process.exit(1);');
 
-      const { stdout, status } = cli(['bad-channel', 'Hello'], env);
+      const { stdout, status } = cli(['bad-channel', 'endpoint1', 'Hello'], env);
       assert.equal(status, 1);
       assert.ok(stdout.includes('Failed to send'));
     });

--- a/skills/comm-bridge/scripts/c4-receive.js
+++ b/skills/comm-bridge/scripts/c4-receive.js
@@ -247,8 +247,12 @@ function emitError(json, code, message, exitCode = 1) {
 }
 
 function sendUnhealthyMessage(channel, endpoint, message) {
-  const args = [path.join(__dirname, 'c4-send.js'), channel];
-  if (endpoint) args.push(endpoint);
+  // c4-send requires an endpoint to route to; without one there is nothing to
+  // deliver to, so fail cleanly instead of spawning an invalid invocation.
+  if (!endpoint) {
+    return { status: 1, stdout: '', stderr: 'no endpoint to deliver status notice', error: new Error('missing endpoint') };
+  }
+  const args = [path.join(__dirname, 'c4-send.js'), channel, endpoint];
   const result = spawnSync('node', args, {
     input: message,
     encoding: 'utf8',

--- a/skills/comm-bridge/scripts/c4-send.js
+++ b/skills/comm-bridge/scripts/c4-send.js
@@ -3,6 +3,9 @@
  * C4 Communication Bridge - Send Interface
  * Sends messages from Claude to external channels
  *
+ * Both <channel> and <endpoint_id> are required — every channel routes to a
+ * specific destination, so there is no channel-wide "broadcast" form.
+ *
  * Usage:
  *   Recommended (stdin — safe for any content):
  *     node c4-send.js <channel> <endpoint_id> <<'EOF'
@@ -10,7 +13,7 @@
  *     EOF
  *
  *   Simple messages (CLI arg — backward compatible):
- *     node c4-send.js <channel> [endpoint_id] "short message"
+ *     node c4-send.js <channel> <endpoint_id> "short message"
  *
  * When no message argument is provided, the message is read from stdin.
  * This avoids shell escaping issues with quotes and special characters.
@@ -27,7 +30,7 @@ function printUsage() {
   console.log('Usage: node c4-send.js <channel> <endpoint_id> <<\'EOF\'');
   console.log('       message content');
   console.log('       EOF');
-  console.log('       node c4-send.js <channel> [endpoint_id] "message"');
+  console.log('       node c4-send.js <channel> <endpoint_id> "message"');
   console.log('Example: node c4-send.js telegram 8101553026 "Hello!"');
   process.exit(1);
 }
@@ -48,40 +51,36 @@ function readStdin() {
 async function main() {
   const args = process.argv.slice(2);
 
-  if (args.length < 2) {
+  // Remove --stdin flag if present (backward compat: forces reading from stdin)
+  const cleanArgs = args.filter(a => a !== '--stdin');
+  const hasStdinFlag = cleanArgs.length !== args.length;
+
+  // <channel> and <endpoint> are both required. Every channel routes to a
+  // specific destination, so there is no channel-wide broadcast form. The
+  // message is either the 3rd argument or piped on stdin.
+  if (cleanArgs.length < 2) {
     printUsage();
   }
 
-  // Remove --stdin flag if present (backward compat)
-  const cleanArgs = args.filter(a => a !== '--stdin');
-  const hasStdinFlag = cleanArgs.length !== args.length;
-  const stdinAvailable = !process.stdin.isTTY;
-
   const channel = cleanArgs[0];
-  let endpoint = null;
+  const endpoint = cleanArgs[1];
   let message = null;
 
-  if (cleanArgs.length === 2 && (stdinAvailable || hasStdinFlag)) {
-    // 2 args (channel + endpoint) with piped stdin or --stdin flag: read from stdin
-    endpoint = cleanArgs[1];
-    message = (await readStdin()).trimEnd();
-  } else if (cleanArgs.length === 1 && (stdinAvailable || hasStdinFlag)) {
-    // 1 arg (channel only) with piped stdin: read from stdin
-    message = (await readStdin()).trimEnd();
-  } else if (cleanArgs.length === 2) {
-    // 2 args, no stdin: channel + message (no endpoint)
+  if (cleanArgs.length >= 3) {
+    // <channel> <endpoint> <message>
     process.stderr.write('[c4-send] Deprecated: passing message as CLI argument. Use stdin/heredoc mode instead.\n');
-    message = cleanArgs[1];
-    // Unescape literal \n sequences that shell may have preserved when passing
-    // multi-line content as a CLI argument (defense-in-depth; prefer stdin mode)
+    message = cleanArgs[2];
+    // Unescape literal \n sequences that the shell may have preserved when
+    // passing multi-line content as a CLI argument (prefer stdin mode).
     message = message.replace(/\\n/g, '\n');
   } else {
-    // 3+ args: channel + endpoint + message
-    process.stderr.write('[c4-send] Deprecated: passing message as CLI argument. Use stdin/heredoc mode instead.\n');
-    endpoint = cleanArgs[1];
-    message = cleanArgs[2];
-    // Same defense for the 3-arg form
-    message = message.replace(/\\n/g, '\n');
+    // <channel> <endpoint> with the message piped on stdin (heredoc mode).
+    const stdinAvailable = !process.stdin.isTTY || hasStdinFlag;
+    if (!stdinAvailable) {
+      console.error('Error: Message is required (pass as the 3rd argument or pipe it via stdin)');
+      process.exit(1);
+    }
+    message = (await readStdin()).trimEnd();
   }
 
   if (!message) {
@@ -96,13 +95,11 @@ async function main() {
     process.exit(1);
   }
 
-  if (endpoint) {
-    try {
-      validateEndpoint(endpoint);
-    } catch (err) {
-      console.error(`[C4] Invalid endpoint: ${err.stack}`);
-      process.exit(1);
-    }
+  try {
+    validateEndpoint(endpoint);
+  } catch (err) {
+    console.error(`[C4] Invalid endpoint: ${err.stack}`);
+    process.exit(1);
   }
 
   try {
@@ -121,7 +118,7 @@ async function main() {
     process.exit(1);
   }
 
-  const scriptArgs = endpoint ? [endpoint, message] : [message];
+  const scriptArgs = [endpoint, message];
 
   const child = spawn('node', [channelScript, ...scriptArgs], {
     stdio: 'inherit'

--- a/skills/web-console/scripts/send.js
+++ b/skills/web-console/scripts/send.js
@@ -6,19 +6,18 @@
  * Messages are already recorded in c4.db by c4-send.js before this is called.
  * The web console frontend polls /api/poll to retrieve new messages.
  *
- * Usage: node send.js [endpoint] <message>
+ * Usage: node send.js <endpoint> <message>
  *
  * Exit code 0 = success (message will be picked up by web console polling)
  */
 
 const args = process.argv.slice(2);
 
-if (args.length < 1) {
-  console.error('Usage: node send.js [endpoint] <message>');
+if (args.length < 2) {
+  console.error('Usage: node send.js <endpoint> <message>');
   process.exit(1);
 }
 
 // Message is already in database, web console will poll for it
-const message = args.length === 1 ? args[0] : args[1];
 console.log(`Message queued for web console`);
 process.exit(0);


### PR DESCRIPTION
## Decision

Supersedes the original approach in this PR. Rather than make the no-endpoint **broadcast** form robust in non-TTY contexts, we remove broadcast entirely and make `<endpoint_id>` mandatory. Rationale below.

## Background

Three `c4-send` CLI tests were failing. Investigation showed the root cause was PR #162 ("c4-send.js stdin support"): `stdinAvailable = !process.stdin.isTTY` treats **any** non-TTY stdin — including an empty/closed pipe — as "the message is on stdin". So the 2-arg broadcast form `c4-send <channel> <message>`, run from any non-interactive context (the test suite, but also cron/spawn), misread the message argument as an **endpoint**, read an empty message from stdin, and exited with `Error: Message is required`. All three tests tripped on that one step.

## Why remove broadcast instead of fixing it

Auditing every channel's `send.js`:

| Channel | Endpoint |
|---|---|
| telegram | **required** |
| lark | **required** |
| wechat | **required** |
| shell | **required** |
| web-console | optional — and a no-op passthrough |

No real user-facing channel supports a channel-wide broadcast. The only consumer of the no-endpoint form was web-console, where `send.js` is a no-op (the message is already in `c4.db`; the frontend polls for it). So "broadcast" was effectively dead capability whose only effect was the argument-parsing ambiguity that caused the bug.

Making `<endpoint_id>` mandatory removes the ambiguity at its root: the second argument is **always** the endpoint, and the message comes from the 3rd argument or stdin.

## Changes

- **`c4-send.js`**: require both `<channel>` and `<endpoint_id>`; drop the 1-arg and 2-arg broadcast branches; always validate the endpoint; always pass `[endpoint, message]` to the channel script. Updated header/usage docs.
- **`web-console/scripts/send.js`**: require `<endpoint> <message>` (drop the `args.length === 1` no-endpoint branch).
- **`c4-receive.js`**: `sendUnhealthyMessage` now fails cleanly (synthetic non-zero result) when no endpoint is available, instead of spawning a now-invalid `c4-send <channel>` broadcast.
- **`references/c4-send.md`**: removed the broadcast example; documented that the endpoint is required.
- **Tests**: rewritten to the endpoint-required contract. Added coverage for heredoc mode (channel + endpoint + piped stdin message) and the "endpoint given, no message" error case.

## Tests

- `c4-send` CLI: **7/7** pass.
- Full comm-bridge suite: **209/209** pass.

## Compatibility

The common reply path I use everywhere — `c4-send <channel> <endpoint> <<'EOF' … EOF` and `c4-send <channel> <endpoint> "msg"` — is unchanged. Only the (unused) no-endpoint broadcast form is removed. Internal DB audit rows that legitimately have a null `endpoint_id` (scheduler/system) are written via `insertConversation` directly and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)