### PR TITLE
fix: guard opus[1m] model backfill against incompatible threshold

### DIFF
--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -291,6 +291,28 @@ describe('Claude model migration hints', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('downgrades 1m model in hint when threshold is above 30', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-model-guard-'));
+    const templatesDir = path.join(tmpDir, 'templates');
+    const zylosDir = path.join(tmpDir, 'zylos');
+
+    fs.mkdirSync(path.join(templatesDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(templatesDir, '.claude', 'settings.json'), JSON.stringify({ model: 'opus[1m]' }), 'utf8');
+    fs.writeFileSync(path.join(zylosDir, '.claude', 'settings.json'), JSON.stringify({ hooks: {} }), 'utf8');
+
+    const hints = generateMigrationHints(templatesDir, {
+      zylosDir,
+      getConfig: () => ({ new_session_threshold: 70 }),
+    });
+    assert.deepEqual(
+      hints.filter((hint) => hint.type === 'model_backfill'),
+      [{ type: 'model_backfill', value: 'opus' }]
+    );
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   it('does not add a model backfill hint when the user already configured model', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-model-nohint-'));
     const templatesDir = path.join(tmpDir, 'templates');

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -68,6 +68,7 @@ describe('syncTemplateModelSetting', () => {
     const result = syncTemplateModelSetting({
       templateSettings: { model: 'claude-opus-4-6' },
       installedSettings,
+      cfg: {},
       log: (line) => logs.push(line),
     });
 
@@ -82,6 +83,7 @@ describe('syncTemplateModelSetting', () => {
     const result = syncTemplateModelSetting({
       templateSettings: { model: 'opus' },
       installedSettings,
+      cfg: {},
       log: () => {
         throw new Error('should not log when model already exists');
       },
@@ -89,6 +91,67 @@ describe('syncTemplateModelSetting', () => {
 
     assert.equal(result.changed, false);
     assert.equal(installedSettings.model, 'sonnet');
+  });
+
+  it('downgrades opus[1m] to opus when threshold is above 30', () => {
+    const installedSettings = {};
+    const logs = [];
+
+    const result = syncTemplateModelSetting({
+      templateSettings: { model: 'opus[1m]' },
+      installedSettings,
+      cfg: { new_session_threshold: 70 },
+      log: (line) => logs.push(line),
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(installedSettings.model, 'opus');
+    assert.equal(result.model, 'opus');
+  });
+
+  it('keeps opus[1m] when threshold is not set', () => {
+    const installedSettings = {};
+    const logs = [];
+
+    const result = syncTemplateModelSetting({
+      templateSettings: { model: 'opus[1m]' },
+      installedSettings,
+      cfg: {},
+      log: (line) => logs.push(line),
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(installedSettings.model, 'opus[1m]');
+  });
+
+  it('keeps opus[1m] when threshold is at or below 30', () => {
+    const installedSettings = {};
+    const logs = [];
+
+    const result = syncTemplateModelSetting({
+      templateSettings: { model: 'opus[1m]' },
+      installedSettings,
+      cfg: { new_session_threshold: 30 },
+      log: (line) => logs.push(line),
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(installedSettings.model, 'opus[1m]');
+  });
+
+  it('does not guard non-1m models regardless of threshold', () => {
+    const installedSettings = {};
+    const logs = [];
+
+    const result = syncTemplateModelSetting({
+      templateSettings: { model: 'opus' },
+      installedSettings,
+      cfg: { new_session_threshold: 70 },
+      log: (line) => logs.push(line),
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(installedSettings.model, 'opus');
   });
 });
 

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -499,9 +499,14 @@ export function generateMigrationHints(templatesDir, deps = {}) {
   }
 
   if (Object.hasOwn(templateSettings, 'model') && !Object.hasOwn(installedSettings, 'model')) {
+    let model = templateSettings.model;
+    const cfg = (deps.getConfig ?? getZylosConfig)();
+    if (model.includes('[1m]') && Object.hasOwn(cfg, 'new_session_threshold') && cfg.new_session_threshold > 30) {
+      model = model.replace('[1m]', '');
+    }
     hints.push({
       type: 'model_backfill',
-      value: templateSettings.model,
+      value: model,
     });
   }
 

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -30,9 +30,20 @@ const ZYLOS_DIR = path.resolve(process.env.ZYLOS_DIR || path.join(os.homedir(), 
 const TEMPLATE_SETTINGS = path.join(__dirname, '..', '..', 'templates', '.claude', 'settings.json');
 const INSTALLED_SETTINGS = path.join(ZYLOS_DIR, '.claude', 'settings.json');
 
+const MAX_SAFE_1M_THRESHOLD = 30;
+
+function is1mModel(model) {
+  return typeof model === 'string' && model.includes('[1m]');
+}
+
+function strip1mSuffix(model) {
+  return model.replace('[1m]', '');
+}
+
 export function syncTemplateModelSetting({
   templateSettings,
   installedSettings,
+  cfg = getZylosConfig(),
   dryRun = false,
   log = console.log,
 } = {}) {
@@ -40,11 +51,18 @@ export function syncTemplateModelSetting({
     return { changed: false };
   }
 
-  if (!dryRun) {
-    installedSettings.model = templateSettings.model;
+  let model = templateSettings.model;
+
+  if (is1mModel(model) && Object.hasOwn(cfg, 'new_session_threshold') && cfg.new_session_threshold > MAX_SAFE_1M_THRESHOLD) {
+    model = strip1mSuffix(model);
+    log(`  ! model: ${templateSettings.model} → ${model} (new_session_threshold ${cfg.new_session_threshold} too high for 1M context)`);
   }
-  log(`  + model: ${templateSettings.model}`);
-  return { changed: true };
+
+  if (!dryRun) {
+    installedSettings.model = model;
+  }
+  log(`  + model: ${model}`);
+  return { changed: true, model };
 }
 
 /**


### PR DESCRIPTION
## Summary

- When upgrading older instances, `syncTemplateModelSetting()` backfills `opus[1m]` without checking whether `new_session_threshold` is compatible — an instance with threshold=70 ends up with opus[1m]+70% (~700K context/session)
- Before backfilling a `[1m]` model, now checks if `new_session_threshold` > 30; if so, strips `[1m]` suffix (e.g. `opus[1m]` → `opus`)
- Applies to both the regular upgrade path (`syncTemplateModelSetting`) and the self-upgrade fallback (`generateMigrationHints`)

## Changes

- `cli/lib/sync-settings-hooks.js`: Added threshold guard to `syncTemplateModelSetting()` — accepts `cfg` param, checks `new_session_threshold` before applying 1M model
- `cli/lib/self-upgrade.js`: Same guard in `generateMigrationHints()` — downgrades the hint value before it's generated
- Tests: 6 new test cases covering guard triggers, passthrough, and edge cases

## Test plan

- [x] `node --test cli/lib/__tests__/sync-settings-hooks.test.js` — 43 pass
- [x] `node --test cli/lib/__tests__/self-upgrade.test.js` — 22 pass
- [x] `npm test` — 532 pass, 0 fail

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)