### PR TITLE
feat: bwrap sandbox system dependency check with AppArmor auto-config

### DIFF
--- a/cli/commands/doctor.js
+++ b/cli/commands/doctor.js
@@ -19,7 +19,7 @@ import { readEnvFile } from '../lib/env.js';
 import { loadComponents } from '../lib/components.js';
 import { fetchLatestTagAsync, compareSemverDesc } from '../lib/github.js';
 import { getCurrentVersion } from '../lib/self-upgrade.js';
-import { commandExists } from '../lib/shell-utils.js';
+import { commandExists, testBwrapSandbox, isAppArmorRestrictingUserns, isBwrapAppArmorProfileLoaded } from '../lib/shell-utils.js';
 import { parseSkillMd } from '../lib/skill.js';
 import { bold, dim, green, red, yellow, heading } from '../lib/colors.js';
 import { getActiveAdapter } from '../lib/runtime/index.js';
@@ -68,6 +68,7 @@ const BULLET_OFF = (label) => `  ${dim('○')} ${label}`;
 function groupHeader(name, status) {
   const icon = status === 'pass' ? green('✓')
     : status === 'fail' ? red('✗')
+    : status === 'warn' ? yellow('⚠')
     : status === 'skip' ? dim('⊘')
     : dim('…');
   return `\n${icon} ${bold(name)}`;
@@ -132,6 +133,22 @@ function checkPm2Installed() {
     if (match) version = match[1];
   } catch {}
   return { installed: true, version };
+}
+
+function checkSandbox() {
+  if (process.platform !== 'linux') return { skip: true, reason: 'non-linux' };
+  const installed = commandExists('bwrap');
+  if (!installed) return { installed: false, functional: false };
+  const test = testBwrapSandbox();
+  const apparmorRestricting = !test.ok && isAppArmorRestrictingUserns();
+  const profileLoaded = apparmorRestricting ? isBwrapAppArmorProfileLoaded() : false;
+  return {
+    installed: true,
+    functional: test.ok,
+    apparmorRestricting,
+    profileLoaded,
+    error: test.error,
+  };
 }
 
 async function checkNetwork(env) {
@@ -287,6 +304,7 @@ async function collectDiagnostics(env) {
 
   const tmux = checkTmuxInstalled();
   const pm2 = checkPm2Installed();
+  const sandbox = checkSandbox();
   const net = await networkPromise;
 
   // Runtime-specific CLI/auth checks.
@@ -310,7 +328,7 @@ async function collectDiagnostics(env) {
   const session = tmux.installed ? checkTmuxSession() : false;
 
   return {
-    system: { tmux, pm2, network: net },
+    system: { tmux, pm2, sandbox, network: net },
     ai: { cli, auth, authStatus, autonomous, networkSkipped: !net.reachable },
     services: { ...services, session },
   };
@@ -326,6 +344,16 @@ function buildDiagnosticJson(diag, coreVersion) {
   }
   if (!diag.system.pm2.installed) {
     issues.push({ id: 'pm2_missing', label: 'PM2 not installed', hint: 'Run zylos init' });
+  }
+  const sb = diag.system.sandbox;
+  if (sb && !sb.skip && !sb.functional) {
+    if (!sb.installed) {
+      issues.push({ id: 'bwrap_missing', label: 'bwrap not installed', hint: 'Run: apt install bubblewrap && zylos init' });
+    } else if (sb.apparmorRestricting && !sb.profileLoaded) {
+      issues.push({ id: 'bwrap_apparmor', label: 'bwrap blocked by AppArmor', hint: 'Run zylos init to auto-configure, or see: zylos doctor --json' });
+    } else {
+      issues.push({ id: 'bwrap_broken', label: 'bwrap sandbox not functional', hint: sb.error || 'Check dmesg for details' });
+    }
   }
   if (!diag.system.network.reachable) {
     const net = diag.system.network;
@@ -418,6 +446,19 @@ function displaySystemGroup(diag, jsonGroup) {
     checks.push(red('PM2 not installed'));
   }
 
+  const sbx = diag.system.sandbox;
+  if (sbx && !sbx.skip) {
+    if (sbx.functional) {
+      checks.push('bwrap sandbox working');
+    } else if (!sbx.installed) {
+      checks.push(yellow('bwrap not installed (sandbox unavailable)'));
+    } else if (sbx.apparmorRestricting) {
+      checks.push(yellow('bwrap blocked by AppArmor — run zylos init to fix'));
+    } else {
+      checks.push(yellow('bwrap sandbox not functional'));
+    }
+  }
+
   if (net.reachable) {
     let label = `network: ${API_HOST} reachable`;
     if (net.proxy) label += dim(' (via proxy)');
@@ -430,7 +471,8 @@ function displaySystemGroup(diag, jsonGroup) {
     }
   }
 
-  displayCheckGroup('System', jsonGroup.passed ? 'pass' : 'fail', checks);
+  const sandboxIssue = sbx && !sbx.skip && !sbx.functional;
+  displayCheckGroup('System', jsonGroup.passed && !sandboxIssue ? 'pass' : sandboxIssue ? 'warn' : 'fail', checks);
   logToFile(`check: system — ${jsonGroup.passed ? 'passed' : 'failed'}`);
 }
 

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -16,7 +16,7 @@ import { ZYLOS_DIR, SKILLS_DIR, CONFIG_DIR, COMPONENTS_DIR, LOCKS_DIR, COMPONENT
 import { generateManifest, saveManifest } from '../lib/manifest.js';
 import { prompt, promptYesNo, promptChoice, promptSecret } from '../lib/prompts.js';
 import { bold, dim, green, red, yellow, cyan, bgGreen, success, error, warn, heading } from '../lib/colors.js';
-import { commandExists } from '../lib/shell-utils.js';
+import { commandExists, testBwrapSandbox, isAppArmorRestrictingUserns, setupBwrapAppArmor } from '../lib/shell-utils.js';
 import { getActiveAdapter } from '../lib/runtime/index.js';
 import { buildInstructionFile } from '../lib/runtime/instruction-builder.js';
 import { deployManifestTemplate } from '../lib/runtime/tmux-env.js';
@@ -1949,7 +1949,52 @@ export async function initCommand(args) {
     }
   }
 
-  // Step 4.5: Select agent runtime
+  // Step 4.5: Check bwrap sandbox (optional — non-fatal)
+  if (process.platform === 'linux') {
+    if (!commandExists('bwrap')) {
+      if (!quiet) console.log(`  ${warn('bwrap not found — installing bubblewrap...')}`);
+      installSystemPackage('bubblewrap');
+    }
+
+    if (commandExists('bwrap')) {
+      const sandbox = testBwrapSandbox();
+      if (sandbox.ok) {
+        if (!quiet) console.log(`  ${success('bwrap sandbox working')}`);
+      } else if (isAppArmorRestrictingUserns()) {
+        if (!quiet) console.log(`  ${warn('bwrap blocked by AppArmor — configuring profile...')}`);
+        if (setupBwrapAppArmor()) {
+          const retest = testBwrapSandbox();
+          if (retest.ok) {
+            if (!quiet) console.log(`  ${success('bwrap sandbox working (AppArmor profile configured)')}`);
+          } else {
+            if (!quiet) console.log(`  ${warn('bwrap sandbox still failing after AppArmor fix')}`);
+            if (!quiet) console.log(`    ${dim('Components using sandboxed execution will fall back to unsandboxed mode.')}`);
+          }
+        } else {
+          if (!quiet) console.log(`  ${warn('Could not configure AppArmor profile (sudo required)')}`);
+          if (!quiet) console.log(`    ${dim('Fix manually:')}`);
+          if (!quiet) console.log(`    ${dim('sudo tee /etc/apparmor.d/bwrap <<\'EOF\'')}`);
+          if (!quiet) console.log(`    ${dim('abi <abi/4.0>,')}`);
+          if (!quiet) console.log(`    ${dim('include <tunables/global>')}`);
+          if (!quiet) console.log(`    ${dim('profile bwrap /usr/bin/bwrap flags=(unconfined) {')}`);
+          if (!quiet) console.log(`    ${dim('  userns,')}`);
+          if (!quiet) console.log(`    ${dim('  include if exists <local/bwrap>')}`);
+          if (!quiet) console.log(`    ${dim('}')}`);
+          if (!quiet) console.log(`    ${dim('EOF')}`);
+          if (!quiet) console.log(`    ${dim('sudo apparmor_parser -r /etc/apparmor.d/bwrap')}`);
+        }
+      } else {
+        if (!quiet) console.log(`  ${warn('bwrap sandbox not working')}`);
+        if (!quiet) console.log(`    ${dim(sandbox.error || 'Unknown error')}`);
+        if (!quiet) console.log(`    ${dim('Components using sandboxed execution will fall back to unsandboxed mode.')}`);
+      }
+    } else {
+      if (!quiet) console.log(`  ${warn('Could not install bubblewrap — sandbox unavailable')}`);
+      if (!quiet) console.log(`    ${dim('Install manually: apt install bubblewrap')}`);
+    }
+  }
+
+  // Step 5: Select agent runtime (was 4.5)
   // Resolution: --runtime flag > ZYLOS_RUNTIME env > existing config > interactive prompt
   const existingRuntime = getZylosConfig().runtime;
   let selectedRuntime = opts.runtime || existingRuntime || null;

--- a/cli/lib/shell-utils.js
+++ b/cli/lib/shell-utils.js
@@ -4,6 +4,9 @@
 
 import { execFileSync } from 'node:child_process';
 
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
 /**
  * Check whether a command exists on the system PATH.
  *
@@ -13,6 +16,101 @@ import { execFileSync } from 'node:child_process';
 export function commandExists(cmd) {
   try {
     execFileSync('which', [cmd], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Test whether bwrap can actually create a sandbox.
+ * Binary existence is necessary but not sufficient — AppArmor or other
+ * kernel restrictions can prevent sandbox creation even when bwrap is installed.
+ *
+ * @returns {{ ok: boolean, error?: string }}
+ */
+export function testBwrapSandbox() {
+  if (!commandExists('bwrap')) {
+    return { ok: false, error: 'bwrap not installed' };
+  }
+  try {
+    execSync(
+      'bwrap --ro-bind /usr /usr --symlink usr/lib /lib --symlink usr/bin /bin --symlink usr/sbin /sbin --proc /proc --dev /dev --tmpfs /tmp --unshare-all --die-with-parent true',
+      { stdio: 'pipe', timeout: 10000 },
+    );
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e.stderr?.toString().trim() || 'sandbox creation failed' };
+  }
+}
+
+/**
+ * Check if AppArmor is restricting unprivileged user namespaces.
+ * @returns {boolean}
+ */
+export function isAppArmorRestrictingUserns() {
+  try {
+    const val = fs.readFileSync('/proc/sys/kernel/apparmor_restrict_unprivileged_userns', 'utf8').trim();
+    return val === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a bwrap AppArmor profile is already loaded.
+ * @returns {boolean}
+ */
+export function isBwrapAppArmorProfileLoaded() {
+  try {
+    const profiles = execSync('cat /sys/kernel/security/apparmor/profiles 2>/dev/null', {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return profiles.includes('bwrap');
+  } catch {
+    try {
+      const result = execSync('sudo aa-status 2>/dev/null', {
+        encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000,
+      });
+      return result.includes('bwrap');
+    } catch {
+      return false;
+    }
+  }
+}
+
+const BWRAP_APPARMOR_PROFILE = `abi <abi/4.0>,
+include <tunables/global>
+
+profile bwrap /usr/bin/bwrap flags=(unconfined) {
+  userns,
+  include if exists <local/bwrap>
+}
+`;
+
+/**
+ * Create and load the bwrap AppArmor profile. Requires sudo.
+ * Follows the setCaddyCapabilities() pattern: attempt sudo directly,
+ * print manual fix command on failure.
+ *
+ * @returns {boolean} true if profile was created and loaded successfully
+ */
+export function setupBwrapAppArmor() {
+  if (process.platform !== 'linux') return true;
+
+  const profilePath = '/etc/apparmor.d/bwrap';
+  const sudo = process.getuid?.() === 0 ? '' : 'sudo ';
+
+  try {
+    execSync(`${sudo}tee ${profilePath} > /dev/null`, {
+      input: BWRAP_APPARMOR_PROFILE,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    });
+    execSync(`${sudo}apparmor_parser -r ${profilePath}`, {
+      stdio: 'pipe',
+      timeout: 10000,
+    });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Closes #663

Adds bwrap sandbox as a system-level dependency check in zylos-core, so any component using sandboxed execution gets it handled automatically.

- **`zylos init`**: After PM2 check, detects if bwrap works. If blocked by AppArmor (Ubuntu 23.10+), auto-creates a minimal profile granting only `userns` permission. Follows `setCaddyCapabilities()` pattern for sudo handling.
- **`zylos doctor`**: Adds sandbox to System diagnostic group with warn status for non-functional sandbox.
- **`shell-utils.js`**: New utilities — `testBwrapSandbox()`, `isAppArmorRestrictingUserns()`, `isBwrapAppArmorProfileLoaded()`, `setupBwrapAppArmor()`.

Non-interactive mode: attempts sudo directly, prints manual fix command on failure, never blocks installation.

## Test plan

- [ ] Verify `testBwrapSandbox()` returns `{ ok: true }` on a system with working bwrap
- [ ] Verify AppArmor detection on Ubuntu 24.04 (`isAppArmorRestrictingUserns()` returns true)
- [ ] Verify `setupBwrapAppArmor()` creates profile and bwrap works after
- [ ] Verify `zylos doctor` shows sandbox status in System group
- [ ] Verify non-interactive mode (`--yes`) attempts sudo without prompting
- [ ] Verify macOS skips sandbox checks entirely

Functional test passed on DGX Spark (Ubuntu 24.04, kernel 6.17.0-1021-nvidia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)