### PR TITLE
feat: Composio MCP integration (Tool Router, JIT tool-scoping)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 *.log
 .DS_Store
 .env
+/.mcp.json
+/.mcp.zylos.json
+/.codex/composio.zylos.json
 *.db
 *.db-shm
 *.db-wal

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -20,6 +20,7 @@ import { commandExists } from '../lib/shell-utils.js';
 import { getActiveAdapter } from '../lib/runtime/index.js';
 import { buildInstructionFile } from '../lib/runtime/instruction-builder.js';
 import { deployManifestTemplate } from '../lib/runtime/tmux-env.js';
+import { syncClaudeComposioMcpJson } from '../lib/composio-mcp.js';
 import { runMigrations } from '../lib/migrate.js';
 import {
   installGlobalPackage,
@@ -787,6 +788,12 @@ function deployTemplates() {
   const claudeDest = path.join(ZYLOS_DIR, '.claude');
   if (fs.existsSync(claudeSrc)) {
     copyMissingTree(claudeSrc, claudeDest);
+  }
+
+  // Project MCP config — generated from .env so secrets stay instance-local.
+  const composioMcp = syncClaudeComposioMcpJson({ projectDir: ZYLOS_DIR });
+  if (composioMcp.changed) {
+    console.log(`  ${success(composioMcp.enabled ? 'Updated Composio MCP config' : 'Disabled Composio MCP config')}`);
   }
 
   // runtime-env.manifest — create from template if missing

--- a/cli/commands/runtime.js
+++ b/cli/commands/runtime.js
@@ -18,6 +18,7 @@ import { getAdapter, SUPPORTED_RUNTIMES } from '../lib/runtime/index.js';
 import { buildInstructionFile } from '../lib/runtime/instruction-builder.js';
 import { commandExists } from '../lib/shell-utils.js';
 import { getCoreEcosystemPath, restartManagedProcess } from '../lib/pm2.js';
+import { syncClaudeComposioMcpJson } from '../lib/composio-mcp.js';
 import {
   installClaude,
   installCodex,
@@ -287,6 +288,11 @@ async function switchRuntime(target, flags) {
       process.exit(1);
     }
     console.log(`  ${green('✓')} base URL saved`);
+  }
+
+  const composioMcp = syncClaudeComposioMcpJson({ projectDir: ZYLOS_DIR });
+  if (composioMcp.changed) {
+    console.log(`  ${green('✓')} Composio MCP config ${composioMcp.enabled ? 'updated' : 'disabled'}`);
   }
 
   // Step 2b: Write Codex headless config (trust dir, suppress all interactive prompts).

--- a/cli/lib/__tests__/composio-mcp.test.js
+++ b/cli/lib/__tests__/composio-mcp.test.js
@@ -8,6 +8,7 @@ import {
   CLAUDE_COMPOSIO_DENIED_TOOLS,
   createComposioToolRouterSession,
   deriveComposioUserId,
+  renderClaudeComposioMcpJson,
   resolveComposioMcpUrl,
   syncClaudeComposioMcpJson,
   syncClaudeComposioSettings,
@@ -305,6 +306,41 @@ describe('syncClaudeComposioMcpJson', () => {
     assert.equal(parsed.mcpServers.composio.url, 'https://example.com/composio/mcp');
     assert.equal(fs.existsSync(path.join(projectDir, '.mcp.zylos.json')), false);
     assert.ok(logs.some(line => line.includes('unmarked Composio MCP server')));
+  });
+
+  it('does not adopt a same-shape unmarked user-owned Composio config', () => {
+    const projectDir = mkProject();
+    const mcpPath = path.join(projectDir, '.mcp.json');
+    const markerPath = path.join(projectDir, '.mcp.zylos.json');
+    const envPath = path.join(projectDir, '.env');
+    const generatedUrl = 'https://backend.composio.dev/tool_router/generated/mcp';
+    const generatedKey = 'test-key';
+    fs.writeFileSync(envPath, [
+      `COMPOSIO_API_KEY=${generatedKey}`,
+      `COMPOSIO_MCP_URL=${generatedUrl}`,
+      '',
+    ].join('\n'));
+    fs.writeFileSync(mcpPath, renderClaudeComposioMcpJson({
+      mcpUrl: generatedUrl,
+      apiKey: generatedKey,
+    }));
+
+    const enabledResult = syncClaudeComposioMcpJson({ projectDir });
+    const afterEnable = fs.readFileSync(mcpPath, 'utf8');
+
+    assert.equal(enabledResult.changed, false);
+    assert.equal(enabledResult.enabled, false);
+    assert.equal(enabledResult.skipped, true);
+    assert.equal(enabledResult.reason, 'user_owned_collision');
+    assert.equal(fs.existsSync(markerPath), false);
+
+    fs.writeFileSync(envPath, 'COMPOSIO_API_KEY=\nCOMPOSIO_MCP_URL=\n');
+    const disabledResult = syncClaudeComposioMcpJson({ projectDir });
+
+    assert.equal(disabledResult.changed, false);
+    assert.equal(fs.existsSync(mcpPath), true);
+    assert.equal(fs.readFileSync(mcpPath, 'utf8'), afterEnable);
+    assert.equal(fs.existsSync(markerPath), false);
   });
 });
 

--- a/cli/lib/__tests__/composio-mcp.test.js
+++ b/cli/lib/__tests__/composio-mcp.test.js
@@ -1,0 +1,331 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+  CLAUDE_COMPOSIO_DENIED_TOOLS,
+  createComposioToolRouterSession,
+  deriveComposioUserId,
+  resolveComposioMcpUrl,
+  syncClaudeComposioMcpJson,
+  syncClaudeComposioSettings,
+} from '../composio-mcp.js';
+
+const tmpDirs = [];
+
+function mkProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-composio-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('resolveComposioMcpUrl', () => {
+  it('stays inert when COMPOSIO_API_KEY is blank', () => {
+    const projectDir = mkProject();
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\nCOMPOSIO_MCP_URL=\n');
+
+    const result = resolveComposioMcpUrl({
+      projectDir,
+      createSession: () => {
+        throw new Error('should not create a session');
+      },
+    });
+
+    assert.equal(result.enabled, false);
+    assert.equal(result.reason, 'missing_api_key');
+  });
+
+  it('creates and persists a Tool Router URL when only the API key is present', () => {
+    const projectDir = mkProject();
+    const envPath = path.join(projectDir, '.env');
+    fs.writeFileSync(envPath, 'COMPOSIO_API_KEY=test-key\nCOMPOSIO_MCP_URL=\n');
+
+    const result = resolveComposioMcpUrl({
+      projectDir,
+      createSession: (apiKey, opts) => {
+        assert.equal(apiKey, 'test-key');
+        assert.equal(opts.userId, deriveComposioUserId({ projectDir }));
+        return 'https://backend.composio.dev/tool_router/session-123/mcp';
+      },
+    });
+
+    assert.equal(result.enabled, true);
+    assert.equal(result.mcpUrl, 'https://backend.composio.dev/tool_router/session-123/mcp');
+    assert.match(fs.readFileSync(envPath, 'utf8'), /^COMPOSIO_MCP_URL=https:\/\/backend\.composio\.dev\/tool_router\/session-123\/mcp$/m);
+  });
+
+  it('uses explicit COMPOSIO_USER_ID and atomic .env persistence when minting a URL', () => {
+    const projectDir = mkProject();
+    const envPath = path.join(projectDir, '.env');
+    const writes = [];
+    fs.writeFileSync(envPath, [
+      'COMPOSIO_API_KEY=test-key',
+      'COMPOSIO_MCP_URL=',
+      'COMPOSIO_USER_ID=owner-instance',
+      '',
+    ].join('\n'));
+
+    const result = resolveComposioMcpUrl({
+      projectDir,
+      createSession: (apiKey, opts) => {
+        assert.equal(apiKey, 'test-key');
+        assert.equal(opts.userId, 'owner-instance');
+        return 'https://backend.composio.dev/tool_router/session-456/mcp';
+      },
+      writeFileAtomic: (filePath, content, opts) => {
+        writes.push({ filePath, content, opts });
+        fs.writeFileSync(filePath, content, 'utf8');
+      },
+    });
+
+    assert.equal(result.enabled, true);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].filePath, envPath);
+    assert.equal(writes[0].opts.mode, 0o600);
+    assert.match(writes[0].content, /^COMPOSIO_MCP_URL=https:\/\/backend\.composio\.dev\/tool_router\/session-456\/mcp$/m);
+  });
+});
+
+describe('createComposioToolRouterSession', () => {
+  it('sends user_id and disables workbench without exposing the API key in argv', () => {
+    const result = createComposioToolRouterSession('secret-key', {
+      userId: 'zylos-user',
+      execFile: (cmd, args, opts) => {
+        assert.equal(cmd, 'curl');
+        assert.equal(args.includes('secret-key'), false);
+        assert.match(opts.input, /x-api-key: secret-key/);
+        const dataIdx = args.indexOf('--data');
+        assert.notEqual(dataIdx, -1);
+        assert.deepEqual(JSON.parse(args[dataIdx + 1]), {
+          user_id: 'zylos-user',
+          workbench: {
+            enable: false,
+          },
+        });
+        return JSON.stringify({
+          mcp: {
+            url: 'https://backend.composio.dev/tool_router/session-123/mcp',
+          },
+          tool_router_tools: [
+            'COMPOSIO_SEARCH_TOOLS',
+            'COMPOSIO_GET_TOOL_SCHEMAS',
+            'COMPOSIO_MULTI_EXECUTE_TOOL',
+            'COMPOSIO_MANAGE_CONNECTIONS',
+          ],
+          config: {
+            workbench: {
+              enable: false,
+            },
+          },
+        });
+      },
+    });
+
+    assert.equal(result, 'https://backend.composio.dev/tool_router/session-123/mcp');
+  });
+
+  it('rejects session responses that still expose remote code tools', () => {
+    assert.throws(() => createComposioToolRouterSession('secret-key', {
+      userId: 'zylos-user',
+      execFile: () => JSON.stringify({
+        mcp: {
+          url: 'https://backend.composio.dev/tool_router/session-123/mcp',
+        },
+        tool_router_tools: [
+          'COMPOSIO_REMOTE_BASH_TOOL',
+          'COMPOSIO_REMOTE_WORKBENCH',
+        ],
+      }),
+    }), /still exposes remote code tools/);
+  });
+});
+
+describe('syncClaudeComposioMcpJson', () => {
+  it('does not create .mcp.json when the integration is disabled', () => {
+    const projectDir = mkProject();
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\n');
+
+    const result = syncClaudeComposioMcpJson({ projectDir });
+
+    assert.equal(result.enabled, false);
+    assert.equal(result.changed, false);
+    assert.equal(fs.existsSync(path.join(projectDir, '.mcp.json')), false);
+  });
+
+  it('writes a resolved local .mcp.json and is idempotent', () => {
+    const projectDir = mkProject();
+    fs.writeFileSync(path.join(projectDir, '.env'), [
+      'COMPOSIO_API_KEY=test-key',
+      'COMPOSIO_MCP_URL=https://backend.composio.dev/tool_router/session-123/mcp',
+      '',
+    ].join('\n'));
+
+    const first = syncClaudeComposioMcpJson({ projectDir });
+    const second = syncClaudeComposioMcpJson({ projectDir });
+    const mcpPath = path.join(projectDir, '.mcp.json');
+    const parsed = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+    const marker = JSON.parse(fs.readFileSync(path.join(projectDir, '.mcp.zylos.json'), 'utf8'));
+    const mode = fs.statSync(mcpPath).mode & 0o777;
+    const markerMode = fs.statSync(path.join(projectDir, '.mcp.zylos.json')).mode & 0o777;
+
+    assert.equal(first.changed, true);
+    assert.equal(second.changed, false);
+    assert.equal(parsed.mcpServers.composio.type, 'http');
+    assert.equal(parsed.mcpServers.composio.url, 'https://backend.composio.dev/tool_router/session-123/mcp');
+    assert.equal(parsed.mcpServers.composio.headers['x-api-key'], 'test-key');
+    assert.equal(marker.managedMcpServers.composio.source, 'zylos-core');
+    assert.equal(marker.managedMcpServers.composio.url, 'https://backend.composio.dev/tool_router/session-123/mcp');
+    assert.equal(marker.managedMcpServers.composio.apiKeyEnv, 'COMPOSIO_API_KEY');
+    assert.equal(mode, 0o600);
+    assert.equal(markerMode, 0o600);
+  });
+
+  it('removes marked generated Composio config when disabled without dropping unrelated entries', () => {
+    const projectDir = mkProject();
+    const mcpPath = path.join(projectDir, '.mcp.json');
+    const markerPath = path.join(projectDir, '.mcp.zylos.json');
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\n');
+    fs.writeFileSync(mcpPath, JSON.stringify({
+      mcpServers: {
+        composio: {
+          type: 'http',
+          url: 'https://backend.composio.dev/tool_router/session-123/mcp',
+          headers: {
+            'x-api-key': 'old-key',
+          },
+        },
+        user_server: {
+          type: 'http',
+          url: 'https://example.com/mcp',
+        },
+      },
+    }, null, 2));
+    fs.writeFileSync(markerPath, JSON.stringify({
+      version: 1,
+      managedMcpServers: {
+        composio: {
+          source: 'zylos-core',
+          url: 'https://backend.composio.dev/tool_router/session-123/mcp',
+          apiKeyEnv: 'COMPOSIO_API_KEY',
+        },
+      },
+    }, null, 2));
+
+    const result = syncClaudeComposioMcpJson({ projectDir });
+    const parsed = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+
+    assert.equal(result.changed, true);
+    assert.equal(parsed.mcpServers.composio, undefined);
+    assert.equal(parsed.mcpServers.user_server.url, 'https://example.com/mcp');
+    assert.equal(fs.existsSync(markerPath), false);
+  });
+
+  it('preserves unmarked user-owned Composio config with an API-key header when disabled', () => {
+    const projectDir = mkProject();
+    const mcpPath = path.join(projectDir, '.mcp.json');
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\n');
+    fs.writeFileSync(mcpPath, JSON.stringify({
+      mcpServers: {
+        composio: {
+          type: 'http',
+          url: 'https://example.com/composio/mcp',
+          headers: {
+            'x-api-key': 'user-owned-key',
+          },
+        },
+      },
+    }, null, 2));
+
+    const result = syncClaudeComposioMcpJson({ projectDir });
+    const parsed = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+
+    assert.equal(result.changed, false);
+    assert.equal(parsed.mcpServers.composio.headers['x-api-key'], 'user-owned-key');
+  });
+
+  it('preserves unmarked user-owned Composio config even when it uses a Tool Router URL', () => {
+    const projectDir = mkProject();
+    const mcpPath = path.join(projectDir, '.mcp.json');
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\n');
+    fs.writeFileSync(mcpPath, JSON.stringify({
+      mcpServers: {
+        composio: {
+          type: 'http',
+          url: 'https://backend.composio.dev/tool_router/user-owned/mcp',
+          headers: {
+            'x-api-key': 'user-owned-key',
+          },
+        },
+      },
+    }, null, 2));
+
+    const result = syncClaudeComposioMcpJson({ projectDir });
+    const parsed = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+
+    assert.equal(result.changed, false);
+    assert.equal(parsed.mcpServers.composio.url, 'https://backend.composio.dev/tool_router/user-owned/mcp');
+  });
+
+  it('does not overwrite an unmarked user-owned Composio config when enabling', () => {
+    const projectDir = mkProject();
+    const mcpPath = path.join(projectDir, '.mcp.json');
+    const logs = [];
+    fs.writeFileSync(path.join(projectDir, '.env'), [
+      'COMPOSIO_API_KEY=test-key',
+      'COMPOSIO_MCP_URL=https://backend.composio.dev/tool_router/generated/mcp',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(mcpPath, JSON.stringify({
+      mcpServers: {
+        composio: {
+          type: 'http',
+          url: 'https://example.com/composio/mcp',
+          headers: {
+            'x-api-key': 'user-owned-key',
+          },
+        },
+      },
+    }, null, 2));
+
+    const result = syncClaudeComposioMcpJson({ projectDir, log: (line) => logs.push(line) });
+    const parsed = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+
+    assert.equal(result.changed, false);
+    assert.equal(result.enabled, false);
+    assert.equal(result.skipped, true);
+    assert.equal(result.reason, 'user_owned_collision');
+    assert.equal(parsed.mcpServers.composio.url, 'https://example.com/composio/mcp');
+    assert.equal(fs.existsSync(path.join(projectDir, '.mcp.zylos.json')), false);
+    assert.ok(logs.some(line => line.includes('unmarked Composio MCP server')));
+  });
+});
+
+describe('syncClaudeComposioSettings', () => {
+  it('merges server approval and remote code-exec denies without dropping user settings', () => {
+    const settings = {
+      enabledMcpjsonServers: ['existing'],
+      permissions: {
+        allow: ['Bash(git:*)'],
+        deny: ['Read(/secret/**)'],
+      },
+    };
+
+    const result = syncClaudeComposioSettings(settings);
+
+    assert.equal(result.changed, true);
+    assert.deepEqual(settings.enabledMcpjsonServers, ['existing', 'composio']);
+    assert.ok(settings.permissions.allow.includes('Bash(git:*)'));
+    assert.ok(settings.permissions.allow.includes('mcp__composio__COMPOSIO_SEARCH_TOOLS'));
+    for (const deny of CLAUDE_COMPOSIO_DENIED_TOOLS) {
+      assert.ok(settings.permissions.deny.includes(deny));
+    }
+  });
+});

--- a/cli/lib/__tests__/runtime-setup.test.js
+++ b/cli/lib/__tests__/runtime-setup.test.js
@@ -19,6 +19,7 @@ fs.mkdirSync(fakeZylosDir, { recursive: true });
 
 const { writeCodexConfig, renderCodexProjectConfig, renderCodexGlobalConfig } = await import('../runtime-setup.js');
 const { parseClaudeAuthStatus, parseCodexLoginStatus, classifyCodexLoginStatus } = await import('../auth-parsers.js');
+const { renderCodexComposioMarker } = await import('../composio-mcp.js');
 
 before(() => {
   fs.mkdirSync(path.join(fakeHome, '.codex'), { recursive: true });
@@ -53,6 +54,71 @@ describe('renderCodexProjectConfig', () => {
     assert.doesNotMatch(content, /\[projects\./);
     assert.doesNotMatch(content, /trust_level/);
     assert.doesNotMatch(content, /openai_base_url/);
+  });
+
+  it('includes Composio HTTP MCP config when a Tool Router URL is available', () => {
+    const content = renderCodexProjectConfig('', {
+      composioMcpUrl: 'https://backend.composio.dev/tool_router/session-123/mcp',
+    });
+
+    assert.match(content, /\[mcp_servers\.composio\]/);
+    assert.match(content, /url = "https:\/\/backend\.composio\.dev\/tool_router\/session-123\/mcp"/);
+    assert.match(content, /bearer_token_env_var = "COMPOSIO_API_KEY"/);
+    assert.match(content, /disabled_tools = \[\s*"COMPOSIO_REMOTE_BASH_TOOL",\s*"COMPOSIO_REMOTE_WORKBENCH"\s*\]/);
+  });
+
+  it('removes marked zylos-managed Composio MCP config when no URL is available', () => {
+    const existing = [
+      '[mcp_servers.composio]',
+      'url = "https://backend.composio.dev/tool_router/session-123/mcp"',
+      'bearer_token_env_var = "COMPOSIO_API_KEY"',
+      '',
+      '[mcp_servers.user_server]',
+      'url = "https://example.com/mcp"',
+      '',
+    ].join('\n');
+
+    const content = renderCodexProjectConfig(existing, {
+      codexComposioMarker: JSON.parse(renderCodexComposioMarker('https://backend.composio.dev/tool_router/session-123/mcp')),
+    });
+
+    assert.doesNotMatch(content, /\[mcp_servers\.composio\]/);
+    assert.match(content, /\[mcp_servers\.user_server\]/);
+  });
+
+  it('preserves unmarked user-owned Composio MCP config when no URL is available', () => {
+    const existing = [
+      '[mcp_servers.composio]',
+      'url = "https://backend.composio.dev/tool_router/user-owned/mcp"',
+      'bearer_token_env_var = "COMPOSIO_API_KEY"',
+      '',
+      '[mcp_servers.user_server]',
+      'url = "https://example.com/mcp"',
+      '',
+    ].join('\n');
+
+    const content = renderCodexProjectConfig(existing);
+
+    assert.match(content, /\[mcp_servers\.composio\]/);
+    assert.match(content, /url = "https:\/\/backend\.composio\.dev\/tool_router\/user-owned\/mcp"/);
+    assert.match(content, /\[mcp_servers\.user_server\]/);
+  });
+
+  it('does not overwrite unmarked user-owned Composio MCP config when URL is available', () => {
+    const existing = [
+      '[mcp_servers.composio]',
+      'url = "https://example.com/user-owned/mcp"',
+      'bearer_token_env_var = "USER_COMPOSIO_API_KEY"',
+      '',
+    ].join('\n');
+
+    const content = renderCodexProjectConfig(existing, {
+      composioMcpUrl: 'https://backend.composio.dev/tool_router/generated/mcp',
+    });
+
+    assert.match(content, /\[mcp_servers\.composio\]/);
+    assert.match(content, /url = "https:\/\/example\.com\/user-owned\/mcp"/);
+    assert.doesNotMatch(content, /generated/);
   });
 
   it('preserves unknown top-level keys, sections, and feature flags while updating zylos keys', () => {
@@ -271,6 +337,91 @@ describe('writeCodexConfig', () => {
     const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
     assert.match(projectContent, /user_added = "keep"/);
     assert.match(projectContent, /\[features\][\s\S]*fast_mode = false[\s\S]*multi_agent = true/);
+  });
+
+  it('keeps Composio inert when .env has no API key', () => {
+    const projectDir = path.join(fakeZylosDir, 'workspace', 'project-composio-blank');
+    const projectConfigPath = path.join(path.resolve(projectDir), '.codex', 'config.toml');
+
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\nCOMPOSIO_MCP_URL=\n');
+
+    assert.equal(writeCodexConfig(projectDir), true);
+
+    const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
+    assert.doesNotMatch(projectContent, /\[mcp_servers\.composio\]/);
+    assert.equal(fs.existsSync(path.join(projectDir, '.mcp.json')), false);
+  });
+
+  it('writes a Codex Composio marker when generated config is installed', () => {
+    const projectDir = path.join(fakeZylosDir, 'workspace', 'project-composio-enabled');
+    const projectConfigPath = path.join(path.resolve(projectDir), '.codex', 'config.toml');
+    const markerPath = path.join(path.resolve(projectDir), '.codex', 'composio.zylos.json');
+
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.env'), [
+      'COMPOSIO_API_KEY=test-key',
+      'COMPOSIO_MCP_URL=https://backend.composio.dev/tool_router/generated/mcp',
+      '',
+    ].join('\n'));
+
+    assert.equal(writeCodexConfig(projectDir), true);
+
+    const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
+    const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    const mode = fs.statSync(markerPath).mode & 0o777;
+    assert.match(projectContent, /\[mcp_servers\.composio\]/);
+    assert.equal(marker.managedMcpServers.composio.url, 'https://backend.composio.dev/tool_router/generated/mcp');
+    assert.equal(mode, 0o600);
+  });
+
+  it('does not delete unmarked user-owned Codex Composio config when disabled', () => {
+    const projectDir = path.join(fakeZylosDir, 'workspace', 'project-composio-user-owned');
+    const projectConfigPath = path.join(path.resolve(projectDir), '.codex', 'config.toml');
+    const markerPath = path.join(path.resolve(projectDir), '.codex', 'composio.zylos.json');
+
+    fs.mkdirSync(path.dirname(projectConfigPath), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\nCOMPOSIO_MCP_URL=\n');
+    fs.writeFileSync(projectConfigPath, [
+      '[mcp_servers.composio]',
+      'url = "https://backend.composio.dev/tool_router/user-owned/mcp"',
+      'bearer_token_env_var = "COMPOSIO_API_KEY"',
+      '',
+    ].join('\n'));
+
+    assert.equal(writeCodexConfig(projectDir), true);
+
+    const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
+    assert.match(projectContent, /\[mcp_servers\.composio\]/);
+    assert.match(projectContent, /user-owned/);
+    assert.equal(fs.existsSync(markerPath), false);
+  });
+
+  it('removes marked Codex Composio config when disabled', () => {
+    const projectDir = path.join(fakeZylosDir, 'workspace', 'project-composio-disable');
+    const projectConfigPath = path.join(path.resolve(projectDir), '.codex', 'config.toml');
+    const markerPath = path.join(path.resolve(projectDir), '.codex', 'composio.zylos.json');
+
+    fs.mkdirSync(path.dirname(projectConfigPath), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.env'), 'COMPOSIO_API_KEY=\nCOMPOSIO_MCP_URL=\n');
+    fs.writeFileSync(projectConfigPath, [
+      '[mcp_servers.composio]',
+      'url = "https://backend.composio.dev/tool_router/generated/mcp"',
+      'bearer_token_env_var = "COMPOSIO_API_KEY"',
+      'disabled_tools = ["COMPOSIO_REMOTE_BASH_TOOL", "COMPOSIO_REMOTE_WORKBENCH"]',
+      '',
+      '[mcp_servers.user_server]',
+      'url = "https://example.com/mcp"',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(markerPath, renderCodexComposioMarker('https://backend.composio.dev/tool_router/generated/mcp'));
+
+    assert.equal(writeCodexConfig(projectDir), true);
+
+    const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
+    assert.doesNotMatch(projectContent, /\[mcp_servers\.composio\]/);
+    assert.match(projectContent, /\[mcp_servers\.user_server\]/);
+    assert.equal(fs.existsSync(markerPath), false);
   });
 });
 

--- a/cli/lib/__tests__/runtime-setup.test.js
+++ b/cli/lib/__tests__/runtime-setup.test.js
@@ -281,19 +281,23 @@ describe('writeCodexConfig', () => {
 
     // Project-level config has headless settings
     const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
+    const projectMode = fs.statSync(projectConfigPath).mode & 0o777;
     assert.match(projectContent, /\[features\]\nmulti_agent = true/);
     assert.match(projectContent, /\[notice\]/);
     assert.match(projectContent, /check_for_update_on_startup = false/);
     assert.doesNotMatch(projectContent, /\[projects\./);
+    assert.equal(projectMode, 0o600);
 
     // Global config has trust only
     const globalContent = fs.readFileSync(globalConfigPath, 'utf8');
+    const globalMode = fs.statSync(globalConfigPath).mode & 0o777;
     assert.match(
       globalContent,
       new RegExp(`\\[projects\\."${escapeRegExp(path.resolve(projectDir))}"\\]\\ntrust_level = "trusted"`)
     );
     assert.doesNotMatch(globalContent, /\[features\]/);
     assert.doesNotMatch(globalContent, /\[notice\]/);
+    assert.equal(globalMode, 0o600);
   });
 
   it('preserves unrelated trusted projects in global config', () => {
@@ -468,6 +472,42 @@ describe('writeCodexConfig', () => {
     assert.doesNotMatch(projectContent, /\[mcp_servers\.composio\]/);
     assert.match(projectContent, /\[mcp_servers\.user_server\]/);
     assert.equal(fs.existsSync(markerPath), false);
+  });
+
+  it('preserves malformed project-level Codex config without overwriting it', () => {
+    const globalConfigPath = path.join(fakeHome, '.codex', 'config.toml');
+    const projectDir = path.join(fakeZylosDir, 'workspace', 'project-codex-malformed-project');
+    const projectConfigPath = path.join(path.resolve(projectDir), '.codex', 'config.toml');
+    const malformedProject = '<malformed [mcp_servers.composio>\nurl = "https://user.example/mcp"\n';
+
+    fs.mkdirSync(path.dirname(projectConfigPath), { recursive: true });
+    fs.mkdirSync(path.dirname(globalConfigPath), { recursive: true });
+    fs.writeFileSync(projectConfigPath, malformedProject);
+    fs.writeFileSync(globalConfigPath, '');
+
+    assert.equal(writeCodexConfig(projectDir), false);
+    assert.equal(fs.readFileSync(projectConfigPath, 'utf8'), malformedProject);
+  });
+
+  it('preserves malformed global Codex config without overwriting it', () => {
+    const globalConfigPath = path.join(fakeHome, '.codex', 'config.toml');
+    const projectDir = path.join(fakeZylosDir, 'workspace', 'project-codex-malformed-global');
+    const projectConfigPath = path.join(path.resolve(projectDir), '.codex', 'config.toml');
+    const existingProject = 'user_added = "keep"\n';
+    const malformedGlobal = '<malformed [projects."/tmp/example">\ntrust_level = "trusted"\n';
+
+    fs.mkdirSync(path.dirname(projectConfigPath), { recursive: true });
+    fs.mkdirSync(path.dirname(globalConfigPath), { recursive: true });
+    fs.writeFileSync(projectConfigPath, existingProject);
+    fs.writeFileSync(globalConfigPath, malformedGlobal);
+
+    try {
+      assert.equal(writeCodexConfig(projectDir), false);
+      assert.equal(fs.readFileSync(projectConfigPath, 'utf8'), existingProject);
+      assert.equal(fs.readFileSync(globalConfigPath, 'utf8'), malformedGlobal);
+    } finally {
+      fs.writeFileSync(globalConfigPath, '');
+    }
   });
 });
 

--- a/cli/lib/__tests__/runtime-setup.test.js
+++ b/cli/lib/__tests__/runtime-setup.test.js
@@ -121,6 +121,25 @@ describe('renderCodexProjectConfig', () => {
     assert.doesNotMatch(content, /generated/);
   });
 
+  it('does not promote unmarked Codex Composio config even when it matches the generated shape', () => {
+    const existing = [
+      '[mcp_servers.composio]',
+      'url = "https://backend.composio.dev/tool_router/generated/mcp"',
+      'bearer_token_env_var = "COMPOSIO_API_KEY"',
+      'disabled_tools = ["COMPOSIO_REMOTE_BASH_TOOL", "COMPOSIO_REMOTE_WORKBENCH"]',
+      'startup_timeout_sec = 20',
+      '',
+    ].join('\n');
+
+    const content = renderCodexProjectConfig(existing, {
+      composioMcpUrl: 'https://backend.composio.dev/tool_router/generated/mcp',
+    });
+
+    assert.match(content, /\[mcp_servers\.composio\]/);
+    assert.match(content, /url = "https:\/\/backend\.composio\.dev\/tool_router\/generated\/mcp"/);
+    assert.match(content, /startup_timeout_sec = 20/);
+  });
+
   it('preserves unknown top-level keys, sections, and feature flags while updating zylos keys', () => {
     const existing = [
       '# User comment',
@@ -394,6 +413,33 @@ describe('writeCodexConfig', () => {
     const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
     assert.match(projectContent, /\[mcp_servers\.composio\]/);
     assert.match(projectContent, /user-owned/);
+    assert.equal(fs.existsSync(markerPath), false);
+  });
+
+  it('does not mark an existing unmarked Codex Composio config as generated', () => {
+    const projectDir = path.join(fakeZylosDir, 'workspace', 'project-composio-user-owned-enabled');
+    const projectConfigPath = path.join(path.resolve(projectDir), '.codex', 'config.toml');
+    const markerPath = path.join(path.resolve(projectDir), '.codex', 'composio.zylos.json');
+
+    fs.mkdirSync(path.dirname(projectConfigPath), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.env'), [
+      'COMPOSIO_API_KEY=test-key',
+      'COMPOSIO_MCP_URL=https://backend.composio.dev/tool_router/user-owned/mcp',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(projectConfigPath, [
+      '[mcp_servers.composio]',
+      'url = "https://backend.composio.dev/tool_router/user-owned/mcp"',
+      'bearer_token_env_var = "COMPOSIO_API_KEY"',
+      'disabled_tools = ["COMPOSIO_REMOTE_BASH_TOOL", "COMPOSIO_REMOTE_WORKBENCH"]',
+      'startup_timeout_sec = 20',
+      '',
+    ].join('\n'));
+
+    assert.equal(writeCodexConfig(projectDir), true);
+
+    const projectContent = fs.readFileSync(projectConfigPath, 'utf8');
+    assert.match(projectContent, /startup_timeout_sec = 20/);
     assert.equal(fs.existsSync(markerPath), false);
   });
 

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -51,6 +51,15 @@ describe('Claude settings template', () => {
     assert.equal(groups.length, 1);
     assert.ok(groups[0].hooks.some(h => h.command.includes('hook-activity.js')));
   });
+
+  it('pre-approves only the Composio project MCP server and denies remote code-exec tools', () => {
+    const template = JSON.parse(fs.readFileSync(TEMPLATE_SETTINGS_PATH, 'utf8'));
+    assert.deepEqual(template.enabledMcpjsonServers, ['composio']);
+    assert.ok(template.permissions.allow.includes('mcp__composio__COMPOSIO_SEARCH_TOOLS'));
+    assert.ok(template.permissions.deny.includes('mcp__composio__*BASH*'));
+    assert.ok(template.permissions.deny.includes('mcp__composio__*WORKBENCH*'));
+    assert.equal(template.enableAllProjectMcpServers, undefined);
+  });
 });
 
 describe('Activity monitor threshold fallback', () => {

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -258,7 +258,7 @@ describe('syncCodexConfig', () => {
       projectDir: '/tmp/zylos',
       existsSync: (filePath) => filePath === globalConfigPath,
       // Return stale content so drift is detected
-      readFileSync: () => 'stale-content\n',
+      readFileSync: () => 'model = "gpt-5.4"\n',
       writeConfig: (projectDir) => {
         writes.push(projectDir);
         return true;
@@ -278,7 +278,7 @@ describe('syncCodexConfig', () => {
       projectDir: '/tmp/zylos',
       existsSync: () => true,
       // Return stale content so drift is detected
-      readFileSync: () => 'stale-content\n',
+      readFileSync: () => 'model = "gpt-5.4"\n',
       writeConfig: () => false,
       log: () => {},
     });

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -58,6 +58,7 @@ describe('Claude settings template', () => {
     assert.ok(template.permissions.allow.includes('mcp__composio__COMPOSIO_SEARCH_TOOLS'));
     assert.ok(template.permissions.deny.includes('mcp__composio__*BASH*'));
     assert.ok(template.permissions.deny.includes('mcp__composio__*WORKBENCH*'));
+    assert.equal(template.permissions.defaultMode, undefined);
     assert.equal(template.enableAllProjectMcpServers, undefined);
   });
 });

--- a/cli/lib/composio-mcp.js
+++ b/cli/lib/composio-mcp.js
@@ -1,0 +1,424 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+
+export const COMPOSIO_SERVER_NAME = 'composio';
+export const COMPOSIO_API_KEY_ENV = 'COMPOSIO_API_KEY';
+export const COMPOSIO_MCP_URL_ENV = 'COMPOSIO_MCP_URL';
+export const COMPOSIO_USER_ID_ENV = 'COMPOSIO_USER_ID';
+export const COMPOSIO_SESSION_ENDPOINT = 'https://backend.composio.dev/api/v3/tool_router/session';
+export const CLAUDE_COMPOSIO_MCP_MARKER_FILE = '.mcp.zylos.json';
+export const CODEX_COMPOSIO_MCP_MARKER_FILE = 'composio.zylos.json';
+
+export const COMPOSIO_META_TOOLS = [
+  'COMPOSIO_SEARCH_TOOLS',
+  'COMPOSIO_GET_TOOL_SCHEMAS',
+  'COMPOSIO_MULTI_EXECUTE_TOOL',
+  'COMPOSIO_MANAGE_CONNECTIONS',
+];
+
+export const COMPOSIO_REMOTE_CODE_TOOLS = [
+  'COMPOSIO_REMOTE_BASH_TOOL',
+  'COMPOSIO_REMOTE_WORKBENCH',
+];
+
+export const CLAUDE_COMPOSIO_ALLOWED_TOOLS = COMPOSIO_META_TOOLS.map(
+  (tool) => `mcp__${COMPOSIO_SERVER_NAME}__${tool}`,
+);
+
+export const CLAUDE_COMPOSIO_DENIED_TOOLS = [
+  `mcp__${COMPOSIO_SERVER_NAME}__*BASH*`,
+  `mcp__${COMPOSIO_SERVER_NAME}__*WORKBENCH*`,
+  ...COMPOSIO_REMOTE_CODE_TOOLS.map((tool) => `mcp__${COMPOSIO_SERVER_NAME}__${tool}`),
+];
+
+function parseEnvContent(content = '') {
+  const vars = {};
+  for (const rawLine of content.split('\n')) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx < 1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    vars[key] = value;
+  }
+  return vars;
+}
+
+function upsertEnvValue(content, key, value, comment = null) {
+  const line = `${key}=${value}`;
+  if (content.match(new RegExp(`^${key}=.*$`, 'm'))) {
+    return content.replace(new RegExp(`^${key}=.*$`, 'm'), line);
+  }
+  const prefix = comment ? `\n\n# ${comment}\n` : '\n';
+  return content.trimEnd() + `${prefix}${line}\n`;
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && !!url.host;
+  } catch {
+    return false;
+  }
+}
+
+function readEnvVars(envPath) {
+  try {
+    return parseEnvContent(fs.readFileSync(envPath, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+export function writeTextFileAtomic(filePath, content, { mode = 0o600 } = {}) {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, content, { mode });
+  fs.renameSync(tmpPath, filePath);
+  try { fs.chmodSync(filePath, mode); } catch {}
+}
+
+export function readJsonFile(filePath, readFileSync = fs.readFileSync) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function renderComposioMarker(mcpUrl) {
+  return JSON.stringify({
+    version: 1,
+    managedMcpServers: {
+      [COMPOSIO_SERVER_NAME]: {
+        source: 'zylos-core',
+        url: mcpUrl,
+        apiKeyEnv: COMPOSIO_API_KEY_ENV,
+      },
+    },
+  }, null, 2) + '\n';
+}
+
+function getComposioMarker(marker) {
+  const server = marker?.managedMcpServers?.[COMPOSIO_SERVER_NAME];
+  if (!server || typeof server !== 'object') return null;
+  if (server.source !== 'zylos-core') return null;
+  if (server.apiKeyEnv !== COMPOSIO_API_KEY_ENV) return null;
+  if (!isValidHttpUrl(String(server.url || ''))) return null;
+  return server;
+}
+
+function matchesComposioMarker(server, marker) {
+  const managed = getComposioMarker(marker);
+  if (!server || typeof server !== 'object' || !managed) return false;
+  return String(server.url || '') === managed.url;
+}
+
+export function renderClaudeComposioMarker(mcpUrl) {
+  return renderComposioMarker(mcpUrl);
+}
+
+export function getClaudeComposioMarker(marker) {
+  return getComposioMarker(marker);
+}
+
+export function matchesClaudeComposioMarker(server, marker) {
+  return matchesComposioMarker(server, marker);
+}
+
+export function renderCodexComposioMarker(mcpUrl) {
+  return renderComposioMarker(mcpUrl);
+}
+
+export function getCodexComposioMarker(marker) {
+  return getComposioMarker(marker);
+}
+
+export function matchesCodexComposioMarker(server, marker) {
+  return matchesComposioMarker(server, marker);
+}
+
+export function isDesiredCodexComposioServer(server, mcpUrl) {
+  if (!server || typeof server !== 'object') return false;
+  return String(server.url || '') === mcpUrl &&
+    String(server.bearer_token_env_var || '') === COMPOSIO_API_KEY_ENV &&
+    Array.isArray(server.disabled_tools) &&
+    COMPOSIO_REMOTE_CODE_TOOLS.every((tool) => server.disabled_tools.includes(tool));
+}
+
+function quoteCurlConfigValue(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export function deriveComposioUserId({ projectDir, envVars = {} } = {}) {
+  const explicitUserId = String(envVars[COMPOSIO_USER_ID_ENV] || '').trim();
+  if (explicitUserId) return explicitUserId;
+  const stableInput = path.resolve(projectDir || process.env.ZYLOS_DIR || process.cwd());
+  const digest = crypto.createHash('sha256').update(stableInput).digest('hex').slice(0, 24);
+  return `zylos-${digest}`;
+}
+
+export function createComposioToolRouterSession(apiKey, {
+  userId,
+  projectDir,
+  execFile = execFileSync,
+  endpoint = COMPOSIO_SESSION_ENDPOINT,
+} = {}) {
+  const resolvedUserId = userId || deriveComposioUserId({ projectDir });
+  const payload = JSON.stringify({
+    user_id: resolvedUserId,
+    workbench: {
+      enable: false,
+    },
+  });
+  const curlConfig = [
+    `header = "x-api-key: ${quoteCurlConfigValue(apiKey)}"`,
+    'header = "content-type: application/json"',
+  ].join('\n') + '\n';
+  const output = execFile('curl', [
+    '-fsS',
+    '-X', 'POST',
+    endpoint,
+    '--config', '-',
+    '--data', payload,
+  ], { encoding: 'utf8', timeout: 30000, input: curlConfig });
+  const parsed = JSON.parse(output);
+  const toolNames = Array.isArray(parsed?.tool_router_tools)
+    ? parsed.tool_router_tools.map((tool) => typeof tool === 'string' ? tool : tool?.name).filter(Boolean)
+    : [];
+  const exposedRemoteCodeTools = COMPOSIO_REMOTE_CODE_TOOLS.filter((tool) => toolNames.includes(tool));
+  if (exposedRemoteCodeTools.length > 0) {
+    throw new Error(`Composio session still exposes remote code tools: ${exposedRemoteCodeTools.join(', ')}`);
+  }
+  const mcpUrl = parsed?.mcp?.url || parsed?.url || '';
+  if (!isValidHttpUrl(mcpUrl)) {
+    throw new Error('Composio session response did not include a valid MCP URL.');
+  }
+  return mcpUrl;
+}
+
+export function resolveComposioMcpUrl({
+  projectDir,
+  envPath = path.join(projectDir, '.env'),
+  createSession = createComposioToolRouterSession,
+  createMissingSession = true,
+  writeFileAtomic = writeTextFileAtomic,
+  readFileSync = fs.readFileSync,
+  mkdirSync = fs.mkdirSync,
+} = {}) {
+  let content = '';
+  try { content = readFileSync(envPath, 'utf8'); } catch {}
+  const vars = parseEnvContent(content);
+  const apiKey = (vars[COMPOSIO_API_KEY_ENV] || '').trim();
+  const userId = deriveComposioUserId({ projectDir, envVars: vars });
+  let mcpUrl = (vars[COMPOSIO_MCP_URL_ENV] || '').trim();
+
+  if (!apiKey) {
+    return { enabled: false, reason: 'missing_api_key', mcpUrl: '' };
+  }
+
+  if (!mcpUrl) {
+    if (!createMissingSession) {
+      return { enabled: false, reason: 'missing_mcp_url', mcpUrl: '' };
+    }
+    try {
+      mcpUrl = createSession(apiKey, { userId, projectDir });
+    } catch (err) {
+      return { enabled: false, reason: 'session_create_failed', mcpUrl: '', error: err.message };
+    }
+    const nextContent = upsertEnvValue(
+      content,
+      COMPOSIO_MCP_URL_ENV,
+      mcpUrl,
+      'Composio Tool Router MCP URL (generated by zylos)',
+    );
+    mkdirSync(path.dirname(envPath), { recursive: true });
+    writeFileAtomic(envPath, nextContent, { mode: 0o600 });
+  }
+
+  if (!isValidHttpUrl(mcpUrl)) {
+    return { enabled: false, reason: 'invalid_mcp_url', mcpUrl };
+  }
+
+  return { enabled: true, reason: 'configured', mcpUrl, apiKey };
+}
+
+export function renderClaudeComposioMcpJson({ mcpUrl, apiKey }) {
+  return JSON.stringify({
+    mcpServers: {
+      [COMPOSIO_SERVER_NAME]: {
+        type: 'http',
+        url: mcpUrl,
+        headers: {
+          'x-api-key': apiKey,
+        },
+      },
+    },
+  }, null, 2) + '\n';
+}
+
+export function renderTemplateComposioMcpJson() {
+  return JSON.stringify({
+    mcpServers: {
+      [COMPOSIO_SERVER_NAME]: {
+        type: 'http',
+        url: '${COMPOSIO_MCP_URL}',
+        headers: {
+          'x-api-key': '${COMPOSIO_API_KEY}',
+        },
+      },
+    },
+  }, null, 2) + '\n';
+}
+
+export function syncClaudeComposioMcpJson({
+  projectDir,
+  envPath = path.join(projectDir, '.env'),
+  mcpPath = path.join(projectDir, '.mcp.json'),
+  markerPath = path.join(projectDir, CLAUDE_COMPOSIO_MCP_MARKER_FILE),
+  dryRun = false,
+  resolve = resolveComposioMcpUrl,
+  existsSync = fs.existsSync,
+  readFileSync = fs.readFileSync,
+  mkdirSync = fs.mkdirSync,
+  unlinkSync = fs.unlinkSync,
+  writeMcp = writeTextFileAtomic,
+  log = () => {},
+} = {}) {
+  const resolved = resolve({ projectDir, envPath, createMissingSession: !dryRun });
+  let current = {};
+  let hadValidJson = true;
+  if (existsSync(mcpPath)) {
+    current = readJsonFile(mcpPath, readFileSync);
+    if (!current) {
+      hadValidJson = false;
+    }
+  }
+  const marker = readJsonFile(markerPath, readFileSync);
+
+  if (!hadValidJson) {
+    log(`  Warning: ${mcpPath} is not valid JSON; Composio MCP sync skipped.`);
+    return { changed: false, enabled: resolved.enabled, skipped: true, reason: 'invalid_json' };
+  }
+
+  current.mcpServers = current.mcpServers && typeof current.mcpServers === 'object'
+    ? current.mcpServers
+    : {};
+
+  if (!resolved.enabled) {
+    const existing = current.mcpServers[COMPOSIO_SERVER_NAME];
+    if (matchesClaudeComposioMarker(existing, marker)) {
+      delete current.mcpServers[COMPOSIO_SERVER_NAME];
+      if (Object.keys(current.mcpServers).length === 0) delete current.mcpServers;
+      if (Object.keys(current).length === 0) {
+        if (!dryRun) {
+          try { unlinkSync(mcpPath); } catch {}
+        }
+      } else {
+        if (!dryRun) {
+          mkdirSync(path.dirname(mcpPath), { recursive: true });
+          writeMcp(mcpPath, JSON.stringify(current, null, 2) + '\n');
+        }
+      }
+      if (!dryRun) {
+        try { unlinkSync(markerPath); } catch {}
+      }
+      return { changed: true, enabled: false, reason: resolved.reason, mcpUrl: resolved.mcpUrl };
+    }
+    if (!existing && getClaudeComposioMarker(marker)) {
+      if (!dryRun) {
+        try { unlinkSync(markerPath); } catch {}
+      }
+      return { changed: true, enabled: false, reason: resolved.reason, mcpUrl: resolved.mcpUrl };
+    }
+    return { changed: false, enabled: false, reason: resolved.reason, mcpUrl: resolved.mcpUrl };
+  }
+
+  const desired = JSON.parse(renderClaudeComposioMcpJson(resolved));
+  const before = JSON.stringify(current.mcpServers[COMPOSIO_SERVER_NAME] || null);
+  if (current.mcpServers[COMPOSIO_SERVER_NAME] &&
+      before !== JSON.stringify(desired.mcpServers[COMPOSIO_SERVER_NAME]) &&
+      !matchesClaudeComposioMarker(current.mcpServers[COMPOSIO_SERVER_NAME], marker)) {
+    log(`  Warning: ${mcpPath} already has an unmarked Composio MCP server; leaving it unchanged.`);
+    return {
+      changed: false,
+      enabled: false,
+      skipped: true,
+      reason: 'user_owned_collision',
+      mcpUrl: resolved.mcpUrl,
+    };
+  }
+
+  current.mcpServers[COMPOSIO_SERVER_NAME] = desired.mcpServers[COMPOSIO_SERVER_NAME];
+  const after = JSON.stringify(current.mcpServers[COMPOSIO_SERVER_NAME]);
+  const desiredMarker = renderClaudeComposioMarker(resolved.mcpUrl);
+  const currentMarker = existsSync(markerPath) ? readFileSync(markerPath, 'utf8') : '';
+  if (before === after && currentMarker === desiredMarker) {
+    return { changed: false, enabled: true, reason: resolved.reason, mcpUrl: resolved.mcpUrl };
+  }
+
+  if (!dryRun) {
+    mkdirSync(path.dirname(mcpPath), { recursive: true });
+    writeMcp(mcpPath, JSON.stringify(current, null, 2) + '\n');
+    writeMcp(markerPath, desiredMarker);
+  }
+  return { changed: true, enabled: true, reason: resolved.reason, mcpUrl: resolved.mcpUrl };
+}
+
+export function syncClaudeComposioSettings(settings, templateSettings = {}, { dryRun = false } = {}) {
+  let changed = false;
+  const templateServers = Array.isArray(templateSettings.enabledMcpjsonServers)
+    ? templateSettings.enabledMcpjsonServers
+    : [COMPOSIO_SERVER_NAME];
+
+  if (!Array.isArray(settings.enabledMcpjsonServers)) {
+    if (!dryRun) settings.enabledMcpjsonServers = [];
+    changed = true;
+  }
+  const enabledServers = Array.isArray(settings.enabledMcpjsonServers) ? settings.enabledMcpjsonServers : [];
+  for (const server of templateServers) {
+    if (!enabledServers.includes(server)) {
+      if (!dryRun) settings.enabledMcpjsonServers.push(server);
+      changed = true;
+    }
+  }
+
+  const templatePermissions = templateSettings.permissions || {};
+  const allow = Array.isArray(templatePermissions.allow)
+    ? templatePermissions.allow
+    : CLAUDE_COMPOSIO_ALLOWED_TOOLS;
+  const deny = Array.isArray(templatePermissions.deny)
+    ? templatePermissions.deny
+    : CLAUDE_COMPOSIO_DENIED_TOOLS;
+
+  if (!settings.permissions || typeof settings.permissions !== 'object') {
+    if (!dryRun) settings.permissions = {};
+    changed = true;
+  }
+  const permissions = settings.permissions && typeof settings.permissions === 'object' ? settings.permissions : {};
+  for (const [key, values] of [['allow', allow], ['deny', deny]]) {
+    if (!Array.isArray(permissions[key])) {
+      if (!dryRun) settings.permissions[key] = [];
+      changed = true;
+    }
+    const existing = Array.isArray(permissions[key]) ? permissions[key] : [];
+    for (const value of values) {
+      if (!existing.includes(value)) {
+        if (!dryRun) settings.permissions[key].push(value);
+        changed = true;
+      }
+    }
+  }
+
+  return { changed };
+}
+
+export function getComposioEnv(projectDir) {
+  return readEnvVars(path.join(projectDir, '.env'));
+}

--- a/cli/lib/composio-mcp.js
+++ b/cli/lib/composio-mcp.js
@@ -343,7 +343,6 @@ export function syncClaudeComposioMcpJson({
   const desired = JSON.parse(renderClaudeComposioMcpJson(resolved));
   const before = JSON.stringify(current.mcpServers[COMPOSIO_SERVER_NAME] || null);
   if (current.mcpServers[COMPOSIO_SERVER_NAME] &&
-      before !== JSON.stringify(desired.mcpServers[COMPOSIO_SERVER_NAME]) &&
       !matchesClaudeComposioMarker(current.mcpServers[COMPOSIO_SERVER_NAME], marker)) {
     log(`  Warning: ${mcpPath} already has an unmarked Composio MCP server; leaving it unchanged.`);
     return {

--- a/cli/lib/runtime-setup.js
+++ b/cli/lib/runtime-setup.js
@@ -342,13 +342,19 @@ const CODEX_MODEL_MIGRATIONS = {
   'gpt-5.3-codex': 'gpt-5.4',
 };
 
-function parseCodexToml(content) {
-  if (!content.trim()) return {};
+function tryParseCodexToml(content) {
+  if (!content.trim()) return { ok: true, value: {} };
   try {
-    return parse(content);
-  } catch {
-    return {};
+    return { ok: true, value: parse(content) };
+  } catch (error) {
+    return { ok: false, error };
   }
+}
+
+function parseCodexToml(content) {
+  const result = tryParseCodexToml(content);
+  if (!result.ok) throw result.error;
+  return result.value;
 }
 
 function tomlWithHeader(header, obj) {
@@ -372,7 +378,9 @@ function isTomlSectionValue(value) {
  * @returns {string}
  */
 export function renderCodexProjectConfig(existingContent = '', opts = {}) {
-  const obj = parseCodexToml(existingContent);
+  const parsed = tryParseCodexToml(existingContent);
+  if (!parsed.ok) return existingContent;
+  const obj = parsed.value;
 
   // Always overwrite: these values are required for unattended Zylos runtime behavior.
   obj.check_for_update_on_startup = false;
@@ -431,7 +439,9 @@ export function renderCodexProjectConfig(existingContent = '', opts = {}) {
 export function renderCodexGlobalConfig(projectDir, existingContent = '', opts = {}) {
   const absProject = path.resolve(projectDir);
   const openaiBaseUrl = opts.openaiBaseUrl || process.env.OPENAI_BASE_URL || '';
-  const obj = parseCodexToml(existingContent);
+  const parsed = tryParseCodexToml(existingContent);
+  if (!parsed.ok) return existingContent;
+  const obj = parsed.value;
   if (openaiBaseUrl) {
     obj.openai_base_url = openaiBaseUrl;
   }
@@ -456,6 +466,26 @@ export function renderCodexGlobalConfig(projectDir, existingContent = '', opts =
  */
 export function writeCodexConfig(projectDir, opts = {}) {
   try {
+    const projectCodexDir = path.join(path.resolve(projectDir), '.codex');
+    const projectConfigPath = path.join(projectCodexDir, 'config.toml');
+    const codexMarkerPath = path.join(projectCodexDir, CODEX_COMPOSIO_MCP_MARKER_FILE);
+    let existingProject = '';
+    try {
+      existingProject = fs.readFileSync(projectConfigPath, 'utf8');
+    } catch { /* new file — nothing to preserve */ }
+
+    const globalCodexDir = path.join(os.homedir(), '.codex');
+    const globalConfigPath = path.join(globalCodexDir, 'config.toml');
+    let existing = '';
+    try {
+      existing = fs.readFileSync(globalConfigPath, 'utf8');
+    } catch { /* new file — nothing to preserve */ }
+
+    const parsedProject = tryParseCodexToml(existingProject);
+    if (!parsedProject.ok) return false;
+    const parsedGlobal = tryParseCodexToml(existing);
+    if (!parsedGlobal.ok) return false;
+
     const composio = opts.composioMcpUrl !== undefined
       ? { enabled: !!opts.composioMcpUrl, mcpUrl: opts.composioMcpUrl }
       : resolveComposioMcpUrl({ projectDir });
@@ -464,25 +494,18 @@ export function writeCodexConfig(projectDir, opts = {}) {
     }
 
     // Write project-level config
-    const projectCodexDir = path.join(path.resolve(projectDir), '.codex');
     fs.mkdirSync(projectCodexDir, { recursive: true });
-    const projectConfigPath = path.join(projectCodexDir, 'config.toml');
-    const codexMarkerPath = path.join(projectCodexDir, CODEX_COMPOSIO_MCP_MARKER_FILE);
     const codexMarker = readJsonFile(codexMarkerPath);
-    let existingProject = '';
-    try {
-      existingProject = fs.readFileSync(projectConfigPath, 'utf8');
-    } catch { /* new file — nothing to preserve */ }
-    const existingComposio = parseCodexToml(existingProject).mcp_servers?.[COMPOSIO_SERVER_NAME];
+    const existingComposio = parsedProject.value.mcp_servers?.[COMPOSIO_SERVER_NAME];
     const composioMcpUrl = composio.enabled ? composio.mcpUrl : '';
     const renderedProject = renderCodexProjectConfig(existingProject, {
       composioMcpUrl,
       codexComposioMarker: codexMarker,
     });
-    fs.writeFileSync(
+    writeTextFileAtomic(
       projectConfigPath,
       renderedProject,
-      'utf8'
+      { mode: 0o600 }
     );
     const renderedComposio = parseCodexToml(renderedProject).mcp_servers?.[COMPOSIO_SERVER_NAME];
     if (composioMcpUrl &&
@@ -494,17 +517,11 @@ export function writeCodexConfig(projectDir, opts = {}) {
     }
 
     // Write global config
-    const globalCodexDir = path.join(os.homedir(), '.codex');
-    const globalConfigPath = path.join(globalCodexDir, 'config.toml');
-    let existing = '';
-    try {
-      existing = fs.readFileSync(globalConfigPath, 'utf8');
-    } catch { /* new file — nothing to preserve */ }
     fs.mkdirSync(globalCodexDir, { recursive: true });
-    fs.writeFileSync(
+    writeTextFileAtomic(
       globalConfigPath,
       renderCodexGlobalConfig(projectDir, existing, opts),
-      'utf8'
+      { mode: 0o600 }
     );
 
     return true;

--- a/cli/lib/runtime-setup.js
+++ b/cli/lib/runtime-setup.js
@@ -14,6 +14,19 @@ import { parse, stringify } from 'smol-toml';
 import { ZYLOS_DIR } from './config.js';
 import { commandExists } from './shell-utils.js';
 import { parseClaudeAuthStatus, parseCodexLoginStatus } from './auth-parsers.js';
+import {
+  CODEX_COMPOSIO_MCP_MARKER_FILE,
+  COMPOSIO_API_KEY_ENV,
+  COMPOSIO_REMOTE_CODE_TOOLS,
+  COMPOSIO_SERVER_NAME,
+  isDesiredCodexComposioServer,
+  matchesCodexComposioMarker,
+  readJsonFile,
+  renderCodexComposioMarker,
+  resolveComposioMcpUrl,
+  syncClaudeComposioMcpJson,
+  writeTextFileAtomic,
+} from './composio-mcp.js';
 
 function upsertEnvValue(content, key, value, comment = null) {
   const line = `${key}=${value}`;
@@ -358,7 +371,7 @@ function isTomlSectionValue(value) {
  * @param {string} existingContent - Existing project config.toml contents (optional)
  * @returns {string}
  */
-export function renderCodexProjectConfig(existingContent = '') {
+export function renderCodexProjectConfig(existingContent = '', opts = {}) {
   const obj = parseCodexToml(existingContent);
 
   // Always overwrite: these values are required for unattended Zylos runtime behavior.
@@ -382,6 +395,23 @@ export function renderCodexProjectConfig(existingContent = '') {
   }
   notice.model_migrations = { ...CODEX_MODEL_MIGRATIONS };
   obj.notice = notice;
+
+  obj.mcp_servers = isTomlSectionValue(obj.mcp_servers) ? obj.mcp_servers : {};
+  const existingComposio = obj.mcp_servers[COMPOSIO_SERVER_NAME];
+  if (opts.composioMcpUrl) {
+    const desiredComposio = {
+      url: opts.composioMcpUrl,
+      bearer_token_env_var: COMPOSIO_API_KEY_ENV,
+      disabled_tools: COMPOSIO_REMOTE_CODE_TOOLS,
+    };
+    if (!existingComposio ||
+        matchesCodexComposioMarker(existingComposio, opts.codexComposioMarker)) {
+      obj.mcp_servers[COMPOSIO_SERVER_NAME] = desiredComposio;
+    }
+  } else if (matchesCodexComposioMarker(existingComposio, opts.codexComposioMarker)) {
+    delete obj.mcp_servers[COMPOSIO_SERVER_NAME];
+  }
+  if (Object.keys(obj.mcp_servers).length === 0) delete obj.mcp_servers;
 
   return tomlWithHeader(CODEX_PROJECT_HEADER, obj);
 }
@@ -426,19 +456,42 @@ export function renderCodexGlobalConfig(projectDir, existingContent = '', opts =
  */
 export function writeCodexConfig(projectDir, opts = {}) {
   try {
+    const composio = opts.composioMcpUrl !== undefined
+      ? { enabled: !!opts.composioMcpUrl, mcpUrl: opts.composioMcpUrl }
+      : resolveComposioMcpUrl({ projectDir });
+    if (opts.composioMcpUrl === undefined) {
+      syncClaudeComposioMcpJson({ projectDir, resolve: () => composio });
+    }
+
     // Write project-level config
     const projectCodexDir = path.join(path.resolve(projectDir), '.codex');
     fs.mkdirSync(projectCodexDir, { recursive: true });
     const projectConfigPath = path.join(projectCodexDir, 'config.toml');
+    const codexMarkerPath = path.join(projectCodexDir, CODEX_COMPOSIO_MCP_MARKER_FILE);
+    const codexMarker = readJsonFile(codexMarkerPath);
     let existingProject = '';
     try {
       existingProject = fs.readFileSync(projectConfigPath, 'utf8');
     } catch { /* new file — nothing to preserve */ }
+    const existingComposio = parseCodexToml(existingProject).mcp_servers?.[COMPOSIO_SERVER_NAME];
+    const composioMcpUrl = composio.enabled ? composio.mcpUrl : '';
+    const renderedProject = renderCodexProjectConfig(existingProject, {
+      composioMcpUrl,
+      codexComposioMarker: codexMarker,
+    });
     fs.writeFileSync(
       projectConfigPath,
-      renderCodexProjectConfig(existingProject),
+      renderedProject,
       'utf8'
     );
+    const renderedComposio = parseCodexToml(renderedProject).mcp_servers?.[COMPOSIO_SERVER_NAME];
+    if (composioMcpUrl &&
+        isDesiredCodexComposioServer(renderedComposio, composioMcpUrl) &&
+        (!existingComposio || matchesCodexComposioMarker(existingComposio, codexMarker))) {
+      writeTextFileAtomic(codexMarkerPath, renderCodexComposioMarker(composioMcpUrl), { mode: 0o600 });
+    } else if (codexMarker && !matchesCodexComposioMarker(renderedComposio, codexMarker)) {
+      try { fs.unlinkSync(codexMarkerPath); } catch {}
+    }
 
     // Write global config
     const globalCodexDir = path.join(os.homedir(), '.codex');

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -24,6 +24,12 @@ import { fileURLToPath } from 'url';
 import { extractScriptPath, extractSkillName, getCommandHooks } from './hook-utils.js';
 import { getZylosConfig, updateZylosConfig } from './config.js';
 import { renderCodexProjectConfig, renderCodexGlobalConfig, writeCodexConfig } from './runtime-setup.js';
+import {
+  CODEX_COMPOSIO_MCP_MARKER_FILE,
+  readJsonFile,
+  syncClaudeComposioMcpJson,
+  syncClaudeComposioSettings,
+} from './composio-mcp.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ZYLOS_DIR = path.resolve(process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
@@ -145,11 +151,17 @@ export function syncCodexConfig({
   try { existingGlobal = readFileSync(state.globalConfigPath, 'utf8'); } catch {}
   let existingProject = '';
   try { existingProject = readFileSync(state.projectConfigPath, 'utf8'); } catch {}
+  const codexMarkerPath = path.join(path.dirname(state.projectConfigPath), CODEX_COMPOSIO_MCP_MARKER_FILE);
+  const codexComposioMarker = readJsonFile(codexMarkerPath, readFileSync);
 
-  const desiredProject = renderCodexProjectConfig(existingProject);
+  const mcpSync = syncClaudeComposioMcpJson({ projectDir, dryRun, log });
+  const desiredProject = renderCodexProjectConfig(existingProject, {
+    composioMcpUrl: mcpSync.enabled ? mcpSync.mcpUrl : '',
+    codexComposioMarker,
+  });
   const desiredGlobal = renderCodexGlobalConfig(projectDir, existingGlobal);
   if (existingProject === desiredProject && existingGlobal === desiredGlobal) {
-    return { attempted: true, changed: false, fatal: false };
+    return { attempted: true, changed: mcpSync.changed, fatal: false };
   }
 
   if (dryRun) {
@@ -171,6 +183,7 @@ export function syncCodexConfig({
     };
   }
 
+  if (mcpSync.changed) log(`  ~ claude MCP config: ${path.join(projectDir, '.mcp.json')}`);
   if (existingProject !== desiredProject) log(`  ~ codex project config: ${state.projectConfigPath}`);
   if (existingGlobal !== desiredGlobal) log(`  ~ codex global config: ${state.globalConfigPath}`);
   return { attempted: true, changed: true, fatal: false };
@@ -397,6 +410,11 @@ export function main(argv = process.argv.slice(2)) {
     dryRun,
   });
 
+  const composioSettingsSync = syncClaudeComposioSettings(installedSettings, templateSettings, { dryRun });
+  if (composioSettingsSync.changed) {
+    console.log('  ~ Composio MCP settings');
+  }
+
   // Backfill boolean settings (autoMemoryEnabled, autoDreamEnabled)
   const backfillKeys = ['autoMemoryEnabled', 'autoDreamEnabled'];
   let settingsBackfilled = false;
@@ -415,30 +433,30 @@ export function main(argv = process.argv.slice(2)) {
     process.exit(1);
   }
 
-  if (added === 0 && updated === 0 && removed === 0 && !statusLineChanged && !modelSync.changed && !settingsBackfilled && !codexSync.changed) {
+  if (added === 0 && updated === 0 && removed === 0 && !statusLineChanged && !modelSync.changed && !settingsBackfilled && !composioSettingsSync.changed && !codexSync.changed) {
     console.log('Settings hooks: all up to date (no changes).');
     return;
   }
 
   if (dryRun) {
-    console.log(`Settings hooks (dry run): ${added} to add, ${updated} to update, ${removed} to remove${statusLineChanged ? ', statusLine to update' : ''}${modelSync.changed ? ', model to backfill' : ''}${settingsBackfilled ? ', settings to backfill' : ''}${codexSync.changed ? ', codex config to refresh' : ''}.`);
+    console.log(`Settings hooks (dry run): ${added} to add, ${updated} to update, ${removed} to remove${statusLineChanged ? ', statusLine to update' : ''}${modelSync.changed ? ', model to backfill' : ''}${settingsBackfilled ? ', settings to backfill' : ''}${composioSettingsSync.changed ? ', Composio MCP settings to refresh' : ''}${codexSync.changed ? ', codex config to refresh' : ''}.`);
     return;
   }
 
   // Write settings first. The paired threshold default is written only after
   // the model backfill has persisted, so a crash cannot leave threshold=30
-  // without the matching opus[1m] settings model.
+  // without the matching settings model.
   const thresholdSync = persistInstalledSettingsAndSyncCoupledThreshold({
     installedSettings,
     modelBackfilled: modelSync.changed,
   });
 
-  if (added === 0 && updated === 0 && removed === 0 && !statusLineChanged && !modelSync.changed && !settingsBackfilled) {
+  if (added === 0 && updated === 0 && removed === 0 && !statusLineChanged && !modelSync.changed && !settingsBackfilled && !composioSettingsSync.changed) {
     console.log(`Settings hooks: all up to date; Codex config ${codexSync.changed ? 'refreshed' : 'unchanged'}.`);
     return;
   }
 
-  console.log(`Settings hooks: ${added} added, ${updated} updated, ${removed} removed${statusLineChanged ? ', statusLine updated' : ''}${modelSync.changed ? ', model backfilled' : ''}${thresholdSync.changed ? ', new-session threshold paired' : ''}${settingsBackfilled ? ', settings backfilled' : ''}${codexSync.changed ? ', Codex config refreshed' : ''}.`);
+  console.log(`Settings hooks: ${added} added, ${updated} updated, ${removed} removed${statusLineChanged ? ', statusLine updated' : ''}${modelSync.changed ? ', model backfilled' : ''}${thresholdSync.changed ? ', new-session threshold paired' : ''}${settingsBackfilled ? ', settings backfilled' : ''}${composioSettingsSync.changed ? ', Composio MCP settings refreshed' : ''}${codexSync.changed ? ', Codex config refreshed' : ''}.`);
 
   // Enqueue restart when hooks changed — this runs from the NEWLY installed
   // package during upgrade (via resolveInstalledSyncScript), so it works even

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -2,6 +2,23 @@
   "model": "opus[1m]",
   "autoMemoryEnabled": false,
   "autoDreamEnabled": false,
+  "enabledMcpjsonServers": [
+    "composio"
+  ],
+  "permissions": {
+    "allow": [
+      "mcp__composio__COMPOSIO_SEARCH_TOOLS",
+      "mcp__composio__COMPOSIO_GET_TOOL_SCHEMAS",
+      "mcp__composio__COMPOSIO_MULTI_EXECUTE_TOOL",
+      "mcp__composio__COMPOSIO_MANAGE_CONNECTIONS"
+    ],
+    "deny": [
+      "mcp__composio__*BASH*",
+      "mcp__composio__*WORKBENCH*",
+      "mcp__composio__COMPOSIO_REMOTE_BASH_TOOL",
+      "mcp__composio__COMPOSIO_REMOTE_WORKBENCH"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -29,6 +29,15 @@ CLAUDE_BYPASS_PERMISSIONS=true
 # OPENAI_API_KEY=sk-xxx
 # Optional: custom OpenAI-compatible base URL for Codex
 # OPENAI_BASE_URL=https://api.example.com/v1
+
+# Composio Tool Router MCP integration
+# Leave blank to keep the integration disabled. Set COMPOSIO_API_KEY and
+# zylos will generate/reuse COMPOSIO_MCP_URL during init/runtime setup.
+COMPOSIO_API_KEY=
+COMPOSIO_MCP_URL=
+# Optional stable Composio user_id override. Leave blank to derive per instance.
+COMPOSIO_USER_ID=
+
 # Proxy (if needed for external API access)
 # HTTP_PROXY=http://proxy:port
 # HTTPS_PROXY=http://proxy:port

--- a/templates/.mcp.json
+++ b/templates/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "composio": {
+      "type": "http",
+      "url": "${COMPOSIO_MCP_URL}",
+      "headers": {
+        "x-api-key": "${COMPOSIO_API_KEY}"
+      }
+    }
+  }
+}

--- a/templates/runtime-env.manifest.example
+++ b/templates/runtime-env.manifest.example
@@ -29,6 +29,13 @@ env TZ
 # ── Agent permissions ─────────────────────────────────────────────────────────
 # env CLAUDE_BYPASS_PERMISSIONS
 
+# ── Composio MCP ──────────────────────────────────────────────────────────────
+# Blank .env values are ignored by the runtime; populated values enable the
+# generated Composio MCP registration.
+env COMPOSIO_API_KEY
+env COMPOSIO_MCP_URL
+env COMPOSIO_USER_ID
+
 # ── Observability (OTel) ──────────────────────────────────────────────────────
 # Uncomment to enable telemetry collection in agent sessions.
 # env CLAUDE_CODE_ENABLE_TELEMETRY


### PR DESCRIPTION
## Summary

Lets any Zylos instance opt into **Composio** (MCP tool-aggregator, ~1,000+ apps with JIT tool-scoping via the Tool Router) by setting `COMPOSIO_API_KEY` in `.env`. One Composio account per instance; the MCP URL is generated/reused automatically during init / runtime setup.

Six integration pieces: `templates/.mcp.json`, the sync step, `enabledMcpjsonServers` in settings, the Codex `config.toml` block, blank `.env` vars, and runtime-switch reapply. Works for both the Claude Code and Codex runtimes.

## Security posture

- **Remote code execution disabled at the source.** The Tool Router session is minted with top-level `workbench: { enable: false }`, which removes `COMPOSIO_REMOTE_BASH_TOOL` and `COMPOSIO_REMOTE_WORKBENCH` from the session entirely (verified live: session tools drop 6 → 4). The runtime allow/deny list is retained as defense-in-depth. A session that still exposes those tools is rejected.
- Session mint requires `user_id` (v3 API — a `{}` body returns 400 and silently broke the mint before this change).
- API key is never placed in argv — it is passed to `curl` via `--config` on stdin.
- Generated `.env` / config writes are atomic (tmp + rename, mode 0600).
- Idempotent re-runs never clobber or silently adopt a user's pre-existing, unmarked `composio` entry (Claude `.mcp.json` and Codex `config.toml`); cleanup only removes zylos-marked entries.

## Prod-readiness review

Partitioned review found 1 HIGH + 2 MEDIUM + 3 LOW; all reconciled and patched:
- **H1** — bash/workbench bypass via `MULTI_EXECUTE` → closed via `workbench:{enable:false}` (+ required `user_id`).
- **M1** — Codex config cleanup is marker-only (never clobbers user entries).
- **M2** — atomic `.env` write (tmp+rename, 0600).
- **L1** — API key kept off the command line.
- **L3** — deny-by-default template posture (no permissive `defaultMode`; only the 4 meta tools allowed; bash/workbench denied).

## Verification (independent VM pass on `3c5bac3`)

- H1 confirmed **live** against a real Composio account: 6→4 tools, no BASH/WORKBENCH; empty `{}` body → 400.
- Node test suite: **550/550** pass; Composio files (composio-mcp / runtime-setup / sync-settings-hooks) **91/91**.
- `git diff --check` clean; syntax checks pass.

> ⚠️ **Cascade risk:** zylos-core upgrades cascade to ALL instances. Merge only after the independent reviewer pass + final VM sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)