### PR TITLE
feat(multi-session): phase 1 — worker registry + team adapter

### DIFF
--- a/scripts/run-node-tests.js
+++ b/scripts/run-node-tests.js
@@ -8,6 +8,7 @@ const TEST_ROOTS = [
   path.join(ROOT, 'cli', 'lib', '__tests__'),
   path.join(ROOT, 'cli', 'lib', 'runtime', '__tests__'),
   path.join(ROOT, 'skills', 'activity-monitor', 'scripts', '__tests__'),
+  path.join(ROOT, 'skills', 'multi-session', 'scripts', '__tests__'),
 ];
 
 function walk(dir, files = []) {
@@ -28,6 +29,7 @@ function isNodeTest(file) {
   if (rel.startsWith('cli/lib/__tests__/')) return true;
   if (rel.startsWith('cli/lib/runtime/__tests__/')) return true;
   if (rel.startsWith('skills/activity-monitor/scripts/__tests__/')) return true;
+  if (rel.startsWith('skills/multi-session/scripts/__tests__/')) return true;
   return false;
 }
 

--- a/skills/multi-session/SKILL.md
+++ b/skills/multi-session/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: multi-session
+description: Multi-session runtime (phase 1) — delegate bounded work to agent-teams teammates. Use when delegating a task to a worker session, preparing a teammate prompt, checking/installing teammate permission guardrails, accepting or failing a worker's delivery, or harvesting in-flight workers before molt (/clear).
+---
+
+# Multi-Session Runtime (Phase 1 — Delegated Work Sessions)
+
+Phase 1 of the multi-session runtime (design: multi-session-runtime-proposal-v2.1).
+Scope: **session registry + team adapter only**. The worker carrier is native
+Claude Code agent teams — the lead (main interactive session) spawns teammates
+itself via its native tools. This skill does bookkeeping and conventions, not
+process spawning. C4 comm-bridge, activity-monitor, scheduler, and runtime
+switching: **zero changes**.
+
+Data lives in `~/zylos/multi-session/`:
+- `registry.json` — persistent worker registry (atomic writes; survives molt)
+- `deliveries/<date>-<slug>/` — per-task delivery directories
+
+## CLI
+
+`~/zylos/.claude/skills/multi-session/scripts/cli.js <command>`
+
+| Command | Description |
+|---------|-------------|
+| `delegate-prep <task-slug> [--task "<desc>"]` | Create delivery dir, register worker, print teammate prompt. Refuses at cap. |
+| `accept <id> [--summary "<text>"]` | Accept a worker's delivery |
+| `fail <id> [--reassign]` | Mark failed; `--reassign` creates a successor entry on the same delivery dir |
+| `harvest` | List in-flight workers; **exit 1 if any exist** (run before molt) |
+| `check-guardrails [--project-dir <dir>]` | Verify teammate deny block in `<dir>/.claude/settings.json` |
+| `write-guardrails [--project-dir <dir>]` | Install/merge the deny block |
+| `list` / `get <id>` / `active` / `add` / `update <id>` / `done <id>` | Registry CRUD |
+
+## Delegation Lifecycle
+
+1. **Prep:** lead runs `delegate-prep <slug> --task "<full description>"`. The
+   adapter enforces the concurrency cap, creates
+   `~/zylos/multi-session/deliveries/<date>-<slug>/`, registers a `pending`
+   worker, and prints a ready-to-use teammate task prompt (goal, boundaries,
+   delivery dir, continuous-checkpoint requirement, down-scoping notes).
+2. **Spawn:** the lead spawns the teammate with its native agent-teams tools,
+   pasting the printed prompt. Ensure the teammate's working directory passes
+   `check-guardrails` first (run `write-guardrails` if not). Then
+   `update <id> --status running --teammate <name> --team <name>`.
+3. **Checkpoint:** the teammate continuously checkpoints progress into the
+   delivery dir. Teammates are **not resumable** — the delivery dir is the only
+   surviving context if the worker dies.
+4. **Completion:** teammate writes `RESULT.md` in the delivery dir and reports
+   to the lead; lead runs `done <id> --summary "..."`.
+5. **Acceptance:** lead verifies the delivery, then `accept <id>`. On failure:
+   `fail <id> --reassign` creates a successor entry linked to the same delivery
+   dir so the next teammate resumes from the checkpoints.
+
+## Tool Down-Scoping (Guardrails)
+
+Teammates must not write zylos memory or impersonate the main session
+externally. The deny block must live in the **project `.claude/settings.json`
+of the cwd the teammate runs in** — that is where teammates inherit it from:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Write(//home/<user>/zylos/memory/**)",
+      "Edit(//home/<user>/zylos/memory/**)",
+      "Bash(*c4-send.js*)",
+      "Bash(*c4-control.js*)"
+    ]
+  }
+}
+```
+
+**IMPORTANT:** absolute paths in permission rules MUST use the `//` prefix.
+A single `/` silently fails to match (spike-verified 2026-06-12).
+`write-guardrails` generates this block; `check-guardrails` verifies presence
+and flags single-slash absolute paths.
+
+## Caveats and Hard Rules
+
+- **Lead-lifecycle coupling (spike-verified 2026-06-12):** teammates are
+  managed by the lead process and **die with the lead**. Molt (/clear), restart,
+  or crash of the main session takes all teammates down. Therefore the molt
+  procedure must run `harvest` first and only molt on exit code 0 — otherwise
+  accept, fail, or explicitly reassign in-flight workers ("harvest before
+  molt"). The registry persists across molt; unfinished work is reassigned at
+  task granularity from the delivery-dir checkpoints.
+- **Hard cap N=2 concurrent workers** (prior decision 2026-06-09). Enforced in
+  `delegate-prep`: it refuses (exit 2) when 2 workers are active
+  (pending/running). Keep workers short-lived — delegate, harvest, release.
+- **Explicit-budget rule:** headless `claude -p` workers are billed on a
+  separate credits pool (post 2026-06-15 policy), NOT the subscription pool.
+  `-p` is never the default path — escalating to it is always an explicit
+  budget decision. Phase 1 uses agent teams (subscription pool) only.
+- Worker token usage should be recorded in the registry (`update <id> --usage`)
+  for subscription-window watermark decisions.

--- a/skills/multi-session/package.json
+++ b/skills/multi-session/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "zylos-multi-session",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Multi-session runtime phase 1: worker registry + team adapter for delegated work sessions",
+  "bin": {
+    "multi-session-cli": "./scripts/cli.js"
+  },
+  "scripts": {
+    "cli": "node scripts/cli.js",
+    "test": "node --test scripts/__tests__/*.test.js"
+  }
+}

--- a/skills/multi-session/scripts/__tests__/adapter.test.js
+++ b/skills/multi-session/scripts/__tests__/adapter.test.js
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { addWorker, getWorker, MAX_ACTIVE_WORKERS } from '../registry.js';
+import {
+  delegatePrep,
+  harvest,
+  accept,
+  fail,
+  denyRules,
+  writeGuardrails,
+  checkGuardrails,
+  settingsPathFor,
+} from '../adapter.js';
+
+let tmpDir;
+let regPath;
+let deliveriesDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'msadapt-'));
+  regPath = path.join(tmpDir, 'registry.json');
+  deliveriesDir = path.join(tmpDir, 'deliveries');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function prep(slug, extra = {}) {
+  return delegatePrep(slug, { registryPath: regPath, deliveriesDir, ...extra });
+}
+
+describe('delegate-prep', () => {
+  it('creates delivery dir, registers a pending worker, and renders a prompt', () => {
+    const { worker, prompt } = prep('Doc Cleanup!', { task: 'Clean up the docs' });
+    assert.equal(worker.status, 'pending');
+    assert.equal(worker.task, 'Clean up the docs');
+    assert.ok(fs.existsSync(worker.deliveryDir));
+    assert.match(path.basename(worker.deliveryDir), /^\d{4}-\d{2}-\d{2}-doc-cleanup$/);
+    assert.ok(prompt.includes(worker.deliveryDir));
+    assert.ok(prompt.includes('checkpoint'));
+    assert.equal(getWorker(worker.id, regPath).id, worker.id);
+  });
+
+  it('rejects invalid slugs', () => {
+    assert.throws(() => prep('!!!'), /Invalid task slug/);
+  });
+
+  it('enforces the hard cap of 2 active workers', () => {
+    prep('one');
+    prep('two');
+    assert.throws(() => prep('three'), (err) => {
+      assert.equal(err.code, 'CAP_REACHED');
+      assert.match(err.message, /Concurrency cap reached \(2\/2/);
+      return true;
+    });
+    assert.equal(MAX_ACTIVE_WORKERS, 2);
+  });
+
+  it('frees cap slots once workers are accepted', () => {
+    const a = prep('one').worker;
+    prep('two');
+    fs.writeFileSync(path.join(a.deliveryDir, 'RESULT.md'), 'done');
+    accept(a.id, {}, regPath);
+    const third = prep('three').worker;
+    assert.equal(third.status, 'pending');
+  });
+});
+
+describe('harvest', () => {
+  it('is clean with no in-flight workers', () => {
+    const { clean, workers } = harvest(regPath);
+    assert.equal(clean, true);
+    assert.deepEqual(workers, []);
+  });
+
+  it('reports pending/running/done(unaccepted) as in-flight, not accepted/failed', () => {
+    addWorker({ task: 'p', status: 'pending' }, regPath);
+    addWorker({ task: 'r', status: 'running' }, regPath);
+    addWorker({ task: 'd', status: 'done' }, regPath);
+    addWorker({ task: 'a', status: 'accepted' }, regPath);
+    addWorker({ task: 'f', status: 'failed' }, regPath);
+    const { clean, workers } = harvest(regPath);
+    assert.equal(clean, false);
+    assert.deepEqual(workers.map((w) => w.task).sort(), ['d', 'p', 'r']);
+  });
+});
+
+describe('accept / fail / reassign', () => {
+  it('accept updates status and summary', () => {
+    const w = prep('task-a').worker;
+    const updated = accept(w.id, { resultSummary: 'shipped' }, regPath);
+    assert.equal(updated.status, 'accepted');
+    assert.equal(updated.resultSummary, 'shipped');
+  });
+
+  it('fail without reassign marks failed, no successor', () => {
+    const w = prep('task-b').worker;
+    const { failed, successor } = fail(w.id, {}, regPath);
+    assert.equal(failed.status, 'failed');
+    assert.equal(successor, null);
+  });
+
+  it('fail --reassign creates a successor on the same delivery dir', () => {
+    const w = prep('task-c').worker;
+    const { failed, successor } = fail(w.id, { reassign: true }, regPath);
+    assert.equal(failed.status, 'reassigned');
+    assert.equal(successor.status, 'pending');
+    assert.equal(successor.deliveryDir, w.deliveryDir);
+    assert.equal(successor.predecessorId, w.id);
+    assert.equal(successor.task, w.task);
+  });
+});
+
+describe('guardrails', () => {
+  it('denyRules use the // prefix for absolute paths', () => {
+    const rules = denyRules('/home/test/zylos');
+    assert.ok(rules.includes('Write(//home/test/zylos/memory/**)'));
+    assert.ok(rules.includes('Edit(//home/test/zylos/memory/**)'));
+    assert.ok(rules.includes('Bash(*c4-send.js*)'));
+    assert.ok(rules.includes('Bash(*c4-control.js*)'));
+  });
+
+  it('write-guardrails creates settings.json and check passes', () => {
+    const projectDir = path.join(tmpDir, 'proj');
+    const settingsPath = writeGuardrails(projectDir, '/home/test/zylos');
+    assert.equal(settingsPath, settingsPathFor(projectDir));
+    const { ok, problems } = checkGuardrails(projectDir, '/home/test/zylos');
+    assert.deepEqual(problems, []);
+    assert.equal(ok, true);
+  });
+
+  it('write-guardrails merges into existing settings without clobbering and is idempotent', () => {
+    const projectDir = path.join(tmpDir, 'proj2');
+    const settingsPath = settingsPathFor(projectDir);
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ env: { FOO: 'bar' }, permissions: { allow: ['Bash(ls*)'], deny: ['WebSearch'] } })
+    );
+    writeGuardrails(projectDir, '/home/test/zylos');
+    writeGuardrails(projectDir, '/home/test/zylos');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.equal(settings.env.FOO, 'bar');
+    assert.deepEqual(settings.permissions.allow, ['Bash(ls*)']);
+    assert.ok(settings.permissions.deny.includes('WebSearch'));
+    const denyCount = settings.permissions.deny.filter((r) => r === 'Edit(//home/test/zylos/memory/**)').length;
+    assert.equal(denyCount, 1);
+  });
+
+  it('check fails when settings file is missing', () => {
+    const { ok, problems } = checkGuardrails(path.join(tmpDir, 'nope'));
+    assert.equal(ok, false);
+    assert.match(problems[0], /not found/);
+  });
+
+  it('check fails on invalid JSON and missing deny array', () => {
+    const projectDir = path.join(tmpDir, 'proj3');
+    const settingsPath = settingsPathFor(projectDir);
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, '{broken');
+    assert.equal(checkGuardrails(projectDir).ok, false);
+    fs.writeFileSync(settingsPath, '{}');
+    const { ok, problems } = checkGuardrails(projectDir);
+    assert.equal(ok, false);
+    assert.match(problems[0], /No permissions.deny/);
+  });
+
+  it('check flags single-slash absolute paths (silently non-matching)', () => {
+    const projectDir = path.join(tmpDir, 'proj4');
+    writeGuardrails(projectDir, '/home/test/zylos');
+    const settingsPath = settingsPathFor(projectDir);
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    settings.permissions.deny.push('Write(/home/test/other/**)');
+    fs.writeFileSync(settingsPath, JSON.stringify(settings));
+    const { ok, problems } = checkGuardrails(projectDir, '/home/test/zylos');
+    assert.equal(ok, false);
+    assert.ok(problems.some((p) => p.includes('single-slash')));
+  });
+});

--- a/skills/multi-session/scripts/__tests__/adapter.test.js
+++ b/skills/multi-session/scripts/__tests__/adapter.test.js
@@ -46,6 +46,17 @@ describe('delegate-prep', () => {
     assert.equal(getWorker(worker.id, regPath).id, worker.id);
   });
 
+  it('refuses to prep when projectDir lacks guardrails, succeeds after write-guardrails', () => {
+    const projectDir = path.join(tmpDir, 'guarded');
+    assert.throws(() => prep('guarded-task', { projectDir, zylosDir: '/home/test/zylos' }), (err) => {
+      assert.equal(err.code, 'GUARDRAILS_MISSING');
+      return true;
+    });
+    writeGuardrails(projectDir, '/home/test/zylos');
+    const { worker } = prep('guarded-task', { projectDir, zylosDir: '/home/test/zylos' });
+    assert.equal(worker.status, 'pending');
+  });
+
   it('rejects invalid slugs', () => {
     assert.throws(() => prep('!!!'), /Invalid task slug/);
   });

--- a/skills/multi-session/scripts/__tests__/cli.test.js
+++ b/skills/multi-session/scripts/__tests__/cli.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const CLI = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'cli.js');
+
+let zylosDir;
+
+beforeEach(() => {
+  zylosDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mscli-'));
+});
+
+afterEach(() => {
+  fs.rmSync(zylosDir, { recursive: true, force: true });
+});
+
+function run(...args) {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    env: { ...process.env, ZYLOS_DIR: zylosDir },
+    encoding: 'utf8',
+  });
+  return result;
+}
+
+describe('cli exit codes', () => {
+  it('harvest exits 0 when clean', () => {
+    const r = run('harvest');
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Safe to molt/);
+  });
+
+  it('harvest exits 1 with in-flight workers', () => {
+    assert.equal(run('add', 'investigate flaky test').status, 0);
+    const r = run('harvest');
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /in-flight worker/);
+  });
+
+  it('delegate-prep exits 2 at the cap', () => {
+    assert.equal(run('delegate-prep', 'one').status, 0);
+    assert.equal(run('delegate-prep', 'two').status, 0);
+    const r = run('delegate-prep', 'three');
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /Concurrency cap reached/);
+  });
+
+  it('delegate-prep prints the teammate prompt block', () => {
+    const r = run('delegate-prep', 'docs', '--task', 'Write the docs');
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /TEAMMATE TASK PROMPT/);
+    assert.match(r.stdout, /Write the docs/);
+  });
+
+  it('full lifecycle: prep -> running -> done -> accept -> harvest clean', () => {
+    const prepOut = run('delegate-prep', 'lifecycle').stdout;
+    const id = /Registered (worker-[a-z0-9-]+)/.exec(prepOut)[1];
+    assert.equal(run('update', id, '--status', 'running', '--teammate', 'tm1').status, 0);
+    assert.equal(run('done', id, '--summary', 'all good').status, 0);
+    assert.equal(run('harvest').status, 1);
+    assert.equal(run('accept', id).status, 0);
+    assert.equal(run('harvest').status, 0);
+    const got = JSON.parse(run('get', id).stdout);
+    assert.equal(got.status, 'accepted');
+    assert.equal(got.resultSummary, 'all good');
+  });
+
+  it('check-guardrails fails then passes after write-guardrails', () => {
+    const projectDir = path.join(zylosDir, 'proj');
+    fs.mkdirSync(projectDir, { recursive: true });
+    assert.equal(run('check-guardrails', '--project-dir', projectDir).status, 1);
+    assert.equal(run('write-guardrails', '--project-dir', projectDir).status, 0);
+    assert.equal(run('check-guardrails', '--project-dir', projectDir).status, 0);
+  });
+
+  it('unknown command exits 1', () => {
+    assert.equal(run('bogus').status, 1);
+  });
+});

--- a/skills/multi-session/scripts/__tests__/registry.test.js
+++ b/skills/multi-session/scripts/__tests__/registry.test.js
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  generateId,
+  loadRegistry,
+  saveRegistry,
+  addWorker,
+  getWorker,
+  updateWorker,
+  listWorkers,
+  activeWorkers,
+  inFlightWorkers,
+  STATUSES,
+} from '../registry.js';
+
+let tmpDir;
+let regPath;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'msreg-'));
+  regPath = path.join(tmpDir, 'registry.json');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('generateId', () => {
+  it('starts with worker- prefix and is unique', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => generateId()));
+    assert.equal(ids.size, 50);
+    for (const id of ids) assert.match(id, /^worker-[a-z0-9]+-[a-f0-9]+$/);
+  });
+});
+
+describe('loadRegistry', () => {
+  it('returns empty registry when file is missing', () => {
+    assert.deepEqual(loadRegistry(regPath), { workers: [] });
+  });
+
+  it('throws on corrupt JSON', () => {
+    fs.writeFileSync(regPath, '{not json');
+    assert.throws(() => loadRegistry(regPath));
+  });
+
+  it('throws on missing workers array', () => {
+    fs.writeFileSync(regPath, '{"foo": 1}');
+    assert.throws(() => loadRegistry(regPath), /Corrupt registry/);
+  });
+});
+
+describe('saveRegistry atomic write', () => {
+  it('writes via temp file + rename, leaving no temp files behind', () => {
+    saveRegistry({ workers: [] }, regPath);
+    assert.ok(fs.existsSync(regPath));
+    const leftovers = fs.readdirSync(tmpDir).filter((f) => f.includes('.tmp'));
+    assert.deepEqual(leftovers, []);
+  });
+
+  it('replaces existing content fully', () => {
+    saveRegistry({ workers: [{ id: 'a' }] }, regPath);
+    saveRegistry({ workers: [] }, regPath);
+    assert.deepEqual(JSON.parse(fs.readFileSync(regPath, 'utf8')), { workers: [] });
+  });
+
+  it('creates parent directories as needed', () => {
+    const nested = path.join(tmpDir, 'deep', 'dir', 'registry.json');
+    saveRegistry({ workers: [] }, nested);
+    assert.ok(fs.existsSync(nested));
+  });
+});
+
+describe('addWorker / getWorker', () => {
+  it('adds a worker with defaults and persists it', () => {
+    const w = addWorker({ task: 'build docs' }, regPath);
+    assert.equal(w.status, 'pending');
+    assert.ok(w.createdAt > 0);
+    assert.equal(w.createdAt, w.updatedAt);
+    const loaded = getWorker(w.id, regPath);
+    assert.deepEqual(loaded, w);
+  });
+
+  it('requires a task description', () => {
+    assert.throws(() => addWorker({}, regPath), /task/);
+  });
+
+  it('rejects invalid status', () => {
+    assert.throws(() => addWorker({ task: 't', status: 'bogus' }, regPath), /Invalid status/);
+  });
+
+  it('rejects duplicate ids', () => {
+    addWorker({ id: 'worker-x', task: 't' }, regPath);
+    assert.throws(() => addWorker({ id: 'worker-x', task: 't2' }, regPath), /already exists/);
+  });
+});
+
+describe('updateWorker', () => {
+  it('updates allowed fields and bumps updatedAt', () => {
+    const w = addWorker({ task: 't' }, regPath);
+    const updated = updateWorker(w.id, { status: 'running', teammate: 'researcher' }, regPath);
+    assert.equal(updated.status, 'running');
+    assert.equal(updated.teammate, 'researcher');
+    assert.ok(updated.updatedAt >= w.updatedAt);
+  });
+
+  it('rejects unknown fields and unknown workers', () => {
+    const w = addWorker({ task: 't' }, regPath);
+    assert.throws(() => updateWorker(w.id, { createdAt: 0 }, regPath), /not updatable/);
+    assert.throws(() => updateWorker('worker-none', { status: 'done' }, regPath), /not found/);
+  });
+
+  it('accepts every documented status', () => {
+    const w = addWorker({ task: 't' }, regPath);
+    for (const status of STATUSES) {
+      assert.equal(updateWorker(w.id, { status }, regPath).status, status);
+    }
+  });
+});
+
+describe('listWorkers / activeWorkers / inFlightWorkers', () => {
+  it('filters by status sets', () => {
+    addWorker({ task: 'a', status: 'pending' }, regPath);
+    addWorker({ task: 'b', status: 'running' }, regPath);
+    addWorker({ task: 'c', status: 'done' }, regPath);
+    addWorker({ task: 'd', status: 'accepted' }, regPath);
+    addWorker({ task: 'e', status: 'failed' }, regPath);
+
+    assert.equal(listWorkers({}, regPath).length, 5);
+    assert.equal(listWorkers({ statuses: ['failed'] }, regPath).length, 1);
+    assert.deepEqual(activeWorkers(regPath).map((w) => w.task), ['a', 'b']);
+    assert.deepEqual(inFlightWorkers(regPath).map((w) => w.task), ['a', 'b', 'c']);
+  });
+});

--- a/skills/multi-session/scripts/adapter.js
+++ b/skills/multi-session/scripts/adapter.js
@@ -1,0 +1,224 @@
+/**
+ * Team Adapter (multi-session runtime, phase 1 — v2.1 design)
+ *
+ * The lead (main interactive session) spawns teammates itself via native
+ * agent-teams tools. This adapter is bookkeeping + conventions only:
+ *   - delegate-prep: delivery dir + registry entry + ready-to-use task prompt
+ *   - guardrails: tool down-scoping deny block for teammate cwd settings
+ *   - harvest: pre-molt check for in-flight workers
+ *   - accept / fail (--reassign): acceptance flow
+ *
+ * It never spawns processes and makes no network calls.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  ZYLOS_DIR,
+  DELIVERIES_DIR,
+  MAX_ACTIVE_WORKERS,
+  addWorker,
+  getWorker,
+  updateWorker,
+  activeWorkers,
+  inFlightWorkers,
+  REGISTRY_PATH,
+} from './registry.js';
+
+/**
+ * Permission deny rules teammates must inherit.
+ *
+ * IMPORTANT: absolute paths in Claude Code permission rules MUST use the
+ * `//` prefix — a single `/` silently fails to match (spike-verified
+ * 2026-06-12). `//` anchors the pattern to the filesystem root.
+ */
+export function denyRules(zylosDir = ZYLOS_DIR) {
+  const memoryGlob = `/${path.join(zylosDir, 'memory')}/**`; // zylosDir is absolute => leading `//`
+  return [
+    `Write(${memoryGlob})`,
+    `Edit(${memoryGlob})`,
+    'Bash(*c4-send.js*)',
+    'Bash(*c4-control.js*)',
+  ];
+}
+
+/**
+ * Where the deny block must live: the project settings of the cwd the
+ * teammate runs in. Teammates inherit project settings from their working
+ * directory, so this is the enforcement point.
+ */
+export function settingsPathFor(projectDir) {
+  return path.join(projectDir, '.claude', 'settings.json');
+}
+
+/** Merge the deny rules into <projectDir>/.claude/settings.json (idempotent). */
+export function writeGuardrails(projectDir, zylosDir = ZYLOS_DIR) {
+  const settingsPath = settingsPathFor(projectDir);
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  let settings = {};
+  if (fs.existsSync(settingsPath)) {
+    settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  }
+  settings.permissions = settings.permissions || {};
+  const deny = new Set(settings.permissions.deny || []);
+  for (const rule of denyRules(zylosDir)) deny.add(rule);
+  settings.permissions.deny = [...deny];
+  const tmp = `${settingsPath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, settingsPath);
+  return settingsPath;
+}
+
+/**
+ * Verify the deny block exists and is syntactically correct in the project
+ * settings of `projectDir`. Returns { ok, problems: [] }.
+ */
+export function checkGuardrails(projectDir, zylosDir = ZYLOS_DIR) {
+  const problems = [];
+  const settingsPath = settingsPathFor(projectDir);
+  if (!fs.existsSync(settingsPath)) {
+    return { ok: false, problems: [`Settings file not found: ${settingsPath}`] };
+  }
+  let settings;
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  } catch (err) {
+    return { ok: false, problems: [`Invalid JSON in ${settingsPath}: ${err.message}`] };
+  }
+  const deny = settings?.permissions?.deny;
+  if (!Array.isArray(deny)) {
+    return { ok: false, problems: [`No permissions.deny array in ${settingsPath}`] };
+  }
+  for (const rule of denyRules(zylosDir)) {
+    if (!deny.includes(rule)) {
+      problems.push(`Missing deny rule: ${rule}`);
+    }
+  }
+  // Syntactic check: any deny rule embedding an absolute path must use the
+  // `//` prefix; a single `/` silently fails to match (spike 2026-06-12).
+  for (const rule of deny) {
+    const match = /^[A-Za-z]+\((\/[^/].*)\)$/.exec(rule);
+    if (match) {
+      problems.push(
+        `Rule "${rule}" uses a single-slash absolute path; use "//" prefix (single "/" silently fails to match)`
+      );
+    }
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+function slugify(slug) {
+  const clean = String(slug).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  if (!clean) throw new Error(`Invalid task slug: "${slug}"`);
+  return clean;
+}
+
+function isoDate(ts = Date.now()) {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+/** Render the ready-to-use teammate task prompt block (the task contract). */
+export function renderPrompt(worker, { projectDir } = {}) {
+  const lines = [
+    '--- TEAMMATE TASK PROMPT (copy into the teammate spawn) ---',
+    '',
+    `# Task: ${worker.task}`,
+    '',
+    '## Contract',
+    `- Goal: ${worker.task}`,
+    '- Boundaries: work ONLY within the scope above. Do not write to zylos memory files,',
+    '  do not send external messages (C4 send/control scripts are denied), do not modify',
+    '  anything outside your task scope.',
+    `- Delivery dir: ${worker.deliveryDir}`,
+    '- Checkpoint requirement: continuously checkpoint progress into the delivery dir',
+    '  (notes, partial results, final artifacts). Teammates are NOT resumable — if you',
+    '  die, the delivery dir is the only surviving context for reassignment.',
+    '- On completion: write a result summary to <delivery dir>/RESULT.md, then report',
+    '  back to the lead.',
+    '',
+    '## Down-scoping (enforced, do not work around)',
+    `- Your working directory's project settings (${settingsPathFor(projectDir || process.cwd())})`,
+    '  deny Write/Edit on zylos memory and Bash on C4 send/control scripts.',
+    `- Registry entry: ${worker.id} (status updates handled by the lead).`,
+    '',
+    '--- END TEAMMATE TASK PROMPT ---',
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Prepare a delegation: enforce the cap, create the delivery dir, register
+ * the worker, return { worker, prompt }.
+ */
+export function delegatePrep(taskSlug, { task, team, teammate, projectDir, registryPath = REGISTRY_PATH, deliveriesDir = DELIVERIES_DIR } = {}) {
+  const active = activeWorkers(registryPath);
+  if (active.length >= MAX_ACTIVE_WORKERS) {
+    const err = new Error(
+      `Concurrency cap reached (${active.length}/${MAX_ACTIVE_WORKERS} active workers: ` +
+        `${active.map((w) => w.id).join(', ')}). Harvest or accept existing workers first.`
+    );
+    err.code = 'CAP_REACHED';
+    throw err;
+  }
+  const slug = slugify(taskSlug);
+  const deliveryDir = path.join(deliveriesDir, `${isoDate()}-${slug}`);
+  fs.mkdirSync(deliveryDir, { recursive: true });
+  const worker = addWorker(
+    {
+      task: task || taskSlug,
+      team: team || null,
+      teammate: teammate || null,
+      deliveryDir,
+      status: 'pending',
+    },
+    registryPath
+  );
+  return { worker, prompt: renderPrompt(worker, { projectDir }) };
+}
+
+/**
+ * Harvest report: in-flight (pending/running/done-unaccepted) workers.
+ * Used by the molt procedure — "harvest before molt".
+ */
+export function harvest(registryPath = REGISTRY_PATH) {
+  const workers = inFlightWorkers(registryPath);
+  return { clean: workers.length === 0, workers };
+}
+
+/** Accept a completed worker's delivery. */
+export function accept(id, { resultSummary } = {}, registryPath = REGISTRY_PATH) {
+  const fields = { status: 'accepted' };
+  if (resultSummary) fields.resultSummary = resultSummary;
+  return updateWorker(id, fields, registryPath);
+}
+
+/**
+ * Mark a worker failed. With reassign=true, also create a successor entry
+ * linked to the same delivery dir (teammates are not resumable; reassignment
+ * at task granularity is the recovery path).
+ */
+export function fail(id, { reassign = false, resultSummary } = {}, registryPath = REGISTRY_PATH) {
+  const worker = getWorker(id, registryPath);
+  if (!worker) throw new Error(`Worker not found: ${id}`);
+  const failed = updateWorker(
+    id,
+    { status: reassign ? 'reassigned' : 'failed', ...(resultSummary ? { resultSummary } : {}) },
+    registryPath
+  );
+  let successor = null;
+  if (reassign) {
+    successor = addWorker(
+      {
+        task: worker.task,
+        team: worker.team,
+        teammate: null,
+        deliveryDir: worker.deliveryDir,
+        status: 'pending',
+        predecessorId: worker.id,
+      },
+      registryPath
+    );
+  }
+  return { failed, successor };
+}

--- a/skills/multi-session/scripts/adapter.js
+++ b/skills/multi-session/scripts/adapter.js
@@ -151,7 +151,7 @@ export function renderPrompt(worker, { projectDir } = {}) {
  * Prepare a delegation: enforce the cap, create the delivery dir, register
  * the worker, return { worker, prompt }.
  */
-export function delegatePrep(taskSlug, { task, team, teammate, projectDir, registryPath = REGISTRY_PATH, deliveriesDir = DELIVERIES_DIR } = {}) {
+export function delegatePrep(taskSlug, { task, team, teammate, projectDir, registryPath = REGISTRY_PATH, deliveriesDir = DELIVERIES_DIR, zylosDir = ZYLOS_DIR } = {}) {
   const active = activeWorkers(registryPath);
   if (active.length >= MAX_ACTIVE_WORKERS) {
     const err = new Error(
@@ -160,6 +160,16 @@ export function delegatePrep(taskSlug, { task, team, teammate, projectDir, regis
     );
     err.code = 'CAP_REACHED';
     throw err;
+  }
+  if (projectDir) {
+    const guard = checkGuardrails(projectDir, zylosDir);
+    if (!guard.ok) {
+      const err = new Error(
+        `Guardrails missing for ${projectDir}: ${guard.problems.join('; ')}. Run write-guardrails first.`
+      );
+      err.code = 'GUARDRAILS_MISSING';
+      throw err;
+    }
   }
   const slug = slugify(taskSlug);
   const deliveryDir = path.join(deliveriesDir, `${isoDate()}-${slug}`);

--- a/skills/multi-session/scripts/cli.js
+++ b/skills/multi-session/scripts/cli.js
@@ -241,5 +241,5 @@ try {
   main();
 } catch (err) {
   console.error(`Error: ${err.message}`);
-  process.exit(err.code === 'CAP_REACHED' ? 2 : 1);
+  process.exit(err.code === 'CAP_REACHED' ? 2 : err.code === 'GUARDRAILS_MISSING' ? 3 : 1);
 }

--- a/skills/multi-session/scripts/cli.js
+++ b/skills/multi-session/scripts/cli.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Multi-Session CLI
+ * Registry CRUD + team adapter commands for the delegation lifecycle.
+ */
+
+import {
+  REGISTRY_PATH,
+  MAX_ACTIVE_WORKERS,
+  addWorker,
+  getWorker,
+  updateWorker,
+  listWorkers,
+  activeWorkers,
+} from './registry.js';
+import {
+  delegatePrep,
+  harvest,
+  accept,
+  fail,
+  writeGuardrails,
+  checkGuardrails,
+  denyRules,
+} from './adapter.js';
+
+const HELP = `
+Multi-Session CLI - Worker registry + team adapter (phase 1)
+
+Usage: ~/zylos/.claude/skills/multi-session/scripts/cli.js <command> [options]
+
+Registry commands:
+  list [--status <s,s>]        List workers (optionally filtered by status)
+  get <worker-id>              Show one worker as JSON
+  active                       List workers counting against the cap (max ${MAX_ACTIVE_WORKERS})
+  add <task> [options]         Add a raw registry entry (prefer delegate-prep)
+  update <worker-id> [options] Update fields of a worker
+  done <worker-id> [--summary "<text>"]    Mark worker done (awaiting acceptance)
+
+Adapter commands:
+  delegate-prep <task-slug> [--task "<desc>"] [--team <name>] [--teammate <name>] [--project-dir <dir>]
+                               Create delivery dir, register worker, print teammate prompt.
+                               Refuses when ${MAX_ACTIVE_WORKERS} workers are already active.
+  accept <worker-id> [--summary "<text>"]   Accept a worker's delivery
+  fail <worker-id> [--reassign] [--summary "<text>"]
+                               Mark failed; --reassign creates a successor entry
+                               linked to the same delivery dir
+  harvest                      List in-flight (pending/running/unaccepted) workers.
+                               Exit code 1 if any exist — run before molt.
+  check-guardrails [--project-dir <dir>]    Verify the teammate deny block in
+                               <dir>/.claude/settings.json (default: cwd)
+  write-guardrails [--project-dir <dir>]    Install/merge the deny block
+
+Options:
+  --team "<name>"        Agent team name
+  --teammate "<name>"    Teammate name
+  --task "<desc>"        Full zylos task description
+  --status <status>      pending|running|done|accepted|failed|reassigned
+  --summary "<text>"     Result summary
+  --usage "<text>"       Usage notes (token/window consumption)
+  --delivery-dir <dir>   Delivery directory path
+
+Registry: ${REGISTRY_PATH}
+`;
+
+function parseArgs(argv) {
+  const result = { command: argv[0] || null, args: [], options: {} };
+  const BOOLEAN_FLAGS = new Set(['reassign']);
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      if (BOOLEAN_FLAGS.has(key) || i + 1 >= argv.length || argv[i + 1].startsWith('--')) {
+        result.options[key] = true;
+      } else {
+        result.options[key] = argv[++i];
+      }
+    } else {
+      result.args.push(arg);
+    }
+  }
+  return result;
+}
+
+function fmtTs(ts) {
+  return ts ? new Date(ts * 1000).toISOString() : '-';
+}
+
+function printWorker(w) {
+  console.log(`${w.id}  [${w.status}]  ${w.task}`);
+  console.log(`  team=${w.team || '-'} teammate=${w.teammate || '-'}`);
+  console.log(`  delivery=${w.deliveryDir || '-'}`);
+  console.log(`  created=${fmtTs(w.createdAt)} updated=${fmtTs(w.updatedAt)}`);
+  if (w.predecessorId) console.log(`  predecessor=${w.predecessorId}`);
+  if (w.usage) console.log(`  usage=${w.usage}`);
+  if (w.resultSummary) console.log(`  result=${w.resultSummary}`);
+}
+
+function main() {
+  const { command, args, options } = parseArgs(process.argv.slice(2));
+
+  switch (command) {
+    case 'list': {
+      const statuses = options.status ? options.status.split(',') : undefined;
+      const workers = listWorkers({ statuses });
+      if (workers.length === 0) {
+        console.log('No workers.');
+        return;
+      }
+      workers.forEach(printWorker);
+      return;
+    }
+    case 'get': {
+      if (!args[0]) throw new Error('Usage: get <worker-id>');
+      const worker = getWorker(args[0]);
+      if (!worker) {
+        console.error(`Worker not found: ${args[0]}`);
+        process.exit(1);
+      }
+      console.log(JSON.stringify(worker, null, 2));
+      return;
+    }
+    case 'active': {
+      const workers = activeWorkers();
+      console.log(`${workers.length}/${MAX_ACTIVE_WORKERS} active workers`);
+      workers.forEach(printWorker);
+      return;
+    }
+    case 'add': {
+      if (!args[0]) throw new Error('Usage: add <task> [options]');
+      const worker = addWorker({
+        task: args[0],
+        team: options.team,
+        teammate: options.teammate,
+        deliveryDir: options['delivery-dir'],
+        status: options.status,
+        usage: options.usage,
+      });
+      console.log(`Added ${worker.id}`);
+      return;
+    }
+    case 'update': {
+      if (!args[0]) throw new Error('Usage: update <worker-id> [options]');
+      const fields = {};
+      if (options.team) fields.team = options.team;
+      if (options.teammate) fields.teammate = options.teammate;
+      if (options.task) fields.task = options.task;
+      if (options.status) fields.status = options.status;
+      if (options.usage) fields.usage = options.usage;
+      if (options.summary) fields.resultSummary = options.summary;
+      if (options['delivery-dir']) fields.deliveryDir = options['delivery-dir'];
+      if (Object.keys(fields).length === 0) throw new Error('No fields to update');
+      const worker = updateWorker(args[0], fields);
+      console.log(`Updated ${worker.id} [${worker.status}]`);
+      return;
+    }
+    case 'done': {
+      if (!args[0]) throw new Error('Usage: done <worker-id> [--summary "<text>"]');
+      const fields = { status: 'done' };
+      if (options.summary) fields.resultSummary = options.summary;
+      const worker = updateWorker(args[0], fields);
+      console.log(`Worker ${worker.id} marked done (awaiting acceptance).`);
+      return;
+    }
+    case 'delegate-prep': {
+      if (!args[0]) throw new Error('Usage: delegate-prep <task-slug> [options]');
+      const { worker, prompt } = delegatePrep(args[0], {
+        task: options.task,
+        team: options.team,
+        teammate: options.teammate,
+        projectDir: options['project-dir'],
+      });
+      console.log(`Registered ${worker.id}`);
+      console.log(`Delivery dir: ${worker.deliveryDir}`);
+      console.log('');
+      console.log(prompt);
+      return;
+    }
+    case 'accept': {
+      if (!args[0]) throw new Error('Usage: accept <worker-id> [--summary "<text>"]');
+      const worker = accept(args[0], { resultSummary: options.summary });
+      console.log(`Worker ${worker.id} accepted.`);
+      return;
+    }
+    case 'fail': {
+      if (!args[0]) throw new Error('Usage: fail <worker-id> [--reassign] [--summary "<text>"]');
+      const { failed, successor } = fail(args[0], {
+        reassign: !!options.reassign,
+        resultSummary: options.summary,
+      });
+      console.log(`Worker ${failed.id} marked ${failed.status}.`);
+      if (successor) {
+        console.log(`Successor ${successor.id} created (same delivery dir: ${successor.deliveryDir}).`);
+      }
+      return;
+    }
+    case 'harvest': {
+      const { clean, workers } = harvest();
+      if (clean) {
+        console.log('Harvest clean: no in-flight workers. Safe to molt.');
+        return;
+      }
+      console.log(`${workers.length} in-flight worker(s) — harvest before molt:`);
+      workers.forEach(printWorker);
+      process.exit(1);
+      return;
+    }
+    case 'check-guardrails': {
+      const dir = options['project-dir'] || process.cwd();
+      const { ok, problems } = checkGuardrails(dir);
+      if (ok) {
+        console.log(`Guardrails OK in ${dir}/.claude/settings.json`);
+        return;
+      }
+      console.error(`Guardrails check FAILED for ${dir}:`);
+      problems.forEach((p) => console.error(`  - ${p}`));
+      console.error('Fix with: cli.js write-guardrails --project-dir ' + dir);
+      process.exit(1);
+      return;
+    }
+    case 'write-guardrails': {
+      const dir = options['project-dir'] || process.cwd();
+      const settingsPath = writeGuardrails(dir);
+      console.log(`Deny block written to ${settingsPath}:`);
+      denyRules().forEach((r) => console.log(`  - ${r}`));
+      return;
+    }
+    case 'help':
+    case '--help':
+    case undefined:
+    case null:
+      console.log(HELP);
+      return;
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.log(HELP);
+      process.exit(1);
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(err.code === 'CAP_REACHED' ? 2 : 1);
+}

--- a/skills/multi-session/scripts/registry.js
+++ b/skills/multi-session/scripts/registry.js
@@ -1,0 +1,149 @@
+/**
+ * Multi-Session Worker Registry
+ *
+ * Persistent JSON store mapping agent-teams workers (teammates) to zylos
+ * tasks, delivery directories, status, and usage notes. Survives main-session
+ * molt (/clear) — the registry is the source of truth for "what work was
+ * delegated and where the artifacts live".
+ *
+ * Data goes to ~/zylos/multi-session/, code stays in skills directory.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+export const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
+export const DATA_DIR = path.join(ZYLOS_DIR, 'multi-session');
+export const REGISTRY_PATH = path.join(DATA_DIR, 'registry.json');
+export const DELIVERIES_DIR = path.join(DATA_DIR, 'deliveries');
+
+/** All valid worker statuses. */
+export const STATUSES = ['pending', 'running', 'done', 'accepted', 'failed', 'reassigned'];
+
+/** Statuses that count against the concurrency cap (worker may be consuming a teammate slot). */
+export const ACTIVE_STATUSES = ['pending', 'running'];
+
+/** Statuses considered "in flight" for harvest purposes: not yet accepted/closed. */
+export const IN_FLIGHT_STATUSES = ['pending', 'running', 'done'];
+
+/** Hard cap on concurrent workers (prior decision 2026-06-09; v2.1 §3). */
+export const MAX_ACTIVE_WORKERS = 2;
+
+export function generateId() {
+  return `worker-${Date.now().toString(36)}-${crypto.randomBytes(3).toString('hex')}`;
+}
+
+export function now() {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Load the registry. Returns { workers: [] } when the file does not exist.
+ * Throws on corrupt JSON (fail loudly rather than silently dropping records).
+ */
+export function loadRegistry(registryPath = REGISTRY_PATH) {
+  if (!fs.existsSync(registryPath)) {
+    return { workers: [] };
+  }
+  const raw = fs.readFileSync(registryPath, 'utf8');
+  const data = JSON.parse(raw);
+  if (!data || !Array.isArray(data.workers)) {
+    throw new Error(`Corrupt registry at ${registryPath}: missing "workers" array`);
+  }
+  return data;
+}
+
+/**
+ * Atomically persist the registry: write to a temp file in the same
+ * directory, then rename over the target. A crash mid-write can never leave
+ * a truncated registry.json behind.
+ */
+export function saveRegistry(data, registryPath = REGISTRY_PATH) {
+  const dir = path.dirname(registryPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.registry-${process.pid}-${crypto.randomBytes(3).toString('hex')}.tmp`);
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmp, registryPath);
+}
+
+function assertStatus(status) {
+  if (!STATUSES.includes(status)) {
+    throw new Error(`Invalid status "${status}". Valid: ${STATUSES.join(', ')}`);
+  }
+}
+
+/**
+ * Add a worker entry. Required: task (description). Optional: team,
+ * teammate, deliveryDir, status (default "pending"), usage, resultSummary,
+ * predecessorId (set when reassigning).
+ */
+export function addWorker(fields, registryPath = REGISTRY_PATH) {
+  if (!fields || !fields.task) {
+    throw new Error('addWorker requires a "task" description');
+  }
+  const status = fields.status || 'pending';
+  assertStatus(status);
+  const ts = now();
+  const worker = {
+    id: fields.id || generateId(),
+    team: fields.team || null,
+    teammate: fields.teammate || null,
+    task: fields.task,
+    deliveryDir: fields.deliveryDir || null,
+    status,
+    createdAt: ts,
+    updatedAt: ts,
+    usage: fields.usage || null,
+    resultSummary: fields.resultSummary || null,
+    predecessorId: fields.predecessorId || null,
+  };
+  const data = loadRegistry(registryPath);
+  if (data.workers.some((w) => w.id === worker.id)) {
+    throw new Error(`Worker id already exists: ${worker.id}`);
+  }
+  data.workers.push(worker);
+  saveRegistry(data, registryPath);
+  return worker;
+}
+
+export function getWorker(id, registryPath = REGISTRY_PATH) {
+  return loadRegistry(registryPath).workers.find((w) => w.id === id) || null;
+}
+
+const UPDATABLE_FIELDS = new Set(['team', 'teammate', 'task', 'deliveryDir', 'status', 'usage', 'resultSummary']);
+
+export function updateWorker(id, fields, registryPath = REGISTRY_PATH) {
+  const data = loadRegistry(registryPath);
+  const worker = data.workers.find((w) => w.id === id);
+  if (!worker) {
+    throw new Error(`Worker not found: ${id}`);
+  }
+  for (const [key, value] of Object.entries(fields)) {
+    if (!UPDATABLE_FIELDS.has(key)) {
+      throw new Error(`Field not updatable: ${key}`);
+    }
+    if (key === 'status') assertStatus(value);
+    worker[key] = value;
+  }
+  worker.updatedAt = now();
+  saveRegistry(data, registryPath);
+  return worker;
+}
+
+export function listWorkers({ statuses } = {}, registryPath = REGISTRY_PATH) {
+  const workers = loadRegistry(registryPath).workers;
+  if (!statuses) return workers;
+  return workers.filter((w) => statuses.includes(w.status));
+}
+
+/** Workers currently counting against the concurrency cap. */
+export function activeWorkers(registryPath = REGISTRY_PATH) {
+  return listWorkers({ statuses: ACTIVE_STATUSES }, registryPath);
+}
+
+/** Workers not yet accepted/closed — must be harvested before molt. */
+export function inFlightWorkers(registryPath = REGISTRY_PATH) {
+  return listWorkers({ statuses: IN_FLIGHT_STATUSES }, registryPath);
+}


### PR DESCRIPTION
Phase 1 of the multi-session runtime (design doc v2.1, approved by linfan 2026-06-12): delegate bounded work to agent-teams teammates while the main interactive session stays untouched.

## What's included
- **Session registry** (`skills/multi-session/scripts/registry.js`): persistent JSON store at `~/zylos/multi-session/registry.json`, atomic temp+rename writes, full CRUD CLI.
- **Team adapter** (`scripts/adapter.js`, `scripts/cli.js`): `delegate-prep` (creates delivery dir, registers worker, renders teammate task prompt; enforces hard cap N=2; refuses if guardrails missing — exit 3), `harvest` (exit 1 on in-flight workers; for harvest-before-molt), `accept` / `fail --reassign`, `write-guardrails` / `check-guardrails` (teammate permission deny block; absolute paths use the spike-verified `//` prefix — single-slash rules are flagged as broken).
- **SKILL.md**: delegation lifecycle, lead-lifecycle coupling caveat (teammates die with lead — spike-verified), explicit-budget rule for headless `-p`.
- **Tests**: 38 new node:test cases (registry CRUD/atomicity, cap, harvest exit codes, guardrails, CLI). Full suite green: jest 92/92, node:test 509/509.

## Explicitly out of scope (phase 1 = pure additive)
C4 comm-bridge, activity-monitor, scheduler, runtime switching — zero changes. Rollback = stop using the skill; no daemons, no schema changes.

## References
- Design doc v2.1: workspace/zylos-design-docs/multi-session-runtime-proposal-v2.1.md (HTML: https://zylosvoya.jinglever.com/multi-session-runtime-v21-20260612.html)
- Agent-teams spike findings (2026-06-12): flag+tools OK on 2.1.173; teammates inherit project deny rules; teammates terminate with lead, no orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)