### PR TITLE
Deduplicate early Memory Sync triggers

### DIFF
--- a/skills/activity-monitor/scripts/__tests__/memory-sync-gate.test.js
+++ b/skills/activity-monitor/scripts/__tests__/memory-sync-gate.test.js
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  clearMemorySyncRequest,
+  createMemorySyncControlPrompt,
+  markMemorySyncRequested,
+  shouldTriggerMemorySync,
+} from '../memory-sync-gate.js';
+
+describe('memory sync gate', () => {
+  it('skips and clears stale request state when unsummarized count is below threshold', () => {
+    const result = shouldTriggerMemorySync({
+      state: {
+        memory_sync: { status: 'requested', requested_at: 100, expires_at: 3700 },
+        last_memory_sync_trigger_at: 100,
+      },
+      now: 200,
+      unsummarizedCount: 5,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'below_checkpoint_threshold');
+    assert.deepEqual(result.nextState, {});
+  });
+
+  it('suppresses repeated requests during cooldown', () => {
+    const state = {
+      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+    };
+
+    const result = shouldTriggerMemorySync({
+      state,
+      now: 1200,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'cooldown');
+    assert.equal(result.nextState, state);
+  });
+
+  it('honors legacy trigger timestamps during cooldown', () => {
+    const result = shouldTriggerMemorySync({
+      state: { last_memory_sync_trigger_at: 1000 },
+      now: 1200,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'cooldown');
+  });
+
+  it('suppresses in-flight requests after cooldown until the TTL expires', () => {
+    const state = {
+      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+    };
+
+    const result = shouldTriggerMemorySync({
+      state,
+      now: 2000,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+      inFlightTtlSeconds: 3600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'sync_request_in_flight');
+  });
+
+  it('allows a new request after the in-flight TTL expires', () => {
+    const result = shouldTriggerMemorySync({
+      state: {
+        memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+      },
+      now: 5000,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+      inFlightTtlSeconds: 3600,
+    });
+
+    assert.equal(result.shouldEnqueue, true);
+    assert.equal(result.reason, 'eligible');
+  });
+
+  it('marks requests with a durable status and legacy timestamp', () => {
+    const nextState = markMemorySyncRequested({
+      state: { session_id: 'abc' },
+      now: 1000,
+      unsummarizedCount: 45,
+      pct: 61,
+      thresholdPct: 75,
+      inFlightTtlSeconds: 3600,
+    });
+
+    assert.equal(nextState.session_id, 'abc');
+    assert.equal(nextState.last_memory_sync_trigger_at, 1000);
+    assert.deepEqual(nextState.memory_sync, {
+      status: 'requested',
+      requested_at: 1000,
+      expires_at: 4600,
+      unsummarized_count: 45,
+      context_pct: 61,
+      session_switch_threshold_pct: 75,
+    });
+  });
+
+  it('removes memory sync request fields without touching unrelated state', () => {
+    const nextState = clearMemorySyncRequest({
+      session_id: 'abc',
+      memory_sync: { status: 'requested' },
+      last_memory_sync_trigger_at: 1000,
+    });
+
+    assert.deepEqual(nextState, { session_id: 'abc' });
+  });
+
+  it('builds a maintenance-only control prompt', () => {
+    const prompt = createMemorySyncControlPrompt({ pct: 61, thresholdPct: 75 });
+
+    assert.match(prompt, /Run Memory Sync now/);
+    assert.match(prompt, /maintenance-only/);
+    assert.match(prompt, /must not reply through C4/);
+    assert.match(prompt, /process user-facing tasks/);
+    assert.match(prompt, /modify business\/project repositories/);
+    assert.match(prompt, /Do NOT wait for completion/);
+  });
+});

--- a/skills/activity-monitor/scripts/adapters/runtime-components.js
+++ b/skills/activity-monitor/scripts/adapters/runtime-components.js
@@ -6,6 +6,11 @@ import { ProcSampler } from '../proc-sampler.js';
 import { ToolPipeline } from '../tool-pipeline.js';
 import { UsageMonitor } from '../usage-monitor.js';
 import { getToolRules } from '../tool-rules.js';
+import {
+  createMemorySyncControlPrompt,
+  markMemorySyncRequested,
+  shouldTriggerMemorySync,
+} from '../memory-sync-gate.js';
 
 export function createUsageMonitor(activeAdapter, options) {
   return new UsageMonitor(activeAdapter, options);
@@ -77,9 +82,10 @@ export function createGuardian(activeAdapter, activeToolPipeline, initialRuntime
 export function startContextMonitor(activeAdapter, {
   getUnsummarizedCount,
   checkpointThreshold,
-  getLastMemorySyncTriggerAt,
-  setLastMemorySyncTriggerAt,
+  loadContextMonitorState,
+  saveContextMonitorState,
   memorySyncCooldownSeconds,
+  memorySyncInFlightTtlSeconds,
   c4ControlPath,
   enqueueContextRotationHandoff,
   log,
@@ -99,24 +105,40 @@ export function startContextMonitor(activeAdapter, {
     onEarlyThreshold: async ({ used, ceiling, ratio }) => {
       const pct = Math.round(ratio * 100);
       const thresholdPct = Math.round(monitor.threshold * 100);
-      // Cooldown: prevent re-inject while sync is still running
       const now = Math.floor(Date.now() / 1000);
-      if ((now - getLastMemorySyncTriggerAt()) < memorySyncCooldownSeconds) {
-        return;
-      }
       const unsummarizedCount = getUnsummarizedCount();
-      if (unsummarizedCount <= checkpointThreshold) {
-        log(`Early memory sync skipped at ${pct}%: unsummarized=${unsummarizedCount} <= ${checkpointThreshold}`);
+      const state = loadContextMonitorState();
+      const gate = shouldTriggerMemorySync({
+        state,
+        now,
+        unsummarizedCount,
+        checkpointThreshold,
+        cooldownSeconds: memorySyncCooldownSeconds,
+        inFlightTtlSeconds: memorySyncInFlightTtlSeconds,
+      });
+
+      if (!gate.shouldEnqueue) {
+        if (gate.nextState !== state) {
+          saveContextMonitorState(gate.nextState);
+        }
+        log(`Early memory sync skipped at ${pct}%: ${gate.reason} (unsummarized=${unsummarizedCount}, threshold=${checkpointThreshold})`);
         return;
       }
       log(`Context at ${pct}% (approaching ${thresholdPct}% threshold), triggering early memory sync (unsummarized=${unsummarizedCount})`);
       try {
         execFileSync('node', [c4ControlPath, 'enqueue',
-          '--content', `Context usage at ${pct}% (approaching ${thresholdPct}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. Launch a background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. Do NOT wait for completion — continue normal work.`,
+          '--content', createMemorySyncControlPrompt({ pct, thresholdPct }),
           '--priority', '2',
           '--no-ack-suffix',
         ], { encoding: 'utf8', stdio: 'pipe', timeout: 10_000 });
-        setLastMemorySyncTriggerAt(now);
+        saveContextMonitorState(markMemorySyncRequested({
+          state,
+          now,
+          unsummarizedCount,
+          pct,
+          thresholdPct,
+          inFlightTtlSeconds: memorySyncInFlightTtlSeconds,
+        }));
         log(`Early memory sync enqueued at ${pct}%`);
       } catch (err) {
         log(`Failed to enqueue early memory sync: ${err.message}`);

--- a/skills/activity-monitor/scripts/context-monitor.js
+++ b/skills/activity-monitor/scripts/context-monitor.js
@@ -19,6 +19,11 @@ import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import {
+  createMemorySyncControlPrompt,
+  markMemorySyncRequested,
+  shouldTriggerMemorySync,
+} from './memory-sync-gate.js';
 
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const AM_DIR = path.join(ZYLOS_DIR, 'activity-monitor');
@@ -40,6 +45,7 @@ const MEMORY_SYNC_RATIO = 0.8;
 const MEMORY_SYNC_THRESHOLD = Math.round(RESTART_THRESHOLD * MEMORY_SYNC_RATIO);
 const CHECKPOINT_THRESHOLD = 30;  // must match c4-config.js CHECKPOINT_THRESHOLD
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
+const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 3600;  // 1 hour safety TTL for delivered-but-unacked sync prompts
 
 function readThresholdFromConfig() {
   try {
@@ -145,26 +151,38 @@ function main(raw) {
  * Only triggers when there are enough unsummarized conversations to warrant sync.
  */
 function maybeEnqueueMemorySync(usedPct) {
-  // Cooldown: prevent re-inject while sync is still running
   const now = Math.floor(Date.now() / 1000);
   const state = loadState();
-  if (state && state.last_memory_sync_trigger_at &&
-      (now - state.last_memory_sync_trigger_at) < MEMORY_SYNC_COOLDOWN_SECONDS) {
-    return;
-  }
 
   // Check unsummarized conversation count — skip if below threshold
   const unsummarizedCount = getUnsummarizedCount();
-  if (unsummarizedCount <= CHECKPOINT_THRESHOLD) {
+  const gate = shouldTriggerMemorySync({
+    state,
+    now,
+    unsummarizedCount,
+    checkpointThreshold: CHECKPOINT_THRESHOLD,
+    cooldownSeconds: MEMORY_SYNC_COOLDOWN_SECONDS,
+    inFlightTtlSeconds: MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS,
+  });
+
+  if (!gate.shouldEnqueue) {
+    if (gate.nextState !== state) {
+      saveState(gate.nextState);
+    }
+    log(`Early memory sync skipped at ${usedPct}%: ${gate.reason} (unsummarized=${unsummarizedCount}, threshold=${CHECKPOINT_THRESHOLD})`);
     return;
   }
 
+  const content = createMemorySyncControlPrompt({
+    pct: usedPct,
+    thresholdPct: RESTART_THRESHOLD,
+  });
   const MAX_RETRIES = 3;
   let enqueued = false;
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       execFileSync('node', [C4_CONTROL, 'enqueue',
-        '--content', `Context usage at ${usedPct}% (approaching ${RESTART_THRESHOLD}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. Launch a background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. Do NOT wait for completion — continue normal work.`,
+        '--content', content,
         '--priority', '2',
         '--no-ack-suffix'
       ], { encoding: 'utf8', stdio: 'pipe' });
@@ -178,10 +196,14 @@ function maybeEnqueueMemorySync(usedPct) {
   }
 
   if (enqueued) {
-    saveState({
-      ...state,
-      last_memory_sync_trigger_at: now,
-    });
+    saveState(markMemorySyncRequested({
+      state,
+      now,
+      unsummarizedCount,
+      pct: usedPct,
+      thresholdPct: RESTART_THRESHOLD,
+      inFlightTtlSeconds: MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS,
+    }));
   }
 }
 

--- a/skills/activity-monitor/scripts/memory-sync-gate.js
+++ b/skills/activity-monitor/scripts/memory-sync-gate.js
@@ -1,0 +1,90 @@
+const DEFAULT_IN_FLIGHT_TTL_SECONDS = 3600;
+
+export function createMemorySyncControlPrompt({ pct, thresholdPct }) {
+  return `Context usage at ${pct}% (approaching ${thresholdPct}% session-switch threshold). Run Memory Sync now as a background maintenance task so it completes before the session switch.
+
+Launch exactly one background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. The subagent is maintenance-only: it must not reply through C4, process user-facing tasks, modify business/project repositories, install or upgrade components, restart services, or apply runtime changes outside the memory sync flow.
+
+Do NOT wait for completion - continue normal work.`;
+}
+
+export function shouldTriggerMemorySync({
+  state,
+  now,
+  unsummarizedCount,
+  checkpointThreshold,
+  cooldownSeconds,
+  inFlightTtlSeconds = DEFAULT_IN_FLIGHT_TTL_SECONDS,
+}) {
+  if (unsummarizedCount <= checkpointThreshold) {
+    return {
+      shouldEnqueue: false,
+      reason: 'below_checkpoint_threshold',
+      nextState: clearMemorySyncRequest(state),
+    };
+  }
+
+  const memorySync = state?.memory_sync ?? {};
+  const requestedAt = Number(memorySync.requested_at ?? state?.last_memory_sync_trigger_at ?? 0);
+  const expiresAt = Number(memorySync.expires_at ?? 0);
+
+  if (requestedAt > 0 && now - requestedAt < cooldownSeconds) {
+    return {
+      shouldEnqueue: false,
+      reason: 'cooldown',
+      nextState: state ?? {},
+    };
+  }
+
+  if (
+    memorySync.status === 'requested' &&
+    requestedAt > 0 &&
+    (expiresAt > now || now - requestedAt < inFlightTtlSeconds)
+  ) {
+    return {
+      shouldEnqueue: false,
+      reason: 'sync_request_in_flight',
+      nextState: state ?? {},
+    };
+  }
+
+  return {
+    shouldEnqueue: true,
+    reason: 'eligible',
+    nextState: state ?? {},
+  };
+}
+
+export function markMemorySyncRequested({
+  state,
+  now,
+  unsummarizedCount,
+  pct,
+  thresholdPct,
+  inFlightTtlSeconds = DEFAULT_IN_FLIGHT_TTL_SECONDS,
+}) {
+  return {
+    ...(state ?? {}),
+    memory_sync: {
+      status: 'requested',
+      requested_at: now,
+      expires_at: now + inFlightTtlSeconds,
+      unsummarized_count: unsummarizedCount,
+      context_pct: pct,
+      session_switch_threshold_pct: thresholdPct,
+    },
+    // Legacy field kept for older readers of context-monitor-state.json.
+    last_memory_sync_trigger_at: now,
+  };
+}
+
+export function clearMemorySyncRequest(state) {
+  if (!state?.memory_sync && !state?.last_memory_sync_trigger_at) {
+    return state ?? {};
+  }
+
+  const nextState = { ...state };
+  delete nextState.memory_sync;
+  delete nextState.last_memory_sync_trigger_at;
+  return nextState;
+}

--- a/skills/activity-monitor/scripts/monitor.js
+++ b/skills/activity-monitor/scripts/monitor.js
@@ -567,7 +567,8 @@ function getTmuxActivity() {
 
 const CHECKPOINT_THRESHOLD = 30;  // must match c4-config.js CHECKPOINT_THRESHOLD
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
-let lastMemorySyncTriggerAt = 0;
+const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 3600;  // 1 hour safety TTL for delivered-but-unacked sync prompts
+const CONTEXT_MONITOR_STATE_FILE = path.join(MONITOR_DIR, 'context-monitor-state.json');
 
 function getUnsummarizedCount() {
   try {
@@ -589,6 +590,25 @@ function runC4Control(args) {
     const stdout = err.stdout ? String(err.stdout).trim() : '';
     const stderr = err.stderr ? String(err.stderr).trim() : '';
     return { ok: false, output: stdout || stderr || err.message };
+  }
+}
+
+function loadContextMonitorState() {
+  try {
+    return JSON.parse(fs.readFileSync(CONTEXT_MONITOR_STATE_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveContextMonitorState(state) {
+  try {
+    if (!fs.existsSync(MONITOR_DIR)) {
+      fs.mkdirSync(MONITOR_DIR, { recursive: true });
+    }
+    atomicWriteJson(CONTEXT_MONITOR_STATE_FILE, state);
+  } catch (err) {
+    log(`Failed to write context monitor state: ${err.message}`);
   }
 }
 
@@ -931,11 +951,10 @@ function startContextMonitor(activeAdapter) {
   return startRuntimeContextMonitor(activeAdapter, {
     getUnsummarizedCount,
     checkpointThreshold: CHECKPOINT_THRESHOLD,
-    getLastMemorySyncTriggerAt: () => lastMemorySyncTriggerAt,
-    setLastMemorySyncTriggerAt: (nextValue) => {
-      lastMemorySyncTriggerAt = nextValue;
-    },
+    loadContextMonitorState,
+    saveContextMonitorState,
     memorySyncCooldownSeconds: MEMORY_SYNC_COOLDOWN_SECONDS,
+    memorySyncInFlightTtlSeconds: MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS,
     c4ControlPath: C4_CONTROL_PATH,
     enqueueContextRotationHandoff,
     log,

--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -42,6 +42,11 @@ This skill must be run via a runtime-appropriate background subagent mechanism. 
 Memory Sync is the highest-priority internal maintenance task.
 When triggered, run it before handling queued user messages.
 
+Memory Sync is maintenance-only. A sync subagent must not reply through C4,
+process user-facing tasks, modify business/project repositories, install or
+upgrade components, restart services, or apply runtime changes outside the
+sync flow below.
+
 ### Trigger Paths
 
 1. Session init: if C4 unsummarized count is over threshold, launch memory sync.
@@ -57,9 +62,11 @@ run `pm2 start ... codex exec ...`, or fork an extra `codex exec` sidecar.
 PM2 is only a fallback when no native background-agent capability is
 available; if used, explicitly record the reason in the handoff/status.
 
-Before starting Memory Sync, check for existing `memory-sync-*` PM2 entries.
-If one is running, do not start another sync writer. If only stopped entries
-exist, report them as historical records and do not create a replacement.
+Before starting Memory Sync, check for existing in-flight sync work. If the
+runtime exposes background-agent status, use that first. If PM2 fallback has
+ever been used, also check for existing `memory-sync-*` PM2 entries. If one is
+running, do not start another sync writer. If only stopped entries exist,
+report them as historical records and do not create a replacement.
 
 ### Sync Flow
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -91,7 +91,7 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
 
 1. **At session start:** identity + state + references are auto-injected.
 2. **During work:** Update appropriate memory files immediately when you learn something important.
-3. **Memory Sync:** When triggered, launch a background subagent using the **Task tool** (`subagent_type: general-purpose`, `model: sonnet`, `run_in_background: true`). The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. Do NOT use the Skill tool for this — it does not support background execution. Continue your main work without waiting.
+3. **Memory Sync:** When triggered, launch a background subagent using the **Task tool** (`subagent_type: general-purpose`, `model: sonnet`, `run_in_background: true`). The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. The subagent is maintenance-only: it must not reply through C4, process user-facing tasks, modify business/project repositories, install or upgrade components, restart services, or apply runtime changes outside the memory sync flow. Do NOT use the Skill tool for this — it does not support background execution. Continue your main work without waiting.
 4. **references.md is a pointer file.** Never duplicate .env values in it — point to the source config file instead.
 
 ### Classification Rules for reference/ Files

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -111,7 +111,7 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
 
 1. **At session start:** identity + state + references are auto-injected.
 2. **During work:** Update appropriate memory files immediately when you learn something important.
-3. **Memory Sync:** When triggered, launch a background subagent using the current runtime's supported subagent/task mechanism. The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. This also applies in Codex and in `new-session` handoff flows: do not run Memory Sync inline in the main loop.
+3. **Memory Sync:** When triggered, launch a background subagent using the current runtime's supported subagent/task mechanism. The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. The subagent is maintenance-only: it must not reply through C4, process user-facing tasks, modify business/project repositories, install or upgrade components, restart services, or apply runtime changes outside the memory sync flow. This also applies in Codex and in `new-session` handoff flows: do not run Memory Sync inline in the main loop.
 4. **references.md is a pointer file.** Never duplicate .env values in it — point to the source config file instead.
 
 ### Classification Rules for reference/ Files

--- a/templates/claude-addon.md
+++ b/templates/claude-addon.md
@@ -55,7 +55,7 @@ The `ack via:` path is included in the message.
 
 ### Memory Sync
 
-When Memory Sync is triggered, launch a background subagent using the **Task tool** (`subagent_type: general-purpose`, `model: sonnet`, `run_in_background: true`). The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. Do NOT use the Skill tool for this — it does not support background execution. Continue your main work without waiting.
+When Memory Sync is triggered, launch a background subagent using the **Task tool** (`subagent_type: general-purpose`, `model: sonnet`, `run_in_background: true`). The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. The subagent is maintenance-only: it must not reply through C4, process user-facing tasks, modify business/project repositories, install or upgrade components, restart services, or apply runtime changes outside the memory sync flow. Do NOT use the Skill tool for this — it does not support background execution. Continue your main work without waiting.
 
 ### Available Skills
 

--- a/templates/codex-addon.md
+++ b/templates/codex-addon.md
@@ -75,7 +75,7 @@ The `ack via:` path and ID are included in the message.
 
 ### Memory Sync
 
-When Memory Sync is triggered, launch a background subagent using Codex's available multi-agent capability. Do not hardcode Claude-only Task tool parameters such as `model: sonnet` or `run_in_background`. Instead, use a Codex-supported agent configuration available in the current session and instruct that agent to follow the sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. This applies in Codex too, including `new-session` handoff flows. Do not run Memory Sync inline in the main loop. Report when complete.
+When Memory Sync is triggered, launch a background subagent using Codex's available multi-agent capability. Do not hardcode Claude-only Task tool parameters such as `model: sonnet` or `run_in_background`. Instead, use a Codex-supported agent configuration available in the current session and instruct that agent to follow the sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. The subagent is maintenance-only: it must not reply through C4, process user-facing tasks, modify business/project repositories, install or upgrade components, restart services, or apply runtime changes outside the memory sync flow. This applies in Codex too, including `new-session` handoff flows. Do not run Memory Sync inline in the main loop. Report when complete.
 
 ### Available Tools
 


### PR DESCRIPTION
## Summary
- add a shared Memory Sync gate for early context-threshold triggers
- persist requested/in-flight sync state across monitor restarts with a TTL and legacy timestamp compatibility
- use the gate from both Claude statusLine and Codex polling monitor paths
- tighten Memory Sync subagent instructions so sync workers cannot reply through C4, process user tasks, modify business repos, install/upgrade components, restart services, or apply runtime changes outside the sync flow

## Tests
- npm test
- npm test (skills/activity-monitor)

Fixes #626.
Fixes #627.