### PR TITLE
Raise zylos-memory core file budgets to 16KB

### DIFF
--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -113,7 +113,7 @@ Review the report and apply these rules:
 ### Core File Budgets
 - Files over 100% budget: summarize and trim older entries.
   Move historical content to `reference/` or `archive/`.
-- `state.md` is the strictest — must stay under 4KB.
+- `state.md` is the strictest — must stay under 16KB.
 
 ### Session Logs
 - Logs in `archiveCandidatesOlderThan30Days`: move from `sessions/` to `archive/`.

--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -49,6 +49,18 @@ When triggered, run it before handling queued user messages.
 
 Both launch a background subagent using the current runtime's supported subagent mechanism with this file's Sync Flow as the prompt.
 
+### Codex Background Execution
+
+In Codex, when the current session has a native background-agent capability,
+Memory Sync must use that capability directly. Do not create PM2 services,
+run `pm2 start ... codex exec ...`, or fork an extra `codex exec` sidecar.
+PM2 is only a fallback when no native background-agent capability is
+available; if used, explicitly record the reason in the handoff/status.
+
+Before starting Memory Sync, check for existing `memory-sync-*` PM2 entries.
+If one is running, do not start another sync writer. If only stopped entries
+exist, report them as historical records and do not create a replacement.
+
 ### Sync Flow
 
 1. Rotate session log if needed:

--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -99,8 +99,9 @@ worked example in `examples/`:
 - `rotate-session.js`: rotates `sessions/current.md` at day boundary.
 - `daily-commit.js`: local git snapshot for `memory/` if changed.
 - `consolidate.js`: JSON consolidation report (sizes, age, budget checks).
-  Use for scheduled or deliberate memory maintenance. Review the report and
-  apply the Consolidation Review rules below.
+  Use for deliberate memory maintenance, or for scheduler-triggered
+  consolidation when such a task is configured. Review the report and apply
+  the Consolidation Review rules below.
 - `memory-status.js`: quick health summary.
   Use when you need a fast manual check of core file sizes and budget status.
   If it reports `OVER`, run `consolidate.js` and perform the needed cleanup.

--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -99,7 +99,11 @@ worked example in `examples/`:
 - `rotate-session.js`: rotates `sessions/current.md` at day boundary.
 - `daily-commit.js`: local git snapshot for `memory/` if changed.
 - `consolidate.js`: JSON consolidation report (sizes, age, budget checks).
+  Use for scheduled or deliberate memory maintenance. Review the report and
+  apply the Consolidation Review rules below.
 - `memory-status.js`: quick health summary.
+  Use when you need a fast manual check of core file sizes and budget status.
+  If it reports `OVER`, run `consolidate.js` and perform the needed cleanup.
 
 C4 scripts used by sync flow (provided by comm-bridge skill):
 - `c4-fetch.js --unsummarized`: fetch unsummarized conversations and range.
@@ -113,7 +117,16 @@ Review the report and apply these rules:
 ### Core File Budgets
 - Files over 100% budget: summarize and trim older entries.
   Move historical content to `reference/` or `archive/`.
-- `state.md` is the strictest — must stay under 16KB.
+- `identity.md`, `state.md`, and `references.md` must stay under 16KB.
+- Apply file-specific cleanup:
+  - `identity.md`: keep only stable identity traits, principles, durable
+    collaboration style, and digital asset references. Move operational state
+    and one-off lessons elsewhere.
+  - `state.md`: keep active focus, pending tasks, and recent completions.
+    Move completed or historical detail to `sessions/current.md` or
+    `reference/`.
+  - `references.md`: keep pointers and lookup facts only. Move prose,
+    project history, and detailed decisions to `reference/`.
 
 ### Session Logs
 - Logs in `archiveCandidatesOlderThan30Days`: move from `sessions/` to `archive/`.

--- a/skills/zylos-memory/references/identity-format.md
+++ b/skills/zylos-memory/references/identity-format.md
@@ -13,7 +13,7 @@ Always loaded at session start via SessionStart hook.
 
 ## Size Guideline
 
-~4KB (always in context).
+~16KB (always in context).
 
 ## Update Frequency
 

--- a/skills/zylos-memory/references/references-file-format.md
+++ b/skills/zylos-memory/references/references-file-format.md
@@ -11,7 +11,7 @@ Always loaded at session start via SessionStart hook.
 
 ## Size Guideline
 
-~2KB. Pointer/index only, not prose.
+~16KB. Pointer/index only, not prose.
 
 ## Update Frequency
 

--- a/skills/zylos-memory/references/state-format.md
+++ b/skills/zylos-memory/references/state-format.md
@@ -11,7 +11,7 @@ Always loaded at session start via SessionStart hook.
 
 ## Size Guideline
 
-~4KB max. This file is in every session's context. Every line must earn
+~16KB max. This file is in every session's context. Every line must earn
 its place.
 
 ## Update Frequency

--- a/skills/zylos-memory/scripts/shared.js
+++ b/skills/zylos-memory/scripts/shared.js
@@ -13,7 +13,7 @@ export const SESSIONS_DIR = path.join(MEMORY_DIR, 'sessions');
 
 export const BUDGETS = {
   'identity.md': 4096,
-  'state.md': 4096,
+  'state.md': 16 * 1024,
   'references.md': 2048
 };
 

--- a/skills/zylos-memory/scripts/shared.js
+++ b/skills/zylos-memory/scripts/shared.js
@@ -12,9 +12,9 @@ export const MEMORY_DIR = path.join(ZYLOS_DIR, 'memory');
 export const SESSIONS_DIR = path.join(MEMORY_DIR, 'sessions');
 
 export const BUDGETS = {
-  'identity.md': 4096,
+  'identity.md': 16 * 1024,
   'state.md': 16 * 1024,
-  'references.md': 2048
+  'references.md': 16 * 1024
 };
 
 export const REFERENCE_FILES = [

--- a/skills/zylos-memory/scripts/tests/test-shared.js
+++ b/skills/zylos-memory/scripts/tests/test-shared.js
@@ -71,7 +71,7 @@ describe('dateInTimeZone', () => {
 // ---------------------------------------------------------------------------
 describe('BUDGETS', () => {
   it('contains identity.md budget', () => {
-    assert.equal(BUDGETS['identity.md'], 4096);
+    assert.equal(BUDGETS['identity.md'], 16 * 1024);
   });
 
   it('contains state.md budget', () => {
@@ -79,7 +79,7 @@ describe('BUDGETS', () => {
   });
 
   it('contains references.md budget', () => {
-    assert.equal(BUDGETS['references.md'], 2048);
+    assert.equal(BUDGETS['references.md'], 16 * 1024);
   });
 
   it('has exactly 3 entries', () => {

--- a/skills/zylos-memory/scripts/tests/test-shared.js
+++ b/skills/zylos-memory/scripts/tests/test-shared.js
@@ -75,7 +75,7 @@ describe('BUDGETS', () => {
   });
 
   it('contains state.md budget', () => {
-    assert.equal(BUDGETS['state.md'], 4096);
+    assert.equal(BUDGETS['state.md'], 16 * 1024);
   });
 
   it('contains references.md budget', () => {


### PR DESCRIPTION
## Summary

- Raise zylos-memory core file budgets for `identity.md`, `state.md`, and `references.md` to 16KB.
- Update format references for identity/state/references to match the 16KB budget.
- Clarify when agents should use `memory-status.js` vs `consolidate.js`, and what behavior budget/freshness findings should trigger.

Closes #622.

## Tests

- `node --test scripts/tests/*.js` from `skills/zylos-memory` (54/54 passing)
