### PR TITLE
fix: broaden rate limit detection patterns (#666)

### DIFF
--- a/cli/lib/__tests__/claude-probe-rate-limit.test.js
+++ b/cli/lib/__tests__/claude-probe-rate-limit.test.js
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { _RATE_LIMIT_PATTERNS as PATTERNS, _parseResetTime } from '../heartbeat/claude-probe.js';
+
+function matchesAny(text) {
+  return PATTERNS.some(p => p.test(text));
+}
+
+describe('RATE_LIMIT_PATTERNS', () => {
+  it('matches "You\'ve hit your limit" (original)', () => {
+    assert.ok(matchesAny("You've hit your limit"));
+    assert.ok(matchesAny("you've hit your limit"));
+  });
+
+  it('matches "You\'ve hit your session limit"', () => {
+    assert.ok(matchesAny("You've hit your session limit · resets 12am (Asia/Singapore)"));
+  });
+
+  it('matches "You\'ve hit your weekly limit"', () => {
+    assert.ok(matchesAny("You've hit your weekly limit · resets Jun 29, 3am (Asia/Singapore)"));
+  });
+
+  it('matches with curly apostrophe', () => {
+    assert.ok(matchesAny("You’ve hit your session limit"));
+  });
+
+  it('matches with straight apostrophe', () => {
+    assert.ok(matchesAny("You've hit your weekly limit"));
+  });
+
+  it('matches Opus/Sonnet limit variants', () => {
+    assert.ok(matchesAny("You've hit your Opus limit"));
+    assert.ok(matchesAny("You've hit your Sonnet limit"));
+  });
+
+  it('matches extra/fast usage variants', () => {
+    assert.ok(matchesAny("out of extra usage"));
+    assert.ok(matchesAny("You're out of fast usage"));
+    assert.ok(matchesAny("usage limit reached"));
+  });
+
+  it('does not match unrelated text', () => {
+    assert.ok(!matchesAny("Hello, how are you?"));
+    assert.ok(!matchesAny("The session has started"));
+    assert.ok(!matchesAny("Your rate is excellent"));
+    assert.ok(!matchesAny("You've hit the mark"));
+  });
+});
+
+describe('_parseResetTime', () => {
+  it('parses simple time "12am"', () => {
+    const result = _parseResetTime('12am');
+    assert.ok(result > 0);
+  });
+
+  it('parses "3am"', () => {
+    const result = _parseResetTime('3am');
+    assert.ok(result > 0);
+  });
+
+  it('parses "7:30pm"', () => {
+    const result = _parseResetTime('7:30pm');
+    assert.ok(result > 0);
+  });
+
+  it('parses time with date "3am" + "Jun 29"', () => {
+    const result = _parseResetTime('3am', 'Jun 29');
+    assert.ok(result > 0);
+    const d = new Date(result * 1000);
+    assert.equal(d.getMonth(), 5); // June
+    assert.equal(d.getDate(), 29);
+  });
+
+  it('parses time with date+year "3am" + "Jun 29, 2026"', () => {
+    const result = _parseResetTime('3am', 'Jun 29, 2026');
+    assert.ok(result > 0);
+    const d = new Date(result * 1000);
+    assert.equal(d.getFullYear(), 2026);
+    assert.equal(d.getMonth(), 5);
+    assert.equal(d.getDate(), 29);
+  });
+
+  it('returns 0 for unparseable input', () => {
+    assert.equal(_parseResetTime('invalid'), 0);
+  });
+
+  it('handles all month abbreviations', () => {
+    for (const mon of ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']) {
+      const result = _parseResetTime('1am', `${mon} 15`);
+      assert.ok(result > 0, `Failed for ${mon}`);
+    }
+  });
+});

--- a/cli/lib/heartbeat/claude-probe.js
+++ b/cli/lib/heartbeat/claude-probe.js
@@ -30,9 +30,9 @@ const C4_CONTROL = path.join(ZYLOS_DIR, '.claude/skills/comm-bridge/scripts/c4-c
 
 const RATE_LIMIT_PATTERNS = [
   /out of extra usage/i,
-  /you['']re out of .* usage/i,
+  /you[''’]re out of .* usage/i,
   /usage limit reached/i,
-  /you['']ve hit your limit/i,
+  /you[''’]ve hit your (?:\w+ )?limit/i,
 ];
 
 const AUTH_FAILURE_PATTERNS = [
@@ -129,14 +129,23 @@ export function createClaudeProbe({
       if (!detected) return { detected: false };
 
       let resetTime = '';
-      const timeMatch = pane.match(/resets?\s+(?:at\s+)?(\d{1,2}(?::\d{2})?\s*(?:am|pm))/i);
-      if (timeMatch) resetTime = timeMatch[1].trim();
+      let resetDate = '';
+      // Match "resets [at] [Mon DD[, YYYY],] HH[:MM]am/pm [(TZ)]"
+      const timeMatch = pane.match(/resets?\s+(?:at\s+)?(?:([A-Z][a-z]{2}\s+\d{1,2}(?:,\s*\d{4})?),?\s+)?(\d{1,2}(?::\d{2})?\s*(?:am|pm))/i);
+      if (timeMatch) {
+        resetDate = (timeMatch[1] || '').trim();
+        resetTime = timeMatch[2].trim();
+      }
 
       const now = Math.floor(Date.now() / 1000);
       let cooldownUntil = now + 3600; // default 1 hour
       if (resetTime) {
-        const parsed = _parseResetTime(resetTime);
+        const parsed = _parseResetTime(resetTime, resetDate);
         if (parsed > now) cooldownUntil = parsed;
+      }
+      // For weekly limits without a parseable reset, use a longer default
+      if (!resetTime && /weekly/i.test(pane)) {
+        cooldownUntil = now + 6 * 3600;
       }
 
       return { detected: true, cooldownUntil, resetTime };
@@ -206,9 +215,10 @@ function _getAckDeadline(phase, { ackDeadline, recoveryAckDeadline }) {
 
 /**
  * Parse a time string like "7am", "7:30am", "3pm" into epoch seconds.
- * Assumes local timezone; if the time is in the past, assumes tomorrow.
+ * Optionally accepts a date string like "Jun 29" or "Jun 29, 2026".
+ * Without a date, assumes local timezone; if the time is in the past, assumes tomorrow.
  */
-function _parseResetTime(timeStr) {
+function _parseResetTime(timeStr, dateStr) {
   const match = timeStr.match(/^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i);
   if (!match) return 0;
 
@@ -221,11 +231,27 @@ function _parseResetTime(timeStr) {
 
   const now = new Date();
   const target = new Date(now);
+
+  if (dateStr) {
+    const dateMatch = dateStr.match(/^([A-Z][a-z]{2})\s+(\d{1,2})(?:,\s*(\d{4}))?$/);
+    if (dateMatch) {
+      const months = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 };
+      const month = months[dateMatch[1]];
+      const day = parseInt(dateMatch[2], 10);
+      const year = dateMatch[3] ? parseInt(dateMatch[3], 10) : now.getFullYear();
+      if (month !== undefined) {
+        target.setFullYear(year, month, day);
+      }
+    }
+  }
+
   target.setHours(hours, minutes, 0, 0);
-  if (target <= now) target.setDate(target.getDate() + 1);
+  if (!dateStr && target <= now) target.setDate(target.getDate() + 1);
 
   return Math.floor(target.getTime() / 1000);
 }
+
+export { RATE_LIMIT_PATTERNS as _RATE_LIMIT_PATTERNS, _parseResetTime };
 
 function _writePending(file, data) {
   try {


### PR DESCRIPTION
## Summary

- Broadens `RATE_LIMIT_PATTERNS` in `claude-probe.js` to match Claude Code's actual rate limit UI text (`session limit`, `weekly limit`, `Opus limit`, `Sonnet limit`, etc.)
- Fixes reset time regex to handle date-based formats like `resets Jun 29, 3am (Asia/Singapore)`
- Uses longer default cooldown (6h) for weekly limits when exact reset time is unparseable
- Adds 15 unit tests for pattern matching and time parsing

Closes #666

## Test plan

- [x] All 15 new unit tests pass (`node --test cli/lib/__tests__/claude-probe-rate-limit.test.js`)
- [x] Existing heartbeat API error pattern tests still pass
- [ ] Code review by zylos0t

🤖 Generated with [Claude Code](https://claude.com/claude-code)