### PR TITLE
fix: runtime auth checks key off explicit signals, not exit codes (Claude + Codex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Claude init auth check**: `isClaudeAuthenticated()` now keys off the explicit `loggedIn` field from `claude auth status --json` instead of the process exit code. The exit code conflated "not logged in" with crashes, timeouts, and cross-version subcommand drift; the new check reads the unambiguous field and treats any unparseable payload as not authenticated. Extracted a pure, unit-tested `parseClaudeAuthStatus()` helper. Local-only — no network call. (#641)
+- **Codex auth false-pass (security)**: `codex login status` exits `0` in **both** the "Logged in using …" and "Not logged in" states, so keying off its exit code reported a logged-out OAuth/ChatGPT session as authenticated. This false-pass affected both `isCodexAuthenticated()` (init) and the `CodexAdapter.checkAuth()` gate used by runtime-switch and the health probe — i.e. a runtime switch into an unauthenticated Codex could pass the auth check and leave the agent unreachable. Both now parse the status text (the line is emitted on **stderr**) via a shared, unit-tested `parseCodexLoginStatus()` and fail closed on anything ambiguous. Pure parsers moved to a dependency-free `cli/lib/auth-parsers.js`. (#641)
 
 ## [0.5.2] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **Claude init auth check**: `isClaudeAuthenticated()` now keys off the explicit `loggedIn` field from `claude auth status --json` instead of the process exit code. The exit code conflated "not logged in" with crashes, timeouts, and cross-version subcommand drift; the new check reads the unambiguous field and treats any unparseable payload as not authenticated. Extracted a pure, unit-tested `parseClaudeAuthStatus()` helper. Local-only — no network call. (#641)
-- **Codex auth false-pass (security)**: `codex login status` exits `0` in **both** the "Logged in using …" and "Not logged in" states, so keying off its exit code reported a logged-out OAuth/ChatGPT session as authenticated. This false-pass affected both `isCodexAuthenticated()` (init) and the `CodexAdapter.checkAuth()` gate used by runtime-switch and the health probe — i.e. a runtime switch into an unauthenticated Codex could pass the auth check and leave the agent unreachable. Both now parse the status text (the line is emitted on **stderr**) via a shared, unit-tested `parseCodexLoginStatus()` and fail closed on anything ambiguous. Pure parsers moved to a dependency-free `cli/lib/auth-parsers.js`. (#641)
-
 ## [0.5.2] - 2026-06-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Claude init auth check**: `isClaudeAuthenticated()` now keys off the explicit `loggedIn` field from `claude auth status --json` instead of the process exit code. The exit code conflated "not logged in" with crashes, timeouts, and cross-version subcommand drift; the new check reads the unambiguous field and treats any unparseable payload as not authenticated. Extracted a pure, unit-tested `parseClaudeAuthStatus()` helper. Local-only — no network call. (#641)
+
 ## [0.5.2] - 2026-06-02
 
 ### Fixed

--- a/cli/lib/__tests__/codex.test.js
+++ b/cli/lib/__tests__/codex.test.js
@@ -2,9 +2,25 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, it } from 'node:test';
+import { after, afterEach, beforeEach, describe, it } from 'node:test';
 
 const tmpDirs = [];
+
+// Install a fake `codex` binary BEFORE importing the adapter — CODEX_BIN is
+// captured at module load. The fake mimics the real CLI's quirk: it writes its
+// status line to STDERR and exits 0 in BOTH states. Per-test output is driven
+// by FAKE_CODEX_STATUS so checkAuth()'s glue path can be asserted directly.
+// NOTE: kept OUT of tmpDirs — the per-test afterEach drains tmpDirs, which would
+// delete this binary before later tests run. Cleaned once via after() below.
+const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-fakebin-'));
+const fakeCodexPath = path.join(fakeBinDir, 'codex');
+fs.writeFileSync(
+  fakeCodexPath,
+  '#!/usr/bin/env bash\necho "${FAKE_CODEX_STATUS:-Not logged in}" >&2\nexit 0\n',
+  { mode: 0o755 }
+);
+process.env.CODEX_BIN = fakeCodexPath;
+after(() => { try { fs.rmSync(fakeBinDir, { recursive: true, force: true }); } catch {} });
 
 const { CodexAdapter, buildCodexBootstrapPrompt, isOnboardingPendingState } = await import('../runtime/codex.js');
 
@@ -91,5 +107,36 @@ describe('Codex auth checks', () => {
 
     assert.equal(result.ok, true);
     assert.equal(requestedUrl, 'https://proxy.example.com/v1/models');
+  });
+
+  // Regression guard: `codex login status` exits 0 even when logged out, so a
+  // non-throwing execFile call must NOT be read as authenticated. This is the
+  // exact false-pass on the runtime-switch / health-probe gate that the PR fixes.
+  it('chatgpt/no-auth: returns not_logged_in when codex login status exits 0 with "Not logged in" on stderr', async () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-test-'));
+    tmpDirs.push(tmpHome);
+    process.env.HOME = tmpHome; // no ~/.codex/auth.json → falls to login-status branch
+    process.env.FAKE_CODEX_STATUS = 'Not logged in';
+
+    const adapter = new CodexAdapter({});
+    const result = await adapter.checkAuth();
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'not_logged_in');
+    delete process.env.FAKE_CODEX_STATUS;
+  });
+
+  it('chatgpt/no-auth: returns ok when codex login status reports "Logged in" on stderr (exit 0)', async () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-test-'));
+    tmpDirs.push(tmpHome);
+    process.env.HOME = tmpHome;
+    process.env.FAKE_CODEX_STATUS = 'Logged in using ChatGPT';
+
+    const adapter = new CodexAdapter({});
+    const result = await adapter.checkAuth();
+
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, 'codex_login_status');
+    delete process.env.FAKE_CODEX_STATUS;
   });
 });

--- a/cli/lib/__tests__/runtime-setup.test.js
+++ b/cli/lib/__tests__/runtime-setup.test.js
@@ -17,7 +17,7 @@ process.env.ZYLOS_DIR = fakeZylosDir;
 fs.mkdirSync(fakeHome, { recursive: true });
 fs.mkdirSync(fakeZylosDir, { recursive: true });
 
-const { writeCodexConfig, renderCodexProjectConfig, renderCodexGlobalConfig } = await import('../runtime-setup.js');
+const { writeCodexConfig, renderCodexProjectConfig, renderCodexGlobalConfig, parseClaudeAuthStatus } = await import('../runtime-setup.js');
 
 before(() => {
   fs.mkdirSync(path.join(fakeHome, '.codex'), { recursive: true });
@@ -270,6 +270,31 @@ describe('writeCodexConfig', () => {
     const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
     assert.match(projectContent, /user_added = "keep"/);
     assert.match(projectContent, /\[features\][\s\S]*fast_mode = false[\s\S]*multi_agent = true/);
+  });
+});
+
+describe('parseClaudeAuthStatus', () => {
+  it('returns true only when loggedIn is exactly true', () => {
+    assert.equal(parseClaudeAuthStatus('{"loggedIn":true,"authMethod":"claude.ai"}'), true);
+  });
+
+  it('returns false when loggedIn is false', () => {
+    assert.equal(parseClaudeAuthStatus('{"loggedIn":false}'), false);
+  });
+
+  it('returns false when loggedIn is missing', () => {
+    assert.equal(parseClaudeAuthStatus('{"authMethod":"claude.ai"}'), false);
+  });
+
+  it('returns false for truthy-but-not-true loggedIn values', () => {
+    assert.equal(parseClaudeAuthStatus('{"loggedIn":"true"}'), false);
+    assert.equal(parseClaudeAuthStatus('{"loggedIn":1}'), false);
+  });
+
+  it('returns false for non-JSON / empty output', () => {
+    assert.equal(parseClaudeAuthStatus(''), false);
+    assert.equal(parseClaudeAuthStatus('Not logged in'), false);
+    assert.equal(parseClaudeAuthStatus(undefined), false);
   });
 });
 

--- a/cli/lib/__tests__/runtime-setup.test.js
+++ b/cli/lib/__tests__/runtime-setup.test.js
@@ -17,7 +17,8 @@ process.env.ZYLOS_DIR = fakeZylosDir;
 fs.mkdirSync(fakeHome, { recursive: true });
 fs.mkdirSync(fakeZylosDir, { recursive: true });
 
-const { writeCodexConfig, renderCodexProjectConfig, renderCodexGlobalConfig, parseClaudeAuthStatus } = await import('../runtime-setup.js');
+const { writeCodexConfig, renderCodexProjectConfig, renderCodexGlobalConfig } = await import('../runtime-setup.js');
+const { parseClaudeAuthStatus, parseCodexLoginStatus } = await import('../auth-parsers.js');
 
 before(() => {
   fs.mkdirSync(path.join(fakeHome, '.codex'), { recursive: true });
@@ -295,6 +296,38 @@ describe('parseClaudeAuthStatus', () => {
     assert.equal(parseClaudeAuthStatus(''), false);
     assert.equal(parseClaudeAuthStatus('Not logged in'), false);
     assert.equal(parseClaudeAuthStatus(undefined), false);
+  });
+});
+
+describe('parseCodexLoginStatus', () => {
+  it('returns true for the logged-in message', () => {
+    assert.equal(parseCodexLoginStatus('Logged in using ChatGPT\n'), true);
+    assert.equal(parseCodexLoginStatus('Logged in using API key\n'), true);
+  });
+
+  it('returns false for the not-logged-in message (which also exits 0)', () => {
+    assert.equal(parseCodexLoginStatus('Not logged in\n'), false);
+  });
+
+  it('does not confuse "Not logged in" via a substring match', () => {
+    // "Not logged in" contains the lowercase substring "logged in" — must not match.
+    assert.equal(parseCodexLoginStatus('Not logged in'), false);
+  });
+
+  it('tolerates leading whitespace / warning-free stdout', () => {
+    assert.equal(parseCodexLoginStatus('   Logged in using ChatGPT'), true);
+  });
+
+  it('matches the status line even with a leading warning line (stderr combined)', () => {
+    // codex writes the status to stderr and may prepend an unrelated warning.
+    assert.equal(parseCodexLoginStatus('WARNING: could not update PATH\nLogged in using ChatGPT\n'), true);
+    assert.equal(parseCodexLoginStatus('WARNING: could not update PATH\nNot logged in\n'), false);
+  });
+
+  it('returns false for empty / undefined / unexpected output', () => {
+    assert.equal(parseCodexLoginStatus(''), false);
+    assert.equal(parseCodexLoginStatus(undefined), false);
+    assert.equal(parseCodexLoginStatus('some unrelated text'), false);
   });
 });
 

--- a/cli/lib/auth-parsers.js
+++ b/cli/lib/auth-parsers.js
@@ -1,0 +1,43 @@
+/**
+ * auth-parsers.js — pure parsers for runtime CLI auth-status output.
+ *
+ * Zero imports / no side effects by design: this leaf module is shared by both
+ * `runtime-setup.js` (the `zylos init` flow) and the runtime adapters
+ * (`runtime/codex.js`, runtime-switch + health probe) without dragging
+ * `node:child_process` into adapter test graphs that mock it.
+ *
+ * Both parsers key off explicit signals rather than process exit codes, which
+ * conflate "not authenticated" with crashes, timeouts, and version drift.
+ */
+
+/**
+ * Parse `claude auth status --json` output into an authenticated boolean.
+ * Keys off the explicit `loggedIn` field; any unparseable / unexpected payload
+ * is treated as not authenticated.
+ * @param {string} stdout
+ * @returns {boolean}
+ */
+export function parseClaudeAuthStatus(stdout) {
+  try {
+    return JSON.parse(stdout)?.loggedIn === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse `codex login status` output into an authenticated boolean.
+ * The exit code is unusable: `codex login status` exits 0 for BOTH
+ * "Logged in using ..." and "Not logged in". So we match the output text —
+ * a line beginning with "Logged in", explicitly excluding "Not logged in".
+ * Anything else (empty, unexpected wording, errors) is treated as not authed.
+ * NOTE: codex writes the status line to STDERR (stdout is empty) and may emit
+ * an unrelated leading warning line, so callers should pass combined
+ * stdout+stderr; the per-line match (`m` flag) ignores the warning.
+ * @param {string} stdout combined stdout+stderr from `codex login status`
+ * @returns {boolean}
+ */
+export function parseCodexLoginStatus(stdout) {
+  const out = String(stdout ?? '');
+  return /^\s*Logged in\b/im.test(out) && !/not logged in/i.test(out);
+}

--- a/cli/lib/runtime-setup.js
+++ b/cli/lib/runtime-setup.js
@@ -13,6 +13,7 @@ import { execSync, execFileSync, spawnSync } from 'node:child_process';
 import { parse, stringify } from 'smol-toml';
 import { ZYLOS_DIR } from './config.js';
 import { commandExists } from './shell-utils.js';
+import { parseClaudeAuthStatus, parseCodexLoginStatus } from './auth-parsers.js';
 
 function upsertEnvValue(content, key, value, comment = null) {
   const line = `${key}=${value}`;
@@ -75,22 +76,6 @@ export function installClaude() {
 // ── Auth checks ────────────────────────────────────────────────────────────
 
 /**
- * Parse `claude auth status --json` output into an authenticated boolean.
- * Keys off the explicit `loggedIn` field — never the exit code, which conflates
- * "not logged in" with crashes, timeouts, and cross-version subcommand drift.
- * Any unparseable / unexpected payload is treated as not authenticated.
- * @param {string} stdout
- * @returns {boolean}
- */
-export function parseClaudeAuthStatus(stdout) {
-  try {
-    return JSON.parse(stdout)?.loggedIn === true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Check if Claude Code is authenticated.
  * Reads the explicit `loggedIn` field from `claude auth status --json` rather
  * than trusting the process exit code. Local-only — reads stored credentials,
@@ -136,11 +121,14 @@ export function isCodexAuthenticated() {
   } catch { /* auth.json absent or malformed — fall through */ }
 
   // Use `codex login status` as the authoritative check for OAuth/device auth.
+  // NOTE: `codex login status` exits 0 in BOTH states ("Logged in using ..." and
+  // "Not logged in"), so the exit code is meaningless — parse the output text.
+  // The status line is written to STDERR (stdout is empty), so combine streams.
   try {
     const result = spawnSync('codex', ['login', 'status'], {
       stdio: 'pipe', encoding: 'utf8', timeout: 10000,
     });
-    return result.status === 0;
+    return parseCodexLoginStatus((result.stdout || '') + (result.stderr || ''));
   } catch {
     return false;
   }

--- a/cli/lib/runtime-setup.js
+++ b/cli/lib/runtime-setup.js
@@ -75,17 +75,36 @@ export function installClaude() {
 // ── Auth checks ────────────────────────────────────────────────────────────
 
 /**
+ * Parse `claude auth status --json` output into an authenticated boolean.
+ * Keys off the explicit `loggedIn` field — never the exit code, which conflates
+ * "not logged in" with crashes, timeouts, and cross-version subcommand drift.
+ * Any unparseable / unexpected payload is treated as not authenticated.
+ * @param {string} stdout
+ * @returns {boolean}
+ */
+export function parseClaudeAuthStatus(stdout) {
+  try {
+    return JSON.parse(stdout)?.loggedIn === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Check if Claude Code is authenticated.
+ * Reads the explicit `loggedIn` field from `claude auth status --json` rather
+ * than trusting the process exit code. Local-only — reads stored credentials,
+ * no network call.
  * @returns {boolean}
  */
 export function isClaudeAuthenticated() {
   try {
-    const result = spawnSync('claude', ['auth', 'status'], {
+    const result = spawnSync('claude', ['auth', 'status', '--json'], {
       stdio: 'pipe',
       encoding: 'utf8',
       timeout: 10000,
     });
-    return result.status === 0;
+    return parseClaudeAuthStatus(result.stdout);
   } catch {
     return false;
   }

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -38,6 +38,7 @@ import {
   hasChildProcess,
 } from './tmux-helpers.js';
 import { buildCleanEnv, buildCompatEnv, loadRuntimeEnvManifest, writeLaunchSpec } from './tmux-env.js';
+import { parseCodexLoginStatus } from '../auth-parsers.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -164,12 +165,19 @@ export class CodexAdapter extends RuntimeAdapter {
 
     if (authMode === 'chatgpt' || (authMode !== 'apikey' && !apiKey)) {
       // OAuth/device auth, or no auth.json — defer to the CLI which reads auth.json natively.
+      // NOTE: `codex login status` exits 0 in BOTH states ("Logged in using ..." and
+      // "Not logged in"), so a non-throwing call does NOT mean authenticated — parse
+      // the output text. Treating exit 0 as "ok" here would false-pass a logged-out
+      // OAuth session straight through the runtime-switch / health-probe auth gate.
+      // The status line is written to STDERR (stdout is empty), so combine streams.
       try {
-        await execFileAsync(CODEX_BIN, ['login', 'status'], {
+        const { stdout, stderr } = await execFileAsync(CODEX_BIN, ['login', 'status'], {
           stdio: 'pipe', encoding: 'utf8', timeout: 10_000,
         });
-        return { ok: true, reason: 'codex_login_status' };
-      } catch { /* binary missing, not logged in, or other error */ }
+        if (parseCodexLoginStatus((stdout || '') + (stderr || ''))) {
+          return { ok: true, reason: 'codex_login_status' };
+        }
+      } catch { /* binary missing, or other error */ }
       return { ok: false, reason: 'not_logged_in' };
     }
 


### PR DESCRIPTION
## Problem

Both runtimes' auth checks decided authentication from a **process exit code**, which is the wrong signal:

### Claude (init)
`isClaudeAuthenticated()` returned `spawnSync('claude', ['auth','status']).status === 0`. The exit code conflates "not logged in" with crashes, timeouts, and cross-version subcommand drift, while the JSON body's explicit `loggedIn` field was piped and discarded.

### Codex (init **and** adapter) — security-relevant
`codex login status` exits **0 in both states** — "Logged in using …" *and* "Not logged in". So keying off the exit code reported a **logged-out OAuth/ChatGPT session as authenticated** (a false-pass). This affected:
- `isCodexAuthenticated()` (init onboarding), and
- `CodexAdapter.checkAuth()` — the gate used by **runtime-switch** and the **activity-monitor health probe**.

The adapter case is the dangerous one: a runtime switch into an unauthenticated Codex would **pass** the auth check and proceed, leaving the agent unreachable over IM — exactly the failure the switch's fail-closed guard exists to prevent (relevant to the #635 design discussion).

## Fix

Key off explicit signals; fail closed on anything ambiguous. Pure parsers live in a new dependency-free `cli/lib/auth-parsers.js`:

- `parseClaudeAuthStatus(stdout)` → `JSON.parse(stdout).loggedIn === true`. `claude auth status --json` passed explicitly so a future default flip to `--text` can't silently break it.
- `parseCodexLoginStatus(text)` → matches a line starting with "Logged in", excludes "Not logged in". The status line is emitted on **stderr** (stdout is empty), so callers pass combined stdout+stderr; the per-line regex ignores any leading warning line.

Extracting the parsers into a leaf module also avoids dragging `runtime-setup.js`'s `child_process` import into adapter test graphs that mock `node:child_process` (which otherwise broke `runtime-launch.test.js`).

Neither check makes a network call — Claude verified via strace (no outbound `connect()`); Codex reads local credential state.

## Tests
- Unit cases for both parsers (logged-in / not-logged-in / missing / truthy-not-true / substring guard / warning-prefixed / empty / undefined).
- Full node suite **506/506** + jest **111/111**.
- Live-verified end to end: real logged-in → authed; isolated-HOME logged-out → not authed — for **both** the init helper and `CodexAdapter.checkAuth()` (the latter now correctly returns `{ok:false, reason:'not_logged_in'}` where it previously false-passed).

## Scope
Decoupled from #635 code-wise, but the Codex adapter fix is a **precondition** for #635's fail-closed guarantee to actually hold for OAuth/ChatGPT Codex. apikey-mode Codex was never affected (it reads auth.json + does a live HTTP probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)