### PR TITLE
Align Codex Memory Sync prompt guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Codex Memory Sync prompt guidance**: clarified session-start and context-threshold prompts so Codex should spawn native multi-agent workers and keep the foreground responsive instead of blocking on long waits; PM2 remains fallback-only when native multi-agent is unavailable.
+
 ## [0.5.3] - 2026-06-17
 
 ### Added

--- a/skills/activity-monitor/scripts/adapters/runtime-components.js
+++ b/skills/activity-monitor/scripts/adapters/runtime-components.js
@@ -112,7 +112,7 @@ export function startContextMonitor(activeAdapter, {
       log(`Context at ${pct}% (approaching ${thresholdPct}% threshold), triggering early memory sync (unsummarized=${unsummarizedCount})`);
       try {
         execFileSync('node', [c4ControlPath, 'enqueue',
-          '--content', `Context usage at ${pct}% (approaching ${thresholdPct}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. Launch a background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. Do NOT wait for completion — continue normal work.`,
+          '--content', `Context usage at ${pct}% (approaching ${thresholdPct}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. In Codex, spawn a native multi-agent worker following ~/zylos/.claude/skills/zylos-memory/SKILL.md, then keep the foreground responsive; do not block on a long wait_agent call. Integrate the result when the subagent notification arrives.`,
           '--priority', '2',
           '--no-ack-suffix',
         ], { encoding: 'utf8', stdio: 'pipe', timeout: 10_000 });

--- a/skills/activity-monitor/scripts/context-monitor.js
+++ b/skills/activity-monitor/scripts/context-monitor.js
@@ -164,7 +164,7 @@ function maybeEnqueueMemorySync(usedPct) {
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       execFileSync('node', [C4_CONTROL, 'enqueue',
-        '--content', `Context usage at ${usedPct}% (approaching ${RESTART_THRESHOLD}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. Launch a background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. Do NOT wait for completion — continue normal work.`,
+        '--content', `Context usage at ${usedPct}% (approaching ${RESTART_THRESHOLD}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. In Codex, spawn a native multi-agent worker following ~/zylos/.claude/skills/zylos-memory/SKILL.md, then keep the foreground responsive; do not block on a long wait_agent call. Integrate the result when the subagent notification arrives.`,
         '--priority', '2',
         '--no-ack-suffix'
       ], { encoding: 'utf8', stdio: 'pipe' });

--- a/skills/comm-bridge/references/hooks.md
+++ b/skills/comm-bridge/references/hooks.md
@@ -8,6 +8,6 @@ Runs when a Claude Code session starts. Outputs:
 
 1. **Last checkpoint summary** (always, if exists)
 2. **Recent conversations** — all unsummarized conversations if under threshold; most recent N if over threshold
-3. **Memory Sync instruction** — only if unsummarized conversation count exceeds the configured threshold; instructs Claude to invoke `/zylos-memory`
+3. **Memory Sync instruction** — only if unsummarized conversation count exceeds the configured threshold; instructs the runtime to launch Memory Sync via a runtime-appropriate background agent. In Codex, this means native multi-agent when available, without blocking the foreground on a long wait.
 
 There is no per-message threshold hook in v5. Additional Memory Sync triggering comes from scheduled context checks, not user-message hooks.

--- a/skills/comm-bridge/scripts/__tests__/c4-session-init-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-session-init-cli.test.js
@@ -95,6 +95,9 @@ describe('c4-session-init', () => {
       assert.equal(status, 0);
       assert.ok(stdout.includes('Action Required'));
       assert.ok(stdout.includes('zylos-memory'));
+      assert.ok(stdout.includes('native multi-agent'));
+      assert.ok(stdout.includes('wait_agent'));
+      assert.ok(stdout.includes('subagent notification'));
       // Should show limited conversations (SESSION_INIT_RECENT_COUNT = 6)
       assert.ok(stdout.includes('msg31'));
       assert.ok(stdout.includes('msg26'));

--- a/skills/comm-bridge/scripts/c4-session-init.js
+++ b/skills/comm-bridge/scripts/c4-session-init.js
@@ -51,7 +51,7 @@ function main() {
 
     // If over threshold, append Memory Sync instruction
     if (needsSync) {
-      lines.push(`[Action Required] There are ${range.count} unsummarized conversations (conversation id ${range.begin_id} ~ ${range.end_id}). Please use zylos-memory skill to process them.`);
+      lines.push(`[Action Required] There are ${range.count} unsummarized conversations (conversation id ${range.begin_id} ~ ${range.end_id}). Launch Memory Sync as a runtime-appropriate background agent following ~/zylos/.claude/skills/zylos-memory/SKILL.md. In Codex, use native multi-agent when available, keep the foreground responsive, and do not block on a long wait_agent call; integrate the result from the subagent notification or short status checks.`);
     }
 
     console.log(lines.join('\n'));

--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   markdown files following the Inside Out model. Handles Memory Sync (processing
   conversations into structured memory), session rotation, consolidation, and
   context-aware state saving. Must be launched via a runtime-appropriate
-  background subagent mechanism — do not invoke with the Skill tool.
+  background agent mechanism — do not invoke with the Skill tool.
 disable-model-invocation: true
 user-invocable: false
 ---
@@ -13,7 +13,7 @@ user-invocable: false
 # Memory System
 
 Maintains persistent memory across sessions via tiered markdown files.
-This skill must be run via a runtime-appropriate background subagent mechanism. For Claude, use the Task tool (`subagent_type: general-purpose`, `model: sonnet`, `run_in_background: true`). For Codex, use the current session's available background-agent capability with a Codex-supported model; do not hardcode `sonnet`.
+This skill must be run via a runtime-appropriate background agent mechanism. For Claude, use the Task tool (`subagent_type: general-purpose`, `model: sonnet`, `run_in_background: true`). For Codex, use the current session's native multi-agent capability when available; do not hardcode Claude-only parameters such as `sonnet` or `run_in_background`.
 
 ## Architecture
 
@@ -47,15 +47,20 @@ When triggered, run it before handling queued user messages.
 1. Session init: if C4 unsummarized count is over threshold, launch memory sync.
 2. Scheduled context check: if context usage is high, launch memory sync.
 
-Both launch a background subagent using the current runtime's supported subagent mechanism with this file's Sync Flow as the prompt.
+Both launch a background agent using the current runtime's supported mechanism with this file's Sync Flow as the prompt.
 
 ### Codex Background Execution
 
-In Codex, when the current session has a native background-agent capability,
-Memory Sync must use that capability directly. Do not create PM2 services,
-run `pm2 start ... codex exec ...`, or fork an extra `codex exec` sidecar.
-PM2 is only a fallback when no native background-agent capability is
-available; if used, explicitly record the reason in the handoff/status.
+In Codex, when the current session has native multi-agent capability,
+Memory Sync must use that capability directly. Spawn the worker and let the
+foreground session continue; do not immediately block the foreground with a
+long `wait_agent` call. Integrate the result when the subagent notification
+arrives, or use only short status checks when necessary.
+
+Do not create PM2 services, run `pm2 start ... codex exec ...`, or fork an
+extra `codex exec` sidecar. PM2 is only a fallback when no native multi-agent
+capability is available; if used, explicitly record the reason in the
+handoff/status.
 
 Before starting Memory Sync, check for existing `memory-sync-*` PM2 entries.
 If one is running, do not start another sync writer. If only stopped entries

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -111,7 +111,7 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
 
 1. **At session start:** identity + state + references are auto-injected.
 2. **During work:** Update appropriate memory files immediately when you learn something important.
-3. **Memory Sync:** When triggered, launch a background subagent using the current runtime's supported subagent/task mechanism. The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. This also applies in Codex and in `new-session` handoff flows: do not run Memory Sync inline in the main loop.
+3. **Memory Sync:** When triggered, launch a background agent using the current runtime's supported mechanism. The agent prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. In Codex, prefer native multi-agent, spawn the worker, and keep the foreground responsive instead of blocking on a long wait; integrate the result from the completion notification or short status checks. This also applies in `new-session` handoff flows: do not run Memory Sync inline in the main loop.
 4. **references.md is a pointer file.** Never duplicate .env values in it — point to the source config file instead.
 
 ### Classification Rules for reference/ Files

--- a/templates/codex-addon.md
+++ b/templates/codex-addon.md
@@ -75,7 +75,7 @@ The `ack via:` path and ID are included in the message.
 
 ### Memory Sync
 
-When Memory Sync is triggered, launch a background subagent using Codex's available multi-agent capability. Do not hardcode Claude-only Task tool parameters such as `model: sonnet` or `run_in_background`. Instead, use a Codex-supported agent configuration available in the current session and instruct that agent to follow the sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. This applies in Codex too, including `new-session` handoff flows. Do not run Memory Sync inline in the main loop. Report when complete.
+When Memory Sync is triggered, launch a background worker using Codex's native multi-agent capability. Do not hardcode Claude-only Task tool parameters such as `model: sonnet` or `run_in_background`; use the current session's available Codex multi-agent configuration and instruct the worker to follow `~/zylos/.claude/skills/zylos-memory/SKILL.md`. After spawning the worker, do not block the foreground with a long `wait_agent`; keep handling user/control messages and integrate the result when the subagent notification arrives, or use only short status checks when necessary. This applies in Codex too, including `new-session` handoff flows. Do not run Memory Sync inline in the main loop.
 
 ### Available Tools
 


### PR DESCRIPTION
## Summary
- update Codex Memory Sync guidance to prefer native multi-agent workers and avoid long foreground waits
- align session-start and context-threshold control prompts with the same behavior
- add C4 session-init regression assertions for native multi-agent / wait_agent / subagent notification wording

## Verification
- git diff --check
- npm test

Notes: direct `node --test skills/comm-bridge/scripts/__tests__/c4-session-init-cli.test.js` exits 1 outside the repo test harness, but `npm run test:node` and full `npm test` pass through the supported runner.