### PR TITLE
fix(runtime): detect agent across pane process tree (macOS shebang comm)

### DIFF
--- a/cli/lib/runtime/__tests__/tmux-helpers.test.js
+++ b/cli/lib/runtime/__tests__/tmux-helpers.test.js
@@ -13,6 +13,9 @@ import {
   tmuxKillSession,
   tmuxCapturePaneText,
   getProcessName,
+  getProcessCommand,
+  getChildPids,
+  isAgentInProcessTree,
   hasChildProcess,
   isTimeoutError,
 } from '../tmux-helpers.js';
@@ -45,6 +48,42 @@ describe('tmux-helpers integration (live calls to nonexistent sessions)', () => 
 
   it('hasChildProcess returns false for nonexistent parent', () => {
     assert.equal(hasChildProcess(999999999, 'nope'), false);
+  });
+
+  it('getProcessCommand returns null for nonexistent PID', () => {
+    assert.equal(getProcessCommand(999999999), null);
+  });
+
+  it('getProcessCommand returns the full command line for the current process', () => {
+    const cmd = getProcessCommand(process.pid);
+    assert.ok(cmd && cmd.includes('node'), `expected node in command line, got: ${cmd}`);
+  });
+
+  it('getChildPids returns [] for nonexistent parent', () => {
+    assert.deepEqual(getChildPids(999999999), []);
+  });
+
+  it('isAgentInProcessTree finds the current node process by command line', () => {
+    // The test runner itself is "node <script>", which the command-line
+    // layer must match even though comm may differ (e.g. MainThread).
+    assert.equal(isAgentInProcessTree(process.pid, 'node'), true);
+  });
+
+  it('isAgentInProcessTree returns false for a name not in the tree', () => {
+    assert.equal(isAgentInProcessTree(process.pid, '__no_such_agent__'), false);
+  });
+
+  it('isAgentInProcessTree returns false for nonexistent PID', () => {
+    assert.equal(isAgentInProcessTree(999999999, 'claude'), false);
+  });
+
+  it('isAgentInProcessTree does not match the name as a bare substring', () => {
+    // "claudette" or "/home/x/.claude/foo" must not match agent "claude".
+    const re = /(^|[/\s])claude(\s|$)/;
+    assert.equal(re.test('node /usr/bin/claudette --flag'), false);
+    assert.equal(re.test('node /home/x/.claude/local/tool.js'), false);
+    assert.equal(re.test('node /usr/local/bin/claude --dangerously-skip-permissions'), true);
+    assert.equal(re.test('claude --dangerously-skip-permissions'), true);
   });
 });
 

--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -31,8 +31,7 @@ import {
   tmuxPasteBuffer,
   tmuxDeleteBuffer,
   tmuxNewSession,
-  getProcessName,
-  hasChildProcess,
+  isAgentInProcessTree,
 } from './tmux-helpers.js';
 import { buildCleanEnv, buildCompatEnv, loadRuntimeEnvManifest, writeLaunchSpec } from './tmux-env.js';
 
@@ -164,10 +163,7 @@ export class ClaudeAdapter extends RuntimeAdapter {
     const panePid = tmuxGetPanePid(SESSION);
     if (!panePid) return false;
 
-    const name = getProcessName(panePid);
-    if (name === 'claude') return true;
-
-    return hasChildProcess(panePid, 'claude');
+    return isAgentInProcessTree(panePid, 'claude');
   }
 
   /**

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -35,7 +35,7 @@ import {
   tmuxSendKeys,
   tmuxNewSession,
   getProcessName,
-  hasChildProcess,
+  isAgentInProcessTree,
 } from './tmux-helpers.js';
 import { buildCleanEnv, buildCompatEnv, loadRuntimeEnvManifest, writeLaunchSpec } from './tmux-env.js';
 
@@ -203,10 +203,12 @@ export class CodexAdapter extends RuntimeAdapter {
     const panePid = tmuxGetPanePid(SESSION);
     if (!panePid) return false;
 
+    // Keep the legacy loose 'node' match for npm-shim installs where the pane
+    // process is the codex shim itself; the tree walk handles the rest.
     const name = getProcessName(panePid);
     if (name === 'codex' || name === 'node') return true;
 
-    return hasChildProcess(panePid, 'codex');
+    return isAgentInProcessTree(panePid, 'codex');
   }
 
   /**

--- a/cli/lib/runtime/tmux-helpers.js
+++ b/cli/lib/runtime/tmux-helpers.js
@@ -154,6 +154,73 @@ export function getProcessName(pid) {
 }
 
 /**
+ * Get the full command line for a PID.
+ * Unlike `comm=`, this includes script paths and arguments — needed on macOS,
+ * where shebang CLIs (claude, codex) report the interpreter (e.g. "node") as
+ * their process name instead of the script name.
+ * @param {number} pid
+ * @returns {string|null}
+ */
+export function getProcessCommand(pid) {
+  try {
+    return execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
+      encoding: 'utf8',
+      timeout: CMD_TIMEOUT,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get direct child PIDs of a process.
+ * @param {number} parentPid
+ * @returns {number[]}
+ */
+export function getChildPids(parentPid) {
+  try {
+    const out = execFileSync('pgrep', ['-P', String(parentPid)], {
+      encoding: 'utf8',
+      timeout: CMD_TIMEOUT,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.trim().split('\n').filter(Boolean).map(Number);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check whether an agent binary (e.g. "claude", "codex") is running anywhere
+ * in the pane's process tree, walking from the pane process down.
+ *
+ * A single comm/pgrep check is not portable: the pane process is usually the
+ * tmux launcher (comm "node" or "MainThread"), macOS reports the interpreter
+ * for shebang CLIs, and a shell wrapper can push the agent one generation
+ * deeper. At each level this matches either the process name or the full
+ * command line (binary name as a path segment or standalone word).
+ *
+ * @param {number} panePid
+ * @param {string} name - agent binary name, e.g. "claude"
+ * @param {number} [maxDepth=3] - generations to descend below the pane process
+ * @returns {boolean}
+ */
+export function isAgentInProcessTree(panePid, name, maxDepth = 3) {
+  const re = new RegExp(`(^|[/\\s])${name}(\\s|$)`);
+  let frontier = [panePid];
+  for (let depth = 0; depth <= maxDepth && frontier.length > 0; depth++) {
+    for (const pid of frontier) {
+      if (getProcessName(pid) === name) return true;
+      const cmd = getProcessCommand(pid);
+      if (cmd && re.test(cmd)) return true;
+    }
+    frontier = frontier.flatMap((pid) => getChildPids(pid));
+  }
+  return false;
+}
+
+/**
  * Check if a PID has a child matching a pattern.
  * @param {number} parentPid
  * @param {string} pattern


### PR DESCRIPTION
Fixes #624

## Problem

`isRunning()` relied on the pane process comm being the agent name, plus a single-generation `pgrep -P -f` fallback. Both fail in common topologies (see issue): the pane process is the tmux launcher ("node"/"MainThread"), macOS reports the interpreter for shebang CLIs, and the agent can sit deeper than direct children. Result on a real macOS install: monitor reports STOPPED while Claude runs, and the Guardian floods the live session's input box with start commands.

## Change

- New `isAgentInProcessTree(panePid, name, maxDepth=3)` in `tmux-helpers.js`: BFS from the pane process down, matching either `comm` or the full command line (`ps -o command=`) at each level. Word/path-segment regex — `.claude/` paths and `claudette` do not match.
- `claude.js` and `codex.js` `isRunning()` switch to the tree walk (codex keeps its legacy loose `node` comm shortcut).
- New helpers `getProcessCommand` / `getChildPids` + unit tests (24 helper tests, full suite 478 pass).

## Verification

- Linux (this host): tree walk returns true for the live `claude-main` pane whose comm is `MainThread` — the old layer-1 check never matched even here.
- macOS: pending — Kevin will install this branch via tarball (`npm i -g .../archive/refs/heads/fix/macos-agent-detection.tar.gz`) and confirm `zylos status` flips to RUNNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)