### PR TITLE
[codex] sync Codex auth source before agent launch

### DIFF
--- a/cli/lib/__tests__/codex.test.js
+++ b/cli/lib/__tests__/codex.test.js
@@ -22,7 +22,12 @@ fs.writeFileSync(
 process.env.CODEX_BIN = fakeCodexPath;
 after(() => { try { fs.rmSync(fakeBinDir, { recursive: true, force: true }); } catch {} });
 
-const { CodexAdapter, buildCodexBootstrapPrompt, isOnboardingPendingState } = await import('../runtime/codex.js');
+const {
+  CodexAdapter,
+  buildCodexBootstrapPrompt,
+  isOnboardingPendingState,
+  syncCodexAuthFromSource,
+} = await import('../runtime/codex.js');
 
 function makeZylosDir(stateContent) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-bootstrap-test-'));
@@ -82,6 +87,45 @@ describe('Codex bootstrap onboarding guard', () => {
 });
 
 describe('Codex auth checks', () => {
+  it('syncs Codex auth from a configured host source before runtime use', () => {
+    const sourceHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-source-'));
+    const agentHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-agent-'));
+    tmpDirs.push(sourceHome, agentHome);
+
+    const sourcePath = path.join(sourceHome, '.codex', 'auth.json');
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(
+      sourcePath,
+      JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: 'fresh' } }, null, 2) + '\n',
+      { mode: 0o600 }
+    );
+
+    const result = syncCodexAuthFromSource({ sourcePath, homeDir: agentHome });
+    const destPath = path.join(agentHome, '.codex', 'auth.json');
+
+    assert.deepEqual(result, { synced: true, reason: 'synced' });
+    assert.equal(fs.readFileSync(destPath, 'utf8'), fs.readFileSync(sourcePath, 'utf8'));
+    assert.equal(fs.statSync(destPath).mode & 0o777, 0o600);
+  });
+
+  it('does not overwrite existing Codex auth when the configured source is invalid', () => {
+    const sourceHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-source-'));
+    const agentHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-agent-'));
+    tmpDirs.push(sourceHome, agentHome);
+
+    const sourcePath = path.join(sourceHome, '.codex', 'auth.json');
+    const destPath = path.join(agentHome, '.codex', 'auth.json');
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.writeFileSync(sourcePath, '{not-json\n', 'utf8');
+    fs.writeFileSync(destPath, JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: 'old' } }) + '\n', 'utf8');
+
+    const result = syncCodexAuthFromSource({ sourcePath, homeDir: agentHome });
+
+    assert.deepEqual(result, { synced: false, reason: 'source_unreadable_or_invalid' });
+    assert.match(fs.readFileSync(destPath, 'utf8'), /"old"/);
+  });
+
   it('uses the configured custom base URL for API key auth checks', async () => {
     const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-codex-auth-test-'));
     tmpDirs.push(tmpHome);

--- a/cli/lib/heartbeat/codex-probe.js
+++ b/cli/lib/heartbeat/codex-probe.js
@@ -39,6 +39,12 @@ import { tmuxCapturePaneText } from '../runtime/tmux-helpers.js';
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const C4_CONTROL = path.join(ZYLOS_DIR, '.claude/skills/comm-bridge/scripts/c4-control.js');
 const AUTH_FAILURE_PATTERNS = [
+  /MCP client for [`'"]?codex_apps[`'"]? failed to start/i,
+  /HTTP\s+401/i,
+  /token_expired/i,
+  /access token could not be refreshed/i,
+  /refresh token was already used/i,
+  /log out and sign in again/i,
   /authentication failed/i,
   /not logged in/i,
   /invalid api key/i,
@@ -197,4 +203,3 @@ function _writePending(file, data) {
     return false;
   }
 }
-

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -66,6 +66,46 @@ function getCodexApiBaseUrl() {
   return 'https://api.openai.com/v1';
 }
 
+export function syncCodexAuthFromSource({
+  sourcePath = process.env.CODEX_AUTH_SOURCE,
+  homeDir = os.homedir(),
+  fsImpl = fs,
+} = {}) {
+  if (!sourcePath) return { synced: false, reason: 'not_configured' };
+  if (!path.isAbsolute(sourcePath)) return { synced: false, reason: 'source_not_absolute' };
+
+  const destPath = path.join(homeDir, '.codex', 'auth.json');
+  if (path.resolve(sourcePath) === path.resolve(destPath)) {
+    return { synced: false, reason: 'same_path' };
+  }
+
+  let sourceContent;
+  try {
+    const sourceStat = fsImpl.statSync(sourcePath);
+    if (!sourceStat.isFile()) return { synced: false, reason: 'source_not_file' };
+    sourceContent = fsImpl.readFileSync(sourcePath, 'utf8');
+    JSON.parse(sourceContent);
+  } catch {
+    return { synced: false, reason: 'source_unreadable_or_invalid' };
+  }
+
+  try {
+    if (fsImpl.existsSync(destPath) && fsImpl.readFileSync(destPath, 'utf8') === sourceContent) {
+      return { synced: false, reason: 'already_current' };
+    }
+
+    fsImpl.mkdirSync(path.dirname(destPath), { recursive: true, mode: 0o700 });
+    const tmpPath = `${destPath}.${process.pid}.${Date.now()}.tmp`;
+    fsImpl.writeFileSync(tmpPath, sourceContent, { mode: 0o600 });
+    fsImpl.chmodSync(tmpPath, 0o600);
+    fsImpl.renameSync(tmpPath, destPath);
+    fsImpl.chmodSync(destPath, 0o600);
+    return { synced: true, reason: 'synced' };
+  } catch {
+    return { synced: false, reason: 'write_failed' };
+  }
+}
+
 export function isOnboardingPendingState(stateContent = '') {
   return /^-\s+Status:\s+pending\b/m.test(stateContent);
 }
@@ -150,6 +190,8 @@ export class CodexAdapter extends RuntimeAdapter {
    * @returns {Promise<{status: 'success'|'failure'|'uncertain', reason: string}>}
    */
   async checkAuth() {
+    syncCodexAuthFromSource();
+
     // Read auth.json to determine the auth mode.
     let authMode = null;
     let apiKey = '';
@@ -275,6 +317,8 @@ export class CodexAdapter extends RuntimeAdapter {
    */
   async launch(opts = {}) {
     const bypassPermissions = opts.bypassPermissions ?? DEFAULT_BYPASS;
+
+    syncCodexAuthFromSource();
 
     // 1. Build AGENTS.md before launching (pass memorySnapshot for session rotation)
     await this.buildInstructionFile({ memorySnapshot: opts.memorySnapshot });

--- a/skills/activity-monitor/scripts/__tests__/health-engine.test.js
+++ b/skills/activity-monitor/scripts/__tests__/health-engine.test.js
@@ -639,6 +639,23 @@ describe('HealthEngine', () => {
       assert.equal(calls.killTmuxSession, 0);
       assert.deepStrictEqual(calls.enqueueHeartbeat, []);
     });
+
+    it('keeps auth_failed when pane still shows an auth failure even if checkAuth would pass', async () => {
+      const { deps, calls } = createMockDeps();
+      let checkAuthCalls = 0;
+      deps.detectAuthFailure = () => ({ detected: true, pattern: 'token_expired' });
+      deps.checkAuth = async () => { checkAuthCalls++; return { status: 'success' }; };
+      const engine = new HeartbeatEngine(deps, { initialHealth: 'auth_failed' });
+
+      const result = await engine.runRecoveryProbe({ timeoutMs: 100, pollIntervalMs: 1 });
+
+      assert.equal(result.recovered, false);
+      assert.equal(result.health, 'auth_failed');
+      assert.equal(result.reason, 'token_expired');
+      assert.equal(checkAuthCalls, 0);
+      assert.equal(calls.killTmuxSession, 0);
+      assert.deepStrictEqual(calls.enqueueHeartbeat, []);
+    });
   });
 
   describe('onUserMessageDelivered', () => {
@@ -840,6 +857,19 @@ describe('HealthEngine', () => {
       engine.processHeartbeat(true, Math.floor(Date.now() / 1000));
 
       assert.deepStrictEqual(calls.enqueueHeartbeat, ['recovery']);
+    });
+
+    it('enters auth_failed without restart when a running unavailable pane shows auth failure', () => {
+      const { deps, calls } = createMockDeps();
+      deps.detectAuthFailure = () => ({ detected: true, pattern: 'token_expired' });
+      const engine = new HeartbeatEngine(deps, { initialHealth: 'unavailable' });
+
+      engine.processHeartbeat(true, Math.floor(Date.now() / 1000));
+
+      assert.equal(engine.health, 'auth_failed');
+      assert.equal(engine.healthReason, 'token_expired');
+      assert.deepStrictEqual(calls.enqueueHeartbeat, []);
+      assert.equal(calls.killTmuxSession, 0);
     });
 
     it('sends post-restart probe after process signal grace', () => {
@@ -1207,6 +1237,24 @@ describe('HealthEngine', () => {
 
       assert.equal(engine.health, 'rate_limited');
       assert.equal(engine.cooldownUntil, 6000);
+    });
+
+    it('enters auth_failed and does not restart when heartbeat fails on an auth error pane', () => {
+      const { deps, calls } = createMockDeps();
+      deps.detectAuthFailure = () => ({ detected: true, pattern: 'token_expired' });
+      deps.detectRateLimit = () => {
+        throw new Error('rate limit should not be checked after auth failure');
+      };
+      deps._pending = { control_id: 1, phase: 'primary', created_at: 1000 };
+      deps._heartbeatStatus = 'timeout';
+      const engine = new HeartbeatEngine(deps);
+
+      engine.processHeartbeat(true, 1500);
+
+      assert.equal(engine.health, 'auth_failed');
+      assert.equal(engine.healthReason, 'token_expired');
+      assert.equal(calls.killTmuxSession, 0);
+      assert.deepStrictEqual(calls.enqueueHeartbeat, []);
     });
 
     it('does not check rate limit when detectRateLimit dep is not provided', () => {

--- a/skills/activity-monitor/scripts/health-engine.js
+++ b/skills/activity-monitor/scripts/health-engine.js
@@ -338,6 +338,16 @@ export class HealthEngine {
       return;
     }
 
+    if (isPostRestartProbeState(this.healthState) && this.deps.detectAuthFailure) {
+      const authFailure = this.deps.detectAuthFailure();
+      if (authFailure.detected) {
+        this.restartFailureCount = 0;
+        this.signalDetectedAt = 0;
+        this.setHealth('auth_failed', authFailure.pattern || 'auth_failure_detected');
+        return;
+      }
+    }
+
     // Process signal acceleration: agentRunning just transitioned false→true,
     // grace period elapsed — send immediate heartbeat to verify recovery.
     // Works in unavailable/recovering, down, and auth_failed states.
@@ -447,6 +457,17 @@ export class HealthEngine {
     const phase = pending.phase || 'primary';
     const now = Math.floor(Date.now() / 1000);
     this.deps.clearHeartbeatPending();
+
+    if ((this.healthState === 'ok' || isUnavailableRecoveryState(this.healthState) || this.healthState === 'rate_limited') && this.deps.detectAuthFailure) {
+      const authFailure = this.deps.detectAuthFailure();
+      if (authFailure.detected) {
+        this.restartFailureCount = 0;
+        this.recoveringStartedAt = 0;
+        this.signalDetectedAt = 0;
+        this.setHealth('auth_failed', authFailure.pattern || 'auth_failure_detected');
+        return;
+      }
+    }
 
     // Before triggering kill+restart recovery, check if the failure is due to
     // a rate limit. This is the "behavioral + text" dual-signal approach:
@@ -572,6 +593,13 @@ export class HealthEngine {
     this.lastRecoveryAt = Math.floor(Date.now() / 1000);
 
     if (this.healthState === 'auth_failed') {
+      const authFailure = this.deps.detectAuthFailure ? this.deps.detectAuthFailure() : { detected: false };
+      if (authFailure.detected) {
+        const reason = authFailure.pattern || this.healthReason || 'auth_still_failed';
+        this.setHealth('auth_failed', reason);
+        return { recovered: false, health: 'auth_failed', reason };
+      }
+
       const authResult = await this._checkAuth();
       if (authResult.status === 'success') {
         const now = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Summary
- sync Codex auth.json from CODEX_AUTH_SOURCE before Codex auth checks and launches
- recognize Codex MCP/OAuth token refresh failures in pane text
- keep health in auth_failed instead of killing/restarting when pane shows unrecoverable auth failure

## Root Cause
Isolated agent runtimes run with their own HOME, so Codex reads each agent's ~/.codex/auth.json. When the operator Codex auth is refreshed, those isolated copies can become stale unless the runtime has an explicit auth source to sync from. Some token refresh failures also appear in the Codex pane as MCP/codex_apps startup failures; restarting the same session cannot repair those.

## Validation
- node --test cli/lib/__tests__/codex.test.js
- node --test skills/activity-monitor/scripts/__tests__/health-engine.test.js
- node --check cli/lib/runtime/codex.js
- node --check cli/lib/heartbeat/codex-probe.js
- node --check skills/activity-monitor/scripts/health-engine.js