### PR TITLE
fix: auto-retry GitHub API calls on rate limiting in zylos add/upgrade (#632)

### DIFF
--- a/cli/lib/__tests__/github-rate-limit.test.js
+++ b/cli/lib/__tests__/github-rate-limit.test.js
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+const origEnv = {};
+for (const key of ['ZYLOS_GH_RETRY_DELAY_MS', 'GITHUB_TOKEN', 'GH_TOKEN', 'PATH']) {
+  origEnv[key] = process.env[key];
+}
+const tmpDirs = [];
+
+const { isRateLimitError, withRateLimitRetrySync, withRateLimitRetryAsync, fetchRawFile } =
+  await import('../github.js');
+
+beforeEach(() => {
+  // Fast retries so tests don't sleep for real
+  process.env.ZYLOS_GH_RETRY_DELAY_MS = '10,10';
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(origEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function curlError(status) {
+  const err = new Error('Command failed: curl -fsSL https://api.github.com/repos/org/repo/tags');
+  err.stderr = `curl: (22) The requested URL returned error: ${status}`;
+  return err;
+}
+
+describe('isRateLimitError', () => {
+  it('matches curl 403 failures', () => {
+    assert.equal(isRateLimitError(curlError('403')), true);
+  });
+
+  it('matches curl 429 failures', () => {
+    assert.equal(isRateLimitError(curlError('429')), true);
+  });
+
+  it('matches older curl messages with status text', () => {
+    assert.equal(isRateLimitError(curlError('403 Forbidden')), true);
+  });
+
+  it('rejects other HTTP errors', () => {
+    assert.equal(isRateLimitError(curlError('404')), false);
+    assert.equal(isRateLimitError(curlError('500')), false);
+  });
+
+  it('rejects network errors without an HTTP status', () => {
+    const err = new Error('Command failed: curl');
+    err.stderr = 'curl: (6) Could not resolve host: api.github.com';
+    assert.equal(isRateLimitError(err), false);
+  });
+
+  it('rejects status digits appearing elsewhere (e.g. in URLs)', () => {
+    const err = new Error('Command failed: curl https://api.github.com/repos/org/repo-403/tags');
+    err.stderr = 'curl: (22) The requested URL returned error: 404';
+    assert.equal(isRateLimitError(err), false);
+  });
+});
+
+describe('withRateLimitRetrySync', () => {
+  it('returns immediately on first success without retrying', () => {
+    let calls = 0;
+    const result = withRateLimitRetrySync(() => { calls++; return 'ok'; }, 'test');
+    assert.equal(result, 'ok');
+    assert.equal(calls, 1);
+  });
+
+  it('retries rate-limit failures and succeeds on a later attempt', () => {
+    let calls = 0;
+    const result = withRateLimitRetrySync(() => {
+      calls++;
+      if (calls < 3) throw curlError('403');
+      return 'recovered';
+    }, 'test');
+    assert.equal(result, 'recovered');
+    assert.equal(calls, 3);
+  });
+
+  it('gives up after 2 retries (3 attempts total)', () => {
+    let calls = 0;
+    assert.throws(
+      () => withRateLimitRetrySync(() => { calls++; throw curlError('429'); }, 'test'),
+      err => /returned error: 429/.test(err.stderr)
+    );
+    assert.equal(calls, 3);
+  });
+
+  it('does not retry non-rate-limit failures', () => {
+    let calls = 0;
+    assert.throws(
+      () => withRateLimitRetrySync(() => { calls++; throw curlError('404'); }, 'test'),
+      err => /returned error: 404/.test(err.stderr)
+    );
+    assert.equal(calls, 1);
+  });
+
+  it('disables retries when ZYLOS_GH_RETRY_DELAY_MS is empty', () => {
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '';
+    let calls = 0;
+    assert.throws(
+      () => withRateLimitRetrySync(() => { calls++; throw curlError('403'); }, 'test'),
+      err => /returned error: 403/.test(err.stderr)
+    );
+    assert.equal(calls, 1);
+  });
+});
+
+describe('withRateLimitRetryAsync', () => {
+  it('retries rate-limit failures and succeeds on a later attempt', async () => {
+    let calls = 0;
+    const result = await withRateLimitRetryAsync(async () => {
+      calls++;
+      if (calls < 2) throw curlError('403');
+      return 'recovered';
+    }, 'test');
+    assert.equal(result, 'recovered');
+    assert.equal(calls, 2);
+  });
+
+  it('gives up after 2 retries (3 attempts total)', async () => {
+    let calls = 0;
+    await assert.rejects(
+      withRateLimitRetryAsync(async () => { calls++; throw curlError('403'); }, 'test'),
+      err => /returned error: 403/.test(err.stderr)
+    );
+    assert.equal(calls, 3);
+  });
+
+  it('does not retry non-rate-limit failures', async () => {
+    let calls = 0;
+    await assert.rejects(
+      withRateLimitRetryAsync(async () => { calls++; throw curlError('500'); }, 'test'),
+      err => /returned error: 500/.test(err.stderr)
+    );
+    assert.equal(calls, 1);
+  });
+});
+
+describe('fetchRawFile wiring (fake curl on PATH)', () => {
+  function installFakeCurl({ failuresBeforeSuccess, status }) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-fake-curl-'));
+    tmpDirs.push(dir);
+    const stateFile = path.join(dir, 'calls');
+    const script = `#!/bin/sh
+n=$(cat "${stateFile}" 2>/dev/null || echo 0)
+n=$((n+1))
+echo $n > "${stateFile}"
+if [ $n -le ${failuresBeforeSuccess} ]; then
+  echo "curl: (22) The requested URL returned error: ${status}" >&2
+  exit 22
+fi
+echo "file-content"
+`;
+    const curlPath = path.join(dir, 'curl');
+    fs.writeFileSync(curlPath, script, { mode: 0o755 });
+    process.env.PATH = `${dir}${path.delimiter}${process.env.PATH}`;
+    return {
+      calls: () => Number(fs.readFileSync(stateFile, 'utf8').trim()),
+    };
+  }
+
+  it('recovers when rate limiting clears within the retry budget', () => {
+    // Token present: each operation attempt = public + authenticated call.
+    // Attempt 1 (calls 1-2) is fully rate limited; the retry's public
+    // call (call 3) succeeds.
+    process.env.GITHUB_TOKEN = 'test-token';
+    const fake = installFakeCurl({ failuresBeforeSuccess: 2, status: '403' });
+    const content = fetchRawFile('org/repo', 'SKILL.md');
+    assert.equal(content.trim(), 'file-content');
+    assert.equal(fake.calls(), 3);
+  });
+
+  it('fails fast on non-rate-limit errors', () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    const fake = installFakeCurl({ failuresBeforeSuccess: 99, status: '404' });
+    assert.throws(() => fetchRawFile('org/repo', 'SKILL.md'));
+    // public + authenticated within the single attempt, no retries
+    assert.equal(fake.calls(), 2);
+  });
+});

--- a/cli/lib/download.js
+++ b/cli/lib/download.js
@@ -7,7 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import os from 'node:os';
-import { getGitHubToken, sanitizeError } from './github.js';
+import { getGitHubToken, sanitizeError, withRateLimitRetrySync } from './github.js';
 import { copyTree } from './fs-utils.js';
 
 function getWritableTmpBase() {
@@ -32,6 +32,7 @@ function createDownloadTmpDir() {
  * Tries the public endpoint first (works for public repos without auth),
  * then falls back to the authenticated GitHub API if a token is available.
  * This avoids 403 errors when a token lacks org access for public repos.
+ * Retries with backoff on GitHub rate limiting.
  *
  * @param {string} repo - GitHub repo in "org/name" format
  * @param {string} ref - Git ref (tag name or branch name)
@@ -39,6 +40,13 @@ function createDownloadTmpDir() {
  * @param {string} tarballPath - Destination file path for the tarball
  */
 function curlDownload(repo, ref, refType, tarballPath) {
+  withRateLimitRetrySync(
+    () => curlDownloadOnce(repo, ref, refType, tarballPath),
+    `${repo}@${ref}`
+  );
+}
+
+function curlDownloadOnce(repo, ref, refType, tarballPath) {
   // 1. Try public endpoint first (no auth needed for public repos)
   const publicUrl = refType === 'tag'
     ? `https://github.com/${repo}/archive/refs/tags/${ref}.tar.gz`

--- a/cli/lib/github.js
+++ b/cli/lib/github.js
@@ -44,10 +44,105 @@ export function getGitHubToken() {
   return null;
 }
 
+// ── Rate-limit aware retry ───────────────────────────────────────
+
+// curl -f reports HTTP errors as "The requested URL returned error: NNN".
+// GitHub signals its primary rate limit with 403 and the secondary
+// (abuse) limit with 429.
+const RATE_LIMIT_STATUS_RE = /returned error:?\s+(403|429)\b/;
+const DEFAULT_RETRY_DELAYS_MS = [15000, 45000];
+
+/**
+ * Check whether a curl child-process error looks like GitHub rate limiting.
+ * Heuristic: with -f the response body is discarded, so the HTTP status in
+ * curl's stderr is the only signal. A 403 can also be a permission denial,
+ * in which case the retries add a bounded delay before the same failure.
+ *
+ * @param {Error} err - Error thrown by execFileSync/execFile for a curl call
+ * @returns {boolean}
+ */
+export function isRateLimitError(err) {
+  const text = [err?.stderr?.toString?.(), err?.message]
+    .filter(Boolean)
+    .join('\n');
+  return RATE_LIMIT_STATUS_RE.test(text);
+}
+
+/**
+ * Retry delays between attempts, in ms. Overridable via
+ * ZYLOS_GH_RETRY_DELAY_MS (comma-separated, e.g. "1000,5000";
+ * empty string disables retries) — used by tests and tunable in ops.
+ */
+function retryDelaysMs() {
+  const env = process.env.ZYLOS_GH_RETRY_DELAY_MS;
+  if (env === undefined) return DEFAULT_RETRY_DELAYS_MS;
+  return env
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s !== '')
+    .map(Number)
+    .filter(n => Number.isFinite(n) && n >= 0);
+}
+
+function notifyRetry(label, attempt, total, delayMs) {
+  // stderr on purpose: `zylos upgrade --json` reserves stdout for JSON
+  console.error(
+    `GitHub rate limited (${label}) — retrying in ${Math.round(delayMs / 1000)}s (attempt ${attempt}/${total})...`
+  );
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Run an operation, retrying when it fails with a GitHub rate-limit
+ * signature. The operation should contain its full fallback chain
+ * (public endpoint → authenticated API), so a rate-limited public call
+ * still falls through to the authenticated endpoint before any sleep.
+ * Non-rate-limit failures are rethrown immediately.
+ *
+ * @param {Function} fn - Operation to run
+ * @param {string} label - Human-readable label for the retry notice
+ * @returns {*} The operation's return value
+ */
+export function withRateLimitRetrySync(fn, label) {
+  const delays = retryDelaysMs();
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return fn();
+    } catch (err) {
+      if (attempt >= delays.length || !isRateLimitError(err)) throw err;
+      notifyRetry(label, attempt + 1, delays.length, delays[attempt]);
+      sleepSync(delays[attempt]);
+    }
+  }
+}
+
+/**
+ * Async flavor of withRateLimitRetrySync.
+ *
+ * @param {Function} fn - Async operation to run
+ * @param {string} label - Human-readable label for the retry notice
+ * @returns {Promise<*>} The operation's resolved value
+ */
+export async function withRateLimitRetryAsync(fn, label) {
+  const delays = retryDelaysMs();
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= delays.length || !isRateLimitError(err)) throw err;
+      notifyRetry(label, attempt + 1, delays.length, delays[attempt]);
+      await new Promise(resolve => setTimeout(resolve, delays[attempt]));
+    }
+  }
+}
+
 /**
  * Fetch raw file content from a GitHub repo.
  * Tries public endpoint first, falls back to authenticated GitHub API
- * for private repos.
+ * for private repos. Retries with backoff on GitHub rate limiting.
  *
  * @param {string} repo - GitHub repo in "org/name" format
  * @param {string} filePath - Path to file in the repo (e.g. "SKILL.md")
@@ -56,6 +151,13 @@ export function getGitHubToken() {
  * @throws {Error} If fetch fails
  */
 export function fetchRawFile(repo, filePath, branch = 'main') {
+  return withRateLimitRetrySync(
+    () => fetchRawFileOnce(repo, filePath, branch),
+    `${repo}/${filePath}`
+  );
+}
+
+function fetchRawFileOnce(repo, filePath, branch) {
   // 1. Try public endpoint first
   const publicUrl = `https://raw.githubusercontent.com/${repo}/${branch}/${filePath}`;
   try {
@@ -190,7 +292,8 @@ async function fetchTagsJsonAsync(repo) {
  */
 export function fetchLatestTag(repo, { includePrerelease = false } = {}) {
   try {
-    return parseTagsResponse(fetchTagsJsonSync(repo), { includePrerelease });
+    const json = withRateLimitRetrySync(() => fetchTagsJsonSync(repo), `${repo} tags`);
+    return parseTagsResponse(json, { includePrerelease });
   } catch (err) {
     const msg = err.stderr?.toString().trim() || err.message || 'unknown error';
     throw new Error(`Failed to fetch tags for ${repo}: ${sanitizeError(msg)}`);
@@ -210,7 +313,8 @@ export function fetchLatestTag(repo, { includePrerelease = false } = {}) {
  */
 export async function fetchLatestTagAsync(repo, { includePrerelease = false } = {}) {
   try {
-    return parseTagsResponse(await fetchTagsJsonAsync(repo), { includePrerelease });
+    const json = await withRateLimitRetryAsync(() => fetchTagsJsonAsync(repo), `${repo} tags`);
+    return parseTagsResponse(json, { includePrerelease });
   } catch (err) {
     const msg = err.stderr?.toString().trim() || err.message || 'unknown error';
     throw new Error(`Failed to fetch tags for ${repo}: ${sanitizeError(msg)}`);


### PR DESCRIPTION
## Summary
- New `withRateLimitRetrySync/Async` helpers in `cli/lib/github.js`: when a GitHub call fails with a rate-limit signature (curl-reported HTTP 403/429), retry up to 2 times with 15s/45s waits and a stderr notice (stderr so `zylos upgrade --json` stdout stays clean). Non-rate-limit failures rethrow immediately — no behavior change.
- Wired into every GitHub path `zylos add`/`zylos upgrade` uses: `fetchRawFile` (SKILL.md fetch), `fetchLatestTag`/`fetchLatestTagAsync` (tags listing), and `curlDownload` (tarball download).
- The retry wraps each operation's **whole** public→authenticated fallback chain, so a rate-limited public call still falls through to the authenticated endpoint *before* any sleep (a token-holding instance never waits needlessly).
- Delays overridable via `ZYLOS_GH_RETRY_DELAY_MS` (comma-separated; empty disables) for tests and ops tuning.

## Notes for review
- Detection is a stderr heuristic (`returned error: 403|429`) because `curl -f` discards the response body/headers. A genuine 403 permission denial would also retry — bounded cost (~60s worst case) on an already-failing path; called out in code comments.
- Sync sleep uses `Atomics.wait` (no child process, no event-loop spin).

## Verification
- 16 new tests in `cli/lib/__tests__/github-rate-limit.test.js`: detection matrix (403/429/404/500/network/digits-in-URL), sync+async retry semantics (success-first, recover-on-retry, exhaust-after-2, fail-fast on non-rate-limit, env disable), plus end-to-end `fetchRawFile` wiring through a fake `curl` shim on PATH (recovers at call 3; non-rate-limit fails fast at 2 calls).
- Full suite: Jest 82/82, node tests 487/487.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)