### PR TITLE
feat(add): local archive/dir source + gitlab: repo support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`zylos add` local source support**: `add <path>` now accepts a local directory or a `.tar.gz`/`.tgz` archive (e.g. `zylos add ./my-component.tar.gz`). `resolveTarget` detects an existing local path before the org/repo branch; `installLocal()` copies a directory or extracts an archive (auto-detecting a single top-level wrapper dir). No remote fetch needed.
+- **GitLab source support**: a component repo of the form `gitlab:<group>/<project>` routes to the GitLab archive API (`/api/v4/projects/{id}/repository/archive.tar.gz`) with `PRIVATE-TOKEN` auth instead of GitHub. Token from `GITLAB_TOKEN`/`ZYLOS_GITLAB_TOKEN` (env or `~/zylos/.env`); host `git.coco.xyz` (override `ZYLOS_GITLAB_HOST`). Tag lookup is skipped for gitlab repos (use `--branch`); `zylos add` display shows the GitLab URL.
+
 ## [0.5.2] - 2026-06-02
 
 ### Fixed

--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -22,7 +22,7 @@ import { execSync } from 'node:child_process';
 import { SKILLS_DIR, COMPONENTS_DIR, BIN_DIR } from '../lib/config.js';
 import { loadRegistry } from '../lib/registry.js';
 import { loadComponents, saveComponents, resolveTarget, outputTask } from '../lib/components.js';
-import { downloadArchive, downloadBranch } from '../lib/download.js';
+import { downloadArchive, downloadBranch, installLocal } from '../lib/download.js';
 import { generateManifest, saveManifest } from '../lib/manifest.js';
 import { parseSkillMd, detectComponentType } from '../lib/skill.js';
 import { linkBins } from '../lib/bin.js';
@@ -32,6 +32,16 @@ import { writeEnvEntries } from '../lib/env.js';
 import { hasConfigureHook, runConfigureHook } from '../lib/configure-hook.js';
 import { registerService } from '../lib/service.js';
 import { bold, dim, green, red, yellow, cyan, success, error, warn, heading } from '../lib/colors.js';
+
+// Render the source URL for display. `gitlab:<group>/<project>` repos show the
+// GitLab host instead of github.com.
+function repoDisplayUrl(repo) {
+  if (typeof repo === 'string' && repo.startsWith('gitlab:')) {
+    const host = process.env.ZYLOS_GITLAB_HOST || 'git.coco.xyz';
+    return `https://${host}/${repo.slice('gitlab:'.length)}`;
+  }
+  return `https://github.com/${repo}`;
+}
 
 function printManualCaddyRoutes(result) {
   console.log(`  ${warn('Caddy routes: manual configuration required')}`);
@@ -103,7 +113,7 @@ export async function addComponent(args) {
     process.exit(1);
   }
 
-  if (!resolved.repo) {
+  if (!resolved.repo && !resolved.isLocal) {
     if (jsonOutput) {
       console.log(JSON.stringify({
         action: 'add_check', component: target, success: false,
@@ -139,6 +149,21 @@ export async function addComponent(args) {
 
   // 4. Check-only mode: show component info without installing
   if (checkOnly) {
+    // Local source (directory or .tar.gz/.tgz): no remote version to look up.
+    if (resolved.isLocal) {
+      if (jsonOutput) {
+        console.log(JSON.stringify({
+          action: 'add_check', component: resolved.name, success: true,
+          alreadyInstalled: false, isLocal: true, localPath: resolved.localPath,
+          reply: `${resolved.name} (local source: ${resolved.localPath})\nReply "add ${target} confirm" to install.`,
+        }, null, 2));
+      } else {
+        console.log(`\n${heading('Component:')} ${bold(resolved.name)} ${dim('(local source)')}`);
+        console.log(`${heading('Source:')} ${dim(resolved.localPath)}`);
+        console.log(`\n${dim(`Run "zylos add ${target} --yes" to install.`)}`);
+      }
+      process.exit(0);
+    }
     const noRelease = !branch && !resolved.version;
     const fetchFailed = !branch && !resolved.version && resolved.fetchError;
     if (jsonOutput) {
@@ -177,7 +202,7 @@ export async function addComponent(args) {
     } else {
       const versionInfo = branch ? ` (branch: ${bold(branch)})` : (resolved.version ? `@${bold(resolved.version)}` : '');
       console.log(`\n${heading('Component:')} ${bold(resolved.name)}${versionInfo}`);
-      console.log(`${heading('Repository:')} ${dim('https://github.com/' + resolved.repo)}`);
+      console.log(`${heading('Repository:')} ${dim(repoDisplayUrl(resolved.repo))}`);
       if (resolved.isThirdParty) {
         console.log(warn('Third-party component — not verified by Zylos team.'));
       }
@@ -202,7 +227,7 @@ export async function addComponent(args) {
   if (!jsonOutput) {
     const versionInfo = branch ? ` (branch: ${bold(branch)})` : (resolved.version ? `@${bold(resolved.version)}` : '');
     console.log(`\n${heading('Component:')} ${bold(resolved.name)}${versionInfo}`);
-    console.log(`${heading('Repository:')} ${dim('https://github.com/' + resolved.repo)}`);
+    console.log(`${heading(resolved.isLocal ? 'Source:' : 'Repository:')} ${dim(resolved.isLocal ? resolved.localPath : repoDisplayUrl(resolved.repo))}`);
 
     if (resolved.isThirdParty) {
       console.log(warn('Third-party component — not verified by Zylos team.'));
@@ -239,11 +264,15 @@ export async function addComponent(args) {
     process.exit(1);
   }
 
-  const downloadLabel = branch ? `${resolved.name} (branch: ${branch})` : resolved.name;
-  if (!jsonOutput) console.log(`\n${cyan('Downloading')} ${bold(downloadLabel)}...`);
+  const downloadLabel = resolved.isLocal
+    ? `${resolved.name} (local: ${resolved.localPath})`
+    : (branch ? `${resolved.name} (branch: ${branch})` : resolved.name);
+  if (!jsonOutput) console.log(`\n${cyan(resolved.isLocal ? 'Installing' : 'Downloading')} ${bold(downloadLabel)}...`);
 
   let downloadResult;
-  if (branch) {
+  if (resolved.isLocal) {
+    downloadResult = installLocal(resolved.localPath, skillDir);
+  } else if (branch) {
     downloadResult = downloadBranch(resolved.repo, branch, skillDir);
   } else if (resolved.version) {
     downloadResult = downloadArchive(resolved.repo, resolved.version, skillDir);

--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -269,11 +269,15 @@ export async function addComponent(args) {
     : (branch ? `${resolved.name} (branch: ${branch})` : resolved.name);
   if (!jsonOutput) console.log(`\n${cyan(resolved.isLocal ? 'Installing' : 'Downloading')} ${bold(downloadLabel)}...`);
 
+  // GitLab (and other non-tag) sources resolve a defaultBranch so they install
+  // without an explicit --branch.
+  const effectiveBranch = branch || resolved.defaultBranch || null;
+
   let downloadResult;
   if (resolved.isLocal) {
     downloadResult = installLocal(resolved.localPath, skillDir);
-  } else if (branch) {
-    downloadResult = downloadBranch(resolved.repo, branch, skillDir);
+  } else if (effectiveBranch) {
+    downloadResult = downloadBranch(resolved.repo, effectiveBranch, skillDir);
   } else if (resolved.version) {
     downloadResult = downloadArchive(resolved.repo, resolved.version, skillDir);
   } else {

--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -45,8 +45,23 @@ export async function resolveTarget(nameOrUrl) {
     version = nameOrUrl.substring(atIndex + 1);
   }
 
-  // Helper: try fetchLatestTag, capture network errors separately
+  // Local source: an existing directory or .tar.gz/.tgz archive on disk.
+  // Checked before the org/repo branch so a path like "./foo" or
+  // "/tmp/x.tar.gz" isn't misread as "org/repo". Bare registry names (no
+  // slash and not an archive) are never treated as local.
+  if ((target.includes('/') || /\.(tar\.gz|tgz)$/i.test(target)) && fs.existsSync(path.resolve(target))) {
+    const base = path.basename(target).replace(/\.(tar\.gz|tgz)$/i, '');
+    const name = base.replace(/^zylos-/, '');
+    return { name, repo: null, version: null, fetchError: null, isThirdParty: true, isLocal: true, localPath: path.resolve(target) };
+  }
+
+  // Helper: try fetchLatestTag, capture network errors separately.
+  // GitLab repos (repo "gitlab:<group>/<project>") skip the lookup — fetchLatestTag
+  // hits the GitHub API and would 404; caller must use --branch.
   function tryFetchLatestTag(repo) {
+    if (typeof repo === 'string' && repo.startsWith('gitlab:')) {
+      return { version: null, fetchError: 'GitLab repo: use --branch <name> to install' };
+    }
     try {
       return { version: fetchLatestTag(repo) || null, fetchError: null };
     } catch (err) {

--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -78,6 +78,20 @@ export async function resolveTarget(nameOrUrl) {
     return { name, repo, version: tag.version, fetchError: tag.fetchError, isThirdParty: !repo.startsWith('zylos-ai/') };
   }
 
+  // Any other http(s) URL → treat as a GitLab repo:
+  //   https://<host>/<group>/<project>[.git]  →  repo "gitlab:<group>/<project>"
+  // GitLab has no GitHub-style tag API wired here, so default to branch main
+  // (no --branch needed). The URL's host overrides ZYLOS_GITLAB_HOST so any
+  // GitLab instance works, not just the default.
+  const urlMatch = target.match(/^https?:\/\/([^/]+)\/(.+?)\/?$/);
+  if (urlMatch) {
+    const host = urlMatch[1];
+    const repoPath = urlMatch[2].replace(/\.git$/, '');
+    const name = repoPath.split('/').pop().replace(/^zylos-/, '');
+    if (host && host !== 'git.coco.xyz') process.env.ZYLOS_GITLAB_HOST = host;
+    return { name, repo: `gitlab:${repoPath}`, version, fetchError: null, isThirdParty: true, defaultBranch: 'main' };
+  }
+
   // Check if it's in format org/repo
   if (target.includes('/')) {
     const name = target.split('/')[1].replace(/^zylos-/, '');

--- a/cli/lib/download.js
+++ b/cli/lib/download.js
@@ -9,6 +9,7 @@ import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 import { getGitHubToken, sanitizeError } from './github.js';
 import { copyTree } from './fs-utils.js';
+import { readEnvFile } from './env.js';
 
 function getWritableTmpBase() {
   let base = os.tmpdir();
@@ -39,6 +40,12 @@ function createDownloadTmpDir() {
  * @param {string} tarballPath - Destination file path for the tarball
  */
 function curlDownload(repo, ref, refType, tarballPath) {
+  // GitLab support: a repo of the form `gitlab:<group>/<project>` routes to the
+  // GitLab archive API (PRIVATE-TOKEN auth) instead of GitHub.
+  if (typeof repo === 'string' && repo.startsWith('gitlab:')) {
+    return curlGitlabDownload(repo.slice('gitlab:'.length), ref, tarballPath);
+  }
+
   // 1. Try public endpoint first (no auth needed for public repos)
   const publicUrl = refType === 'tag'
     ? `https://github.com/${repo}/archive/refs/tags/${ref}.tar.gz`
@@ -70,6 +77,46 @@ function curlDownload(repo, ref, refType, tarballPath) {
     timeout: 60000,
     stdio: 'pipe',
   });
+}
+
+/**
+ * Download a GitLab archive tarball via the GitLab API.
+ * Authenticates with a PAT from GITLAB_TOKEN / ZYLOS_GITLAB_TOKEN (env or
+ * ~/zylos/.env). Host is git.coco.xyz unless overridden via ZYLOS_GITLAB_HOST.
+ *
+ * @param {string} repoPath - GitLab project path "group/project" (no "gitlab:" prefix)
+ * @param {string} ref - Git ref (tag or branch) — passed as ?sha=
+ * @param {string} tarballPath - Destination file path
+ */
+function curlGitlabDownload(repoPath, ref, tarballPath) {
+  const host = process.env.ZYLOS_GITLAB_HOST || 'git.coco.xyz';
+  const token = getGitlabToken();
+  if (!token) {
+    throw new Error(
+      'GitLab repo install requires a token. Set GITLAB_TOKEN or ZYLOS_GITLAB_TOKEN ' +
+      '(env var or ~/zylos/.env entry).'
+    );
+  }
+  const encoded = encodeURIComponent(repoPath);
+  const apiUrl = `https://${host}/api/v4/projects/${encoded}/repository/archive.tar.gz?sha=${encodeURIComponent(ref)}`;
+  execFileSync('curl', ['-fsSL', '-H', `PRIVATE-TOKEN: ${token}`, '-o', tarballPath, apiUrl], {
+    timeout: 60000,
+    stdio: 'pipe',
+  });
+}
+
+let _gitlabTokenCache;
+function getGitlabToken() {
+  if (_gitlabTokenCache !== undefined) return _gitlabTokenCache;
+  const envTok = process.env.GITLAB_TOKEN || process.env.ZYLOS_GITLAB_TOKEN;
+  if (envTok) { _gitlabTokenCache = envTok; return _gitlabTokenCache; }
+  try {
+    const env = readEnvFile();
+    const fromEnv = env.get('GITLAB_TOKEN') || env.get('ZYLOS_GITLAB_TOKEN');
+    if (fromEnv) { _gitlabTokenCache = fromEnv; return _gitlabTokenCache; }
+  } catch { /* no ~/zylos/.env */ }
+  _gitlabTokenCache = null;
+  return _gitlabTokenCache;
 }
 
 /**
@@ -134,6 +181,60 @@ export function copyLocal(localPath, destDir) {
     return { success: true };
   } catch (err) {
     return { success: false, error: `Failed to copy from ${srcPath}: ${err.message}` };
+  }
+}
+
+/**
+ * Install a component from a local source — either a directory or a
+ * `.tar.gz` / `.tgz` archive. Lets `zylos add ./comp` or
+ * `zylos add ./comp.tar.gz` work without any remote (GitHub/GitLab) fetch.
+ *
+ * For archives: extracted to a temp dir; if the archive has a single
+ * top-level wrapper directory (the common case) its contents are used,
+ * otherwise the archive root is used. Then copied into destDir.
+ *
+ * @param {string} srcPath - Local path to a directory or .tar.gz/.tgz file
+ * @param {string} destDir - Destination directory
+ * @returns {{ success: boolean, extractedDir?: string, error?: string }}
+ */
+export function installLocal(srcPath, destDir) {
+  const abs = path.resolve(srcPath);
+  if (!fs.existsSync(abs)) {
+    return { success: false, error: `Local source not found: ${abs}` };
+  }
+
+  // Directory → straight copy.
+  if (fs.statSync(abs).isDirectory()) {
+    const r = copyLocal(abs, destDir);
+    return r.success ? { success: true, extractedDir: destDir } : r;
+  }
+
+  // File → must be a gzip tarball.
+  if (!/\.(tar\.gz|tgz)$/i.test(abs)) {
+    return { success: false, error: `Local file must be a .tar.gz/.tgz archive or a directory: ${abs}` };
+  }
+
+  let tmpDir;
+  try {
+    tmpDir = createDownloadTmpDir();
+  } catch (err) {
+    return { success: false, error: `Failed to prepare temp dir: ${sanitizeError(err.message)}` };
+  }
+  try {
+    fs.mkdirSync(destDir, { recursive: true });
+    execFileSync('tar', ['xzf', abs, '-C', tmpDir], { timeout: 30000, stdio: 'pipe' });
+    // Detect a single wrapper directory (e.g. "component-name/").
+    const entries = fs.readdirSync(tmpDir);
+    let root = tmpDir;
+    if (entries.length === 1 && fs.statSync(path.join(tmpDir, entries[0])).isDirectory()) {
+      root = path.join(tmpDir, entries[0]);
+    }
+    copyTree(root, destDir, { excludes: ['.git'] });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    return { success: true, extractedDir: destDir };
+  } catch (err) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    return { success: false, error: `Failed to install local archive ${abs}: ${err.message}` };
   }
 }
 


### PR DESCRIPTION
Two related capabilities for `zylos add`:

1. Local source — `add <path>` accepts a local directory OR a .tar.gz/.tgz archive. resolveTarget detects an existing local path (before the org/repo branch, so it isn't misread as org/repo); installLocal() copies a dir or extracts an archive (auto-detects a single top-level wrapper dir). Enables `zylos add ./my-component.tar.gz`, no remote fetch.

2. GitLab — a repo `gitlab:<group>/<project>` routes to the GitLab archive API with PRIVATE-TOKEN auth instead of GitHub. Token from GITLAB_TOKEN/ZYLOS_GITLAB_TOKEN (env or ~/zylos/.env); host git.coco.xyz (override ZYLOS_GITLAB_HOST). Tag lookup skipped for gitlab repos (use --branch); display shows the GitLab URL. (folds in the local gitlab patch.)

Verified locally: dir + tarball install, gitlab repo resolution.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
