### PR TITLE
feat: consolidate SessionStart hooks into single orchestrator (#651)

### DIFF
--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -424,6 +424,172 @@ describe('Boolean setting migration hints (autoMemoryEnabled, autoDreamEnabled)'
   });
 });
 
+describe('self-upgrade hook migration hints', () => {
+  function writeSettingsPair({ templateSettings, installedSettings }) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-hook-hints-'));
+    const templatesDir = path.join(tmpDir, 'templates');
+    const zylosDir = path.join(tmpDir, 'zylos');
+    fs.mkdirSync(path.join(templatesDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(templatesDir, '.claude', 'settings.json'),
+      JSON.stringify(templateSettings),
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(zylosDir, '.claude', 'settings.json'),
+      JSON.stringify(installedSettings),
+      'utf8'
+    );
+    return { tmpDir, templatesDir, zylosDir };
+  }
+
+  it('generates removed_hook for retired core SessionStart hooks absent from the template', () => {
+    const { tmpDir, templatesDir, zylosDir } = writeSettingsPair({
+      templateSettings: {
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup',
+            hooks: [{
+              type: 'command',
+              command: 'node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js',
+              timeout: 20000,
+            }],
+          }],
+        },
+      },
+      installedSettings: {
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup',
+            hooks: [{
+              type: 'command',
+              command: 'node /Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js',
+              timeout: 10000,
+            }],
+          }],
+        },
+      },
+    });
+
+    const hints = generateMigrationHints(templatesDir, { zylosDir });
+
+    assert.ok(hints.some(hint =>
+      hint.type === 'removed_hook' &&
+      hint.command.includes('session-start-inject.js')
+    ));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not generate removed_hook for custom or non-command hooks', () => {
+    const { tmpDir, templatesDir, zylosDir } = writeSettingsPair({
+      templateSettings: {
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup',
+            hooks: [{
+              type: 'command',
+              command: 'node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js',
+              timeout: 20000,
+            }],
+          }],
+        },
+      },
+      installedSettings: {
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup',
+            hooks: [
+              { type: 'command', command: 'node /custom/session-start.js', timeout: 5000 },
+              { type: 'prompt', prompt: 'keep me' },
+            ],
+          }],
+        },
+      },
+    });
+
+    const hints = generateMigrationHints(templatesDir, { zylosDir });
+
+    assert.equal(hints.some(hint => hint.type === 'removed_hook'), false);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches modified hooks by canonical script key during hint generation and apply', () => {
+    const { tmpDir, templatesDir, zylosDir } = writeSettingsPair({
+      templateSettings: {
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup',
+            hooks: [{
+              type: 'command',
+              command: 'node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js',
+              timeout: 20000,
+            }],
+          }],
+        },
+      },
+      installedSettings: {
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup',
+            hooks: [{
+              type: 'command',
+              command: 'node /Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js',
+              timeout: 10000,
+            }],
+          }],
+        },
+      },
+    });
+
+    const hints = generateMigrationHints(templatesDir, { zylosDir });
+    const modified = hints.find(hint => hint.type === 'modified_hook');
+
+    assert.ok(modified);
+    assert.equal(modified.timeout, 20000);
+
+    const result = applyMigrationHints(hints, { zylosDir });
+    const updated = JSON.parse(fs.readFileSync(path.join(zylosDir, '.claude', 'settings.json'), 'utf8'));
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(updated.hooks.SessionStart[0].hooks[0].command, 'node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js');
+    assert.equal(updated.hooks.SessionStart[0].hooks[0].timeout, 20000);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes hooks by canonical script key during applyMigrationHints', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-hook-apply-'));
+    const zylosDir = path.join(tmpDir, 'zylos');
+    const settingsPath = path.join(zylosDir, '.claude', 'settings.json');
+
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        SessionStart: [{
+          matcher: 'startup',
+          hooks: [{
+            type: 'command',
+            command: 'node /Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js',
+            timeout: 10000,
+          }],
+        }],
+      },
+    }) + '\n', 'utf8');
+
+    const result = applyMigrationHints([{
+      type: 'removed_hook',
+      event: 'SessionStart',
+      command: 'node ~/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js',
+      timeout: 10000,
+    }], { zylosDir });
+    const updated = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+
+    assert.equal(result.applied, 1);
+    assert.equal(updated.hooks, undefined);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
 describe('step7 manifest deploy (real step7_syncClaudeMd)', () => {
   it('creates manifest from tempDir template when missing, message includes manifest: created', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-step7-'));

--- a/cli/lib/__tests__/self-upgrade.test.js
+++ b/cli/lib/__tests__/self-upgrade.test.js
@@ -15,6 +15,14 @@ const {
 const { generateMigrationHints, applyMigrationHints } = await import('../self-upgrade.js');
 const { deployManifestTemplate } = await import('../runtime/tmux-env.js');
 
+function fixtureZylosDir() {
+  return path.resolve(process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
+}
+
+function zylosHookPath(relativePath) {
+  return path.join(fixtureZylosDir(), '.claude', relativePath).replaceAll('\\', '/');
+}
+
 describe('self-upgrade finalizer handoff', () => {
   it('serializes the state needed by the newly installed finalizer', () => {
     assert.deepEqual(createFinalizeState({
@@ -464,7 +472,7 @@ describe('self-upgrade hook migration hints', () => {
             matcher: 'startup',
             hooks: [{
               type: 'command',
-              command: 'node /Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js',
+              command: `node ${zylosHookPath('skills/zylos-memory/scripts/session-start-inject.js')}`,
               timeout: 10000,
             }],
           }],
@@ -534,7 +542,7 @@ describe('self-upgrade hook migration hints', () => {
             matcher: 'startup',
             hooks: [{
               type: 'command',
-              command: 'node /Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js',
+              command: `node ${zylosHookPath('skills/activity-monitor/scripts/session-start-orchestrator.js')}`,
               timeout: 10000,
             }],
           }],
@@ -569,7 +577,7 @@ describe('self-upgrade hook migration hints', () => {
           matcher: 'startup',
           hooks: [{
             type: 'command',
-            command: 'node /Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js',
+            command: `node ${zylosHookPath('skills/zylos-memory/scripts/session-start-inject.js')}`,
             timeout: 10000,
           }],
         }],

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const {
   CORE_MANAGED_HOOKS,
+  isCoreManaged,
   persistInstalledSettingsAndSyncCoupledThreshold,
   shouldSyncCodexConfig,
   syncCodexConfig,
@@ -14,7 +16,7 @@ const {
   syncTemplateSetting,
   syncTemplateModelSetting,
 } = await import('../sync-settings-hooks.js');
-const { getCommandHooks, hookScriptKey } = await import('../hook-utils.js');
+const { extractScriptPath, getCommandHooks, hookScriptKey } = await import('../hook-utils.js');
 const {
   renderCodexGlobalConfig,
   renderCodexProjectConfig,
@@ -561,8 +563,35 @@ function assertSessionStartUsesOrchestrator(settings) {
   }
 }
 
+describe('extractScriptPath', () => {
+  it('takes the interpreter script argument instead of later path-like arguments', () => {
+    assert.equal(extractScriptPath('node x.js /tmp/y.js'), 'x.js');
+  });
+
+  it('uses the last shell segment so source prefixes do not win', () => {
+    assert.equal(
+      extractScriptPath('source ~/.nvm/nvm.sh && node ~/zylos/.claude/skills/a/scripts/b.js'),
+      path.join(os.homedir(), 'zylos/.claude/skills/a/scripts/b.js')
+    );
+  });
+
+  it('skips interpreter flags before the script argument', () => {
+    assert.equal(
+      extractScriptPath('node --trace-warnings ~/zylos/.claude/skills/a/scripts/b.js --mode startup'),
+      path.join(os.homedir(), 'zylos/.claude/skills/a/scripts/b.js')
+    );
+  });
+
+  it('keeps quoted paths with spaces as one script argument', () => {
+    assert.equal(
+      extractScriptPath('node "/Users/howard/zylos/.claude/skills/a dir/scripts/b.js" /tmp/y.js'),
+      '/Users/howard/zylos/.claude/skills/a dir/scripts/b.js'
+    );
+  });
+});
+
 describe('hookScriptKey', () => {
-  it('normalizes absolute, home-relative, and backslash script paths to the same registry key', () => {
+  it('normalizes absolute, home-relative, and backslash zylos-root script paths to the same registry key', () => {
     assert.equal(
       hookScriptKey('node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js'),
       'skills/activity-monitor/scripts/session-start-orchestrator.js'
@@ -572,12 +601,12 @@ describe('hookScriptKey', () => {
       'skills/activity-monitor/scripts/session-start-orchestrator.js'
     );
     assert.equal(
-      hookScriptKey('node C:\\zylos\\.claude\\skills\\activity-monitor\\scripts\\session-start-orchestrator.js'),
+      hookScriptKey('node \\Users\\howard\\zylos\\.claude\\skills\\activity-monitor\\scripts\\session-start-orchestrator.js'),
       'skills/activity-monitor/scripts/session-start-orchestrator.js'
     );
   });
 
-  it('keeps non-.claude paths as full normalized paths even when they contain skills suffixes', () => {
+  it('keeps paths outside the zylos .claude root as full normalized paths even when suffixes collide', () => {
     assert.equal(
       hookScriptKey('node /opt/custom/skills/activity-monitor/scripts/session-start-orchestrator.js --mine'),
       '/opt/custom/skills/activity-monitor/scripts/session-start-orchestrator.js'
@@ -586,6 +615,38 @@ describe('hookScriptKey', () => {
       hookScriptKey('node /opt/custom/skills/zylos-memory/scripts/session-start-inject.js'),
       '/opt/custom/skills/zylos-memory/scripts/session-start-inject.js'
     );
+    assert.equal(
+      hookScriptKey('node ~/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js'),
+      `${os.homedir()}/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js`
+    );
+    assert.equal(
+      isCoreManaged({ type: 'command', command: 'node ~/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js' }),
+      false
+    );
+  });
+
+  it('resolves relative ZYLOS_DIR before checking the zylos .claude root', () => {
+    const previousZylosDir = process.env.ZYLOS_DIR;
+    process.env.ZYLOS_DIR = 'relative-zylos';
+    try {
+      const absoluteCoreHook = path.resolve(
+        'relative-zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js'
+      );
+      assert.equal(
+        hookScriptKey(`node ${absoluteCoreHook}`),
+        'skills/activity-monitor/scripts/session-start-orchestrator.js'
+      );
+      assert.equal(
+        isCoreManaged({ type: 'command', command: `node ${absoluteCoreHook}` }),
+        true
+      );
+    } finally {
+      if (previousZylosDir === undefined) {
+        delete process.env.ZYLOS_DIR;
+      } else {
+        process.env.ZYLOS_DIR = previousZylosDir;
+      }
+    }
   });
 });
 
@@ -703,7 +764,7 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
     assert.equal(startup.hooks.some(h => h.command?.includes('session-start-inject.js')), false);
   });
 
-  it('does not claim non-.claude user hooks whose suffix collides with current or retired registry keys', () => {
+  it('does not claim user hooks outside the zylos .claude root whose suffix collides with current or retired registry keys', () => {
     const installed = {
       hooks: {
         SessionStart: [
@@ -712,6 +773,7 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
             hooks: [
               makeHook('/opt/custom/skills/activity-monitor/scripts/session-start-orchestrator.js --mine', 9000),
               makeHook('/opt/custom/skills/zylos-memory/scripts/session-start-inject.js', 7000),
+              { type: 'command', command: 'node ~/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js --foreign', timeout: 6000 },
             ],
           },
         ],
@@ -730,6 +792,10 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
     assert.ok(startup.hooks.some(h =>
       h.command === 'node /opt/custom/skills/zylos-memory/scripts/session-start-inject.js' &&
       h.timeout === 7000
+    ));
+    assert.ok(startup.hooks.some(h =>
+      h.command === 'node ~/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js --foreign' &&
+      h.timeout === 6000
     ));
   });
 

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -26,6 +26,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_SETTINGS_PATH = path.join(__dirname, '..', '..', '..', 'templates', '.claude', 'settings.json');
 const CONTEXT_MONITOR_PATH = path.join(__dirname, '..', '..', '..', 'skills', 'activity-monitor', 'scripts', 'context-monitor.js');
 
+function fixtureZylosDir() {
+  return path.resolve(process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
+}
+
+function zylosHookPath(relativePath) {
+  return path.join(fixtureZylosDir(), '.claude', relativePath).replaceAll('\\', '/');
+}
+
 describe('Claude settings template', () => {
   it('defaults fresh installs to Opus with 1M context (opus[1m])', () => {
     const template = JSON.parse(fs.readFileSync(TEMPLATE_SETTINGS_PATH, 'utf8'));
@@ -520,10 +528,10 @@ function makeStandardOldSessionStartGroup(matcher) {
   return {
     matcher,
     hooks: [
-      makeHook('/Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js', 10000),
-      makeHook('/Users/howard/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js', 10000),
-      makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-foreground.js', 5000),
-      makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js', 5000),
+      makeHook(zylosHookPath('skills/zylos-memory/scripts/session-start-inject.js'), 10000),
+      makeHook(zylosHookPath('skills/comm-bridge/scripts/c4-session-init.js'), 10000),
+      makeHook(zylosHookPath('skills/activity-monitor/scripts/session-foreground.js'), 5000),
+      makeHook(zylosHookPath('skills/activity-monitor/scripts/session-start-prompt.js'), 5000),
     ],
   };
 }
@@ -547,7 +555,7 @@ function makeOrchestratorTemplate() {
       SessionStart: ['startup', 'clear', 'compact'].map(matcher => ({
         matcher,
         hooks: [
-          makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js', 20000),
+          makeHook(zylosHookPath('skills/activity-monitor/scripts/session-start-orchestrator.js'), 20000),
         ],
       })),
     },
@@ -583,9 +591,10 @@ describe('extractScriptPath', () => {
   });
 
   it('keeps quoted paths with spaces as one script argument', () => {
+    const scriptPath = zylosHookPath('skills/a dir/scripts/b.js');
     assert.equal(
-      extractScriptPath('node "/Users/howard/zylos/.claude/skills/a dir/scripts/b.js" /tmp/y.js'),
-      '/Users/howard/zylos/.claude/skills/a dir/scripts/b.js'
+      extractScriptPath(`node "${scriptPath}" /tmp/y.js`),
+      scriptPath
     );
   });
 });
@@ -597,11 +606,11 @@ describe('hookScriptKey', () => {
       'skills/activity-monitor/scripts/session-start-orchestrator.js'
     );
     assert.equal(
-      hookScriptKey('node /Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js'),
+      hookScriptKey(`node ${zylosHookPath('skills/activity-monitor/scripts/session-start-orchestrator.js')}`),
       'skills/activity-monitor/scripts/session-start-orchestrator.js'
     );
     assert.equal(
-      hookScriptKey('node \\Users\\howard\\zylos\\.claude\\skills\\activity-monitor\\scripts\\session-start-orchestrator.js'),
+      hookScriptKey(`node ${zylosHookPath('skills/activity-monitor/scripts/session-start-orchestrator.js').replaceAll('/', '\\')}`),
       'skills/activity-monitor/scripts/session-start-orchestrator.js'
     );
   });
@@ -705,9 +714,9 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
           {
             matcher: 'startup',
             hooks: [
-              makeHook('/Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js', 9000),
-              makeHook('/Users/howard/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js', 10000),
-              makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js', 5000),
+              makeHook(zylosHookPath('skills/zylos-memory/scripts/session-start-inject.js'), 9000),
+              makeHook(zylosHookPath('skills/comm-bridge/scripts/c4-session-init.js'), 10000),
+              makeHook(zylosHookPath('skills/activity-monitor/scripts/session-start-prompt.js'), 5000),
             ],
           },
           makeStandardOldSessionStartGroup('clear'),

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -483,6 +483,19 @@ function makeStandardOldSessionStartGroup(matcher) {
   };
 }
 
+function makeDriftedOldSessionStartGroup(matcher) {
+  const group = makeStandardOldSessionStartGroup(matcher);
+  return {
+    matcher,
+    hooks: [
+      group.hooks[0],
+      group.hooks[1],
+      group.hooks[3],
+      group.hooks[2],
+    ],
+  };
+}
+
 function makeOrchestratorTemplate() {
   return {
     hooks: {
@@ -512,6 +525,22 @@ describe('migrateSessionStartOrchestrator', () => {
       assert.equal(group.hooks.length, 1);
       assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
       assert.equal(group.hooks[0].timeout, 20000);
+    }
+  });
+
+  it('migrates real installed SessionStart groups with prompt and foreground order drift', () => {
+    const installed = {
+      hooks: {
+        SessionStart: ['startup', 'clear', 'compact'].map(makeDriftedOldSessionStartGroup),
+      },
+    };
+    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    assert.equal(result.updated, 3);
+    assert.deepEqual(result.skipEvents, ['SessionStart']);
+    for (const group of installed.hooks.SessionStart) {
+      assert.equal(group.hooks.length, 1);
+      assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
     }
   });
 
@@ -557,7 +586,35 @@ describe('migrateSessionStartOrchestrator', () => {
     const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { dryRun: true, log: noopLog });
 
     assert.equal(result.updated, 3);
+    assert.deepEqual(result.skipEvents, ['SessionStart']);
     assert.match(installed.hooks.SessionStart[0].hooks[0].command, /session-start-inject\.js/);
+  });
+
+  it('skips and protects timeout-drifted old SessionStart hooks', () => {
+    const installed = {
+      hooks: {
+        SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
+      },
+    };
+    installed.hooks.SessionStart[0].hooks[0].timeout = 9000;
+    const logs = [];
+    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: line => logs.push(line) });
+
+    assert.equal(result.updated, 0);
+    assert.deepEqual(result.skipEvents, ['SessionStart']);
+    assert.ok(logs.some(line => line.includes('custom/non-standard')));
+    assert.match(installed.hooks.SessionStart[0].hooks[0].command, /session-start-inject\.js/);
+  });
+
+  it('syncHooks dry-run counts a standard SessionStart migration once', () => {
+    const installed = {
+      hooks: {
+        SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
+      },
+    };
+    const result = syncHooks(installed, makeOrchestratorTemplate(), { dryRun: true, log: noopLog });
+
+    assert.deepEqual(result, { added: 0, updated: 3, removed: 0 });
   });
 
   it('syncHooks preserves custom/non-standard SessionStart configs instead of removing old hooks', () => {

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const {
+  migrateSessionStartOrchestrator,
   migrateMatcherSplit,
   persistInstalledSettingsAndSyncCoupledThreshold,
   shouldSyncCodexConfig,
@@ -35,13 +36,15 @@ describe('Claude settings template', () => {
     assert.equal(template.autoDreamEnabled, false);
   });
 
-  it('includes session-foreground hooks for all SessionStart matchers', () => {
+  it('uses the SessionStart orchestrator for all SessionStart matchers', () => {
     const template = JSON.parse(fs.readFileSync(TEMPLATE_SETTINGS_PATH, 'utf8'));
     const groups = template.hooks.SessionStart;
     assert.equal(groups.length, 3);
     for (const group of groups) {
       const commands = group.hooks.map(h => h.command);
-      assert.ok(commands.some(cmd => cmd.includes('session-foreground.js')));
+      assert.equal(group.hooks.length, 1);
+      assert.ok(commands.some(cmd => cmd.includes('session-start-orchestrator.js')));
+      assert.equal(group.hooks[0].timeout, 20000);
     }
   });
 
@@ -222,6 +225,8 @@ describe('syncModelCoupledNewSessionThreshold', () => {
 });
 
 describe('persistInstalledSettingsAndSyncCoupledThreshold', () => {
+  const normalizeBackupPath = (filePath) => filePath.replace(/\.bak\.\d+$/, '.bak.<ts>');
+
   it('writes settings before syncing the paired threshold', () => {
     const calls = [];
     const result = persistInstalledSettingsAndSyncCoupledThreshold({
@@ -241,6 +246,43 @@ describe('persistInstalledSettingsAndSyncCoupledThreshold', () => {
       ['mkdir', '/tmp/zylos/.claude', { recursive: true }],
       ['writeSettings', '/tmp/zylos/.claude/settings.json', { model: 'opus[1m]' }],
       ['syncThreshold', true],
+    ]);
+  });
+
+  it('backs up existing settings before writing', () => {
+    const calls = [];
+    persistInstalledSettingsAndSyncCoupledThreshold({
+      installedSettings: { hooks: {} },
+      settingsPath: '/tmp/zylos/.claude/settings.json',
+      mkdirSync: (dir, opts) => calls.push(['mkdir', dir, opts]),
+      existsSync: () => true,
+      copyFileSync: (from, to) => calls.push(['copy', normalizeBackupPath(from), normalizeBackupPath(to)]),
+      writeFileSync: (filePath, content) => calls.push(['writeSettings', filePath, JSON.parse(content)]),
+      syncThreshold: () => ({ changed: false }),
+    });
+
+    assert.deepEqual(calls, [
+      ['mkdir', '/tmp/zylos/.claude', { recursive: true }],
+      ['copy', '/tmp/zylos/.claude/settings.json', '/tmp/zylos/.claude/settings.json.bak.<ts>'],
+      ['writeSettings', '/tmp/zylos/.claude/settings.json', { hooks: {} }],
+    ]);
+  });
+
+  it('restores the backup when writing settings fails', () => {
+    const calls = [];
+    assert.throws(() => persistInstalledSettingsAndSyncCoupledThreshold({
+      installedSettings: { hooks: {} },
+      settingsPath: '/tmp/zylos/.claude/settings.json',
+      mkdirSync: () => {},
+      existsSync: () => true,
+      copyFileSync: (from, to) => calls.push(['copy', normalizeBackupPath(from), normalizeBackupPath(to)]),
+      writeFileSync: () => { throw new Error('disk full'); },
+      syncThreshold: () => { throw new Error('should not sync threshold after failed write'); },
+    }), /disk full/);
+
+    assert.deepEqual(calls, [
+      ['copy', '/tmp/zylos/.claude/settings.json', '/tmp/zylos/.claude/settings.json.bak.<ts>'],
+      ['copy', '/tmp/zylos/.claude/settings.json.bak.<ts>', '/tmp/zylos/.claude/settings.json'],
     ]);
   });
 });
@@ -428,6 +470,121 @@ function makeMatcherGroup(matcher, scriptPaths) {
     hooks: scriptPaths.map(p => makeHook(p)),
   };
 }
+
+function makeStandardOldSessionStartGroup(matcher) {
+  return {
+    matcher,
+    hooks: [
+      makeHook('/Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js', 10000),
+      makeHook('/Users/howard/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js', 10000),
+      makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-foreground.js', 5000),
+      makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js', 5000),
+    ],
+  };
+}
+
+function makeOrchestratorTemplate() {
+  return {
+    hooks: {
+      SessionStart: ['startup', 'clear', 'compact'].map(matcher => ({
+        matcher,
+        hooks: [
+          makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js', 20000),
+        ],
+      })),
+    },
+  };
+}
+
+describe('migrateSessionStartOrchestrator', () => {
+  const noopLog = () => {};
+
+  it('migrates exact standard SessionStart groups to the orchestrator', () => {
+    const installed = {
+      hooks: {
+        SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
+      },
+    };
+    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    assert.equal(result.updated, 3);
+    for (const group of installed.hooks.SessionStart) {
+      assert.equal(group.hooks.length, 1);
+      assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
+      assert.equal(group.hooks[0].timeout, 20000);
+    }
+  });
+
+  it('is idempotent when SessionStart is already on the orchestrator', () => {
+    const installed = JSON.parse(JSON.stringify(makeOrchestratorTemplate()));
+    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    assert.equal(result.updated, 0);
+    assert.deepEqual(result.skipEvents, []);
+  });
+
+  it('skips and protects custom/non-standard old SessionStart hooks', () => {
+    const installed = {
+      hooks: {
+        SessionStart: [
+          {
+            ...makeStandardOldSessionStartGroup('startup'),
+            hooks: [
+              ...makeStandardOldSessionStartGroup('startup').hooks,
+              makeHook('/custom/my-session-start.js', 5000),
+            ],
+          },
+          makeStandardOldSessionStartGroup('clear'),
+          makeStandardOldSessionStartGroup('compact'),
+        ],
+      },
+    };
+    const logs = [];
+    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: line => logs.push(line) });
+
+    assert.equal(result.updated, 0);
+    assert.deepEqual(result.skipEvents, ['SessionStart']);
+    assert.ok(logs.some(line => line.includes('custom/non-standard')));
+    assert.equal(installed.hooks.SessionStart[0].hooks.length, 5);
+  });
+
+  it('dryRun reports migration without mutating installed settings', () => {
+    const installed = {
+      hooks: {
+        SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
+      },
+    };
+    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { dryRun: true, log: noopLog });
+
+    assert.equal(result.updated, 3);
+    assert.match(installed.hooks.SessionStart[0].hooks[0].command, /session-start-inject\.js/);
+  });
+
+  it('syncHooks preserves custom/non-standard SessionStart configs instead of removing old hooks', () => {
+    const installed = {
+      hooks: {
+        SessionStart: [
+          {
+            ...makeStandardOldSessionStartGroup('startup'),
+            hooks: [
+              ...makeStandardOldSessionStartGroup('startup').hooks,
+              makeHook('/custom/my-session-start.js', 5000),
+            ],
+          },
+          makeStandardOldSessionStartGroup('clear'),
+          makeStandardOldSessionStartGroup('compact'),
+        ],
+      },
+    };
+
+    const result = syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    assert.equal(result.added, 0);
+    assert.equal(result.removed, 0);
+    assert.equal(installed.hooks.SessionStart[0].hooks.length, 5);
+    assert.ok(installed.hooks.SessionStart[0].hooks.some(h => h.command.includes('session-start-inject.js')));
+  });
+});
 
 // --- migrateMatcherSplit tests ---
 describe('migrateMatcherSplit', () => {

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -576,6 +576,17 @@ describe('hookScriptKey', () => {
       'skills/activity-monitor/scripts/session-start-orchestrator.js'
     );
   });
+
+  it('keeps non-.claude paths as full normalized paths even when they contain skills suffixes', () => {
+    assert.equal(
+      hookScriptKey('node /opt/custom/skills/activity-monitor/scripts/session-start-orchestrator.js --mine'),
+      '/opt/custom/skills/activity-monitor/scripts/session-start-orchestrator.js'
+    );
+    assert.equal(
+      hookScriptKey('node /opt/custom/skills/zylos-memory/scripts/session-start-inject.js'),
+      '/opt/custom/skills/zylos-memory/scripts/session-start-inject.js'
+    );
+  });
 });
 
 describe('core hook registry', () => {
@@ -690,6 +701,36 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
     assert.ok(startup.hooks.some(h => h.command?.includes('/custom/my-session-start.js')));
     assert.ok(startup.hooks.some(h => h.type === 'prompt'));
     assert.equal(startup.hooks.some(h => h.command?.includes('session-start-inject.js')), false);
+  });
+
+  it('does not claim non-.claude user hooks whose suffix collides with current or retired registry keys', () => {
+    const installed = {
+      hooks: {
+        SessionStart: [
+          {
+            matcher: 'startup',
+            hooks: [
+              makeHook('/opt/custom/skills/activity-monitor/scripts/session-start-orchestrator.js --mine', 9000),
+              makeHook('/opt/custom/skills/zylos-memory/scripts/session-start-inject.js', 7000),
+            ],
+          },
+        ],
+      },
+    };
+
+    const result = syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    const startup = installed.hooks.SessionStart.find(group => group.matcher === 'startup');
+    assert.equal(result.updated, 0);
+    assert.equal(result.removed, 0);
+    assert.ok(startup.hooks.some(h =>
+      h.command === 'node /opt/custom/skills/activity-monitor/scripts/session-start-orchestrator.js --mine' &&
+      h.timeout === 9000
+    ));
+    assert.ok(startup.hooks.some(h =>
+      h.command === 'node /opt/custom/skills/zylos-memory/scripts/session-start-inject.js' &&
+      h.timeout === 7000
+    ));
   });
 
   it('is idempotent when installed hooks already match the template', () => {

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -5,8 +5,7 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const {
-  migrateSessionStartOrchestrator,
-  migrateMatcherSplit,
+  CORE_MANAGED_HOOKS,
   persistInstalledSettingsAndSyncCoupledThreshold,
   shouldSyncCodexConfig,
   syncCodexConfig,
@@ -15,6 +14,7 @@ const {
   syncTemplateSetting,
   syncTemplateModelSetting,
 } = await import('../sync-settings-hooks.js');
+const { getCommandHooks, hookScriptKey } = await import('../hook-utils.js');
 const {
   renderCodexGlobalConfig,
   renderCodexProjectConfig,
@@ -552,401 +552,153 @@ function makeOrchestratorTemplate() {
   };
 }
 
-describe('migrateSessionStartOrchestrator', () => {
+function assertSessionStartUsesOrchestrator(settings) {
+  assert.equal(settings.hooks.SessionStart.length, 3);
+  for (const group of settings.hooks.SessionStart) {
+    assert.equal(group.hooks.length, 1);
+    assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
+    assert.equal(group.hooks[0].timeout, 20000);
+  }
+}
+
+describe('hookScriptKey', () => {
+  it('normalizes absolute, home-relative, and backslash script paths to the same registry key', () => {
+    assert.equal(
+      hookScriptKey('node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js'),
+      'skills/activity-monitor/scripts/session-start-orchestrator.js'
+    );
+    assert.equal(
+      hookScriptKey('node /Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js'),
+      'skills/activity-monitor/scripts/session-start-orchestrator.js'
+    );
+    assert.equal(
+      hookScriptKey('node C:\\zylos\\.claude\\skills\\activity-monitor\\scripts\\session-start-orchestrator.js'),
+      'skills/activity-monitor/scripts/session-start-orchestrator.js'
+    );
+  });
+});
+
+describe('core hook registry', () => {
+  it('includes every command hook in the settings template', () => {
+    const template = JSON.parse(fs.readFileSync(TEMPLATE_SETTINGS_PATH, 'utf8'));
+    const templateKeys = new Set();
+
+    for (const groups of Object.values(template.hooks || {})) {
+      if (!Array.isArray(groups)) continue;
+      for (const group of groups) {
+        for (const hook of getCommandHooks(group)) {
+          templateKeys.add(hookScriptKey(hook.command));
+        }
+      }
+    }
+
+    for (const key of templateKeys) {
+      assert.equal(CORE_MANAGED_HOOKS.has(key), true, `${key} missing from CORE_MANAGED_HOOKS`);
+    }
+  });
+});
+
+describe('syncHooks SessionStart orchestrator convergence', () => {
   const noopLog = () => {};
 
-  it('migrates exact standard SessionStart groups to the orchestrator', () => {
+  it('converges standard old SessionStart groups through generic sync', () => {
     const installed = {
       hooks: {
         SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
-      },
-    };
-    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: noopLog });
-
-    assert.equal(result.updated, 3);
-    for (const group of installed.hooks.SessionStart) {
-      assert.equal(group.hooks.length, 1);
-      assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
-      assert.equal(group.hooks[0].timeout, 20000);
-    }
-  });
-
-  it('migrates real installed SessionStart groups with prompt and foreground order drift', () => {
-    const installed = {
-      hooks: {
-        SessionStart: ['startup', 'clear', 'compact'].map(makeDriftedOldSessionStartGroup),
-      },
-    };
-    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: noopLog });
-
-    assert.equal(result.updated, 3);
-    assert.deepEqual(result.skipEvents, ['SessionStart']);
-    for (const group of installed.hooks.SessionStart) {
-      assert.equal(group.hooks.length, 1);
-      assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
-    }
-  });
-
-  it('is idempotent when SessionStart is already on the orchestrator', () => {
-    const installed = JSON.parse(JSON.stringify(makeOrchestratorTemplate()));
-    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: noopLog });
-
-    assert.equal(result.updated, 0);
-    assert.deepEqual(result.skipEvents, []);
-  });
-
-  it('skips and protects custom/non-standard old SessionStart hooks', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [
-          {
-            ...makeStandardOldSessionStartGroup('startup'),
-            hooks: [
-              ...makeStandardOldSessionStartGroup('startup').hooks,
-              makeHook('/custom/my-session-start.js', 5000),
-            ],
-          },
-          makeStandardOldSessionStartGroup('clear'),
-          makeStandardOldSessionStartGroup('compact'),
-        ],
-      },
-    };
-    const logs = [];
-    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: line => logs.push(line) });
-
-    assert.equal(result.updated, 0);
-    assert.deepEqual(result.skipEvents, ['SessionStart']);
-    assert.ok(logs.some(line => line.includes('custom/non-standard')));
-    assert.equal(installed.hooks.SessionStart[0].hooks.length, 5);
-  });
-
-  it('dryRun reports migration without mutating installed settings', () => {
-    const installed = {
-      hooks: {
-        SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
-      },
-    };
-    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { dryRun: true, log: noopLog });
-
-    assert.equal(result.updated, 3);
-    assert.deepEqual(result.skipEvents, ['SessionStart']);
-    assert.match(installed.hooks.SessionStart[0].hooks[0].command, /session-start-inject\.js/);
-  });
-
-  it('skips and protects timeout-drifted old SessionStart hooks', () => {
-    const installed = {
-      hooks: {
-        SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
-      },
-    };
-    installed.hooks.SessionStart[0].hooks[0].timeout = 9000;
-    const logs = [];
-    const result = migrateSessionStartOrchestrator(installed, makeOrchestratorTemplate(), { log: line => logs.push(line) });
-
-    assert.equal(result.updated, 0);
-    assert.deepEqual(result.skipEvents, ['SessionStart']);
-    assert.ok(logs.some(line => line.includes('custom/non-standard')));
-    assert.match(installed.hooks.SessionStart[0].hooks[0].command, /session-start-inject\.js/);
-  });
-
-  it('syncHooks dry-run counts a standard SessionStart migration once', () => {
-    const installed = {
-      hooks: {
-        SessionStart: ['startup', 'clear', 'compact'].map(makeStandardOldSessionStartGroup),
-      },
-    };
-    const result = syncHooks(installed, makeOrchestratorTemplate(), { dryRun: true, log: noopLog });
-
-    assert.deepEqual(result, { added: 0, updated: 3, removed: 0 });
-  });
-
-  it('syncHooks preserves custom/non-standard SessionStart configs instead of removing old hooks', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [
-          {
-            ...makeStandardOldSessionStartGroup('startup'),
-            hooks: [
-              ...makeStandardOldSessionStartGroup('startup').hooks,
-              makeHook('/custom/my-session-start.js', 5000),
-            ],
-          },
-          makeStandardOldSessionStartGroup('clear'),
-          makeStandardOldSessionStartGroup('compact'),
-        ],
       },
     };
 
     const result = syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
 
-    assert.equal(result.added, 0);
-    assert.equal(result.removed, 0);
-    assert.equal(installed.hooks.SessionStart[0].hooks.length, 5);
-    assert.ok(installed.hooks.SessionStart[0].hooks.some(h => h.command.includes('session-start-inject.js')));
+    assert.deepEqual(result, { added: 3, updated: 0, removed: 12 });
+    assertSessionStartUsesOrchestrator(installed);
   });
-});
 
-// --- migrateMatcherSplit tests ---
-describe('migrateMatcherSplit', () => {
-  const noopLog = () => {};
+  it('converges order-drifted old SessionStart groups', () => {
+    const installed = {
+      hooks: {
+        SessionStart: ['startup', 'clear', 'compact'].map(makeDriftedOldSessionStartGroup),
+      },
+    };
 
-  it('splits a catch-all into specific matchers', () => {
+    syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    assertSessionStartUsesOrchestrator(installed);
+  });
+
+  it('converges timeout-drifted and partial old SessionStart groups', () => {
     const installed = {
       hooks: {
         SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js', '/skills/b/scripts/b.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js', '/skills/b/scripts/b.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js', '/skills/b/scripts/b.js']),
-          makeMatcherGroup('compact', ['/skills/a/scripts/a.js', '/skills/b/scripts/b.js']),
+          {
+            matcher: 'startup',
+            hooks: [
+              makeHook('/Users/howard/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js', 9000),
+              makeHook('/Users/howard/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js', 10000),
+              makeHook('/Users/howard/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js', 5000),
+            ],
+          },
+          makeStandardOldSessionStartGroup('clear'),
+          makeStandardOldSessionStartGroup('compact'),
         ],
       },
     };
 
-    const count = migrateMatcherSplit(installed, template, { log: noopLog });
+    syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
 
-    assert.equal(count, 3);
-    assert.equal(installed.hooks.SessionStart.length, 3);
-    const matchers = installed.hooks.SessionStart.map(g => g.matcher).sort();
-    assert.deepEqual(matchers, ['clear', 'compact', 'startup']);
-    for (const group of installed.hooks.SessionStart) {
-      assert.equal(group.hooks.length, 2);
-    }
+    assertSessionStartUsesOrchestrator(installed);
   });
 
-  it('skips when no catch-all exists in installed config', () => {
+  it('converges old catch-all SessionStart group to specific orchestrator matchers', () => {
     const installed = {
       hooks: {
         SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js']),
+          {
+            matcher: '',
+            hooks: makeStandardOldSessionStartGroup('').hooks,
+          },
         ],
       },
     };
 
-    const count = migrateMatcherSplit(installed, template, { log: noopLog });
-    assert.equal(count, 0);
-    assert.equal(installed.hooks.SessionStart.length, 1);
+    syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    assertSessionStartUsesOrchestrator(installed);
+    assert.equal(installed.hooks.SessionStart.some(group => group.matcher === ''), false);
   });
 
-  it('skips when template also has a catch-all', () => {
+  it('preserves user command hooks and non-command hooks while removing retired core hooks', () => {
     const installed = {
       hooks: {
         SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js']),
+          {
+            matcher: 'startup',
+            hooks: [
+              ...makeStandardOldSessionStartGroup('startup').hooks,
+              makeHook('/custom/my-session-start.js', 5000),
+              { type: 'prompt', prompt: 'keep me' },
+            ],
+          },
         ],
       },
     };
 
-    const count = migrateMatcherSplit(installed, template, { log: noopLog });
-    assert.equal(count, 0);
+    syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
+
+    const startup = installed.hooks.SessionStart.find(group => group.matcher === 'startup');
+    assert.ok(startup.hooks.some(h => h.command?.includes('session-start-orchestrator.js')));
+    assert.ok(startup.hooks.some(h => h.command?.includes('/custom/my-session-start.js')));
+    assert.ok(startup.hooks.some(h => h.type === 'prompt'));
+    assert.equal(startup.hooks.some(h => h.command?.includes('session-start-inject.js')), false);
   });
 
-  it('skips when catch-all has user hooks not in template', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js', '/custom/user-hook.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
+  it('is idempotent when installed hooks already match the template', () => {
+    const installed = JSON.parse(JSON.stringify(makeOrchestratorTemplate()));
 
-    const count = migrateMatcherSplit(installed, template, { log: noopLog });
-    assert.equal(count, 0);
-    assert.equal(installed.hooks.SessionStart.length, 1);
-    assert.equal(installed.hooks.SessionStart[0].matcher, '');
-  });
+    const result = syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
 
-  it('does not duplicate matchers that already exist', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('compact', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-
-    const count = migrateMatcherSplit(installed, template, { log: noopLog });
-    assert.equal(count, 3);
-    assert.equal(installed.hooks.SessionStart.length, 3);
-    const matchers = installed.hooks.SessionStart.map(g => g.matcher).sort();
-    assert.deepEqual(matchers, ['clear', 'compact', 'startup']);
-  });
-
-  it('dryRun does not modify installed config', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-
-    const count = migrateMatcherSplit(installed, template, { dryRun: true, log: noopLog });
-    assert.equal(count, 2);
-    assert.equal(installed.hooks.SessionStart.length, 1);
-    assert.equal(installed.hooks.SessionStart[0].matcher, '');
-  });
-
-  it('handles undefined matcher as catch-all', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [
-          { hooks: [makeHook('/skills/a/scripts/a.js')] },
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-
-    const count = migrateMatcherSplit(installed, template, { log: noopLog });
-    assert.equal(count, 1);
-    assert.equal(installed.hooks.SessionStart.length, 1);
-    assert.equal(installed.hooks.SessionStart[0].matcher, 'startup');
-  });
-
-  it('preserves hook content (command, timeout) during split', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [{
-          matcher: '',
-          hooks: [
-            { type: 'command', command: 'node /skills/a/scripts/a.js', timeout: 5000 },
-            { type: 'command', command: 'node /skills/b/scripts/b.js', timeout: 15000 },
-          ],
-        }],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js', '/skills/b/scripts/b.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js', '/skills/b/scripts/b.js']),
-        ],
-      },
-    };
-
-    migrateMatcherSplit(installed, template, { log: noopLog });
-
-    for (const group of installed.hooks.SessionStart) {
-      assert.equal(group.hooks[0].timeout, 5000);
-      assert.equal(group.hooks[1].timeout, 15000);
-      assert.ok(group.hooks[0].command.includes('a.js'));
-      assert.ok(group.hooks[1].command.includes('b.js'));
-    }
-  });
-
-  it('handles empty hooks gracefully', () => {
-    const count1 = migrateMatcherSplit({}, {}, { log: noopLog });
-    assert.equal(count1, 0);
-
-    const count2 = migrateMatcherSplit({ hooks: {} }, { hooks: {} }, { log: noopLog });
-    assert.equal(count2, 0);
-  });
-
-  it('works across multiple events independently', () => {
-    const installed = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js']),
-        ],
-        Stop: [
-          makeMatcherGroup('', ['/skills/b/scripts/b.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js']),
-        ],
-        Stop: [
-          makeMatcherGroup('success', ['/skills/b/scripts/b.js']),
-        ],
-      },
-    };
-
-    const count = migrateMatcherSplit(installed, template, { log: noopLog });
-    assert.equal(count, 3);
-    assert.equal(installed.hooks.SessionStart.length, 2);
-    assert.equal(installed.hooks.Stop.length, 1);
-    assert.equal(installed.hooks.Stop[0].matcher, 'success');
-  });
-
-  it('logs migration actions', () => {
-    const logs = [];
-    const installed = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-    const template = {
-      hooks: {
-        SessionStart: [
-          makeMatcherGroup('startup', ['/skills/a/scripts/a.js']),
-          makeMatcherGroup('clear', ['/skills/a/scripts/a.js']),
-        ],
-      },
-    };
-
-    migrateMatcherSplit(installed, template, { log: (msg) => logs.push(msg) });
-    assert.equal(logs.length, 1);
-    assert.ok(logs[0].includes('SessionStart'));
-    assert.ok(logs[0].includes('startup'));
-    assert.ok(logs[0].includes('clear'));
+    assert.deepEqual(result, { added: 0, updated: 0, removed: 0 });
+    assertSessionStartUsesOrchestrator(installed);
   });
 });
 

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -268,6 +268,49 @@ describe('persistInstalledSettingsAndSyncCoupledThreshold', () => {
     ]);
   });
 
+  it('prunes old .bak backups after a successful write, keeping the newest N', () => {
+    const unlinked = [];
+    persistInstalledSettingsAndSyncCoupledThreshold({
+      installedSettings: { hooks: {} },
+      settingsPath: '/tmp/zylos/.claude/settings.json',
+      maxBackups: 3,
+      mkdirSync: () => {},
+      existsSync: () => true,
+      copyFileSync: () => {},
+      writeFileSync: () => {},
+      readdirSync: () => [
+        'settings.json',
+        'settings.json.bak.100',
+        'settings.json.bak.500',
+        'settings.json.bak.300',
+        'settings.json.bak.200',
+        'settings.json.bak.400',
+        'other.json.bak.999',
+      ],
+      unlinkSync: (p) => unlinked.push(p),
+      syncThreshold: () => ({ changed: false }),
+    });
+
+    // newest 3 (500,400,300) kept; oldest 2 (200,100) removed; unrelated file untouched
+    assert.deepEqual(unlinked.sort(), [
+      '/tmp/zylos/.claude/settings.json.bak.100',
+      '/tmp/zylos/.claude/settings.json.bak.200',
+    ]);
+  });
+
+  it('does not fail the write when backup pruning throws', () => {
+    assert.doesNotThrow(() => persistInstalledSettingsAndSyncCoupledThreshold({
+      installedSettings: { hooks: {} },
+      settingsPath: '/tmp/zylos/.claude/settings.json',
+      mkdirSync: () => {},
+      existsSync: () => true,
+      copyFileSync: () => {},
+      writeFileSync: () => {},
+      readdirSync: () => { throw new Error('ENOENT'); },
+      syncThreshold: () => ({ changed: false }),
+    }));
+  });
+
   it('restores the backup when writing settings fails', () => {
     const calls = [];
     assert.throws(() => persistInstalledSettingsAndSyncCoupledThreshold({

--- a/cli/lib/hook-utils.js
+++ b/cli/lib/hook-utils.js
@@ -6,6 +6,121 @@
 import path from 'node:path';
 import os from 'node:os';
 
+const SCRIPT_EXT_RE = /\.(?:[cm]?js|jsx|tsx?|sh|bash|zsh|py|rb|pl|php|lua)$/i;
+const INTERPRETERS = new Set(['node', 'nodejs', 'bun', 'deno']);
+
+function expandHome(scriptPath) {
+  return scriptPath.startsWith('~/') ? path.join(os.homedir(), scriptPath.slice(2)) : scriptPath;
+}
+
+function commandSegments(command) {
+  const segments = [];
+  let current = '';
+  let quote = null;
+  let escaped = false;
+
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      current += ch;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === ';' || ch === '|') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    if (ch === '&' && command[i + 1] === '&') {
+      segments.push(current);
+      current = '';
+      i += 1;
+      continue;
+    }
+    current += ch;
+  }
+
+  segments.push(current);
+  return segments.map(segment => segment.trim()).filter(Boolean);
+}
+
+function shellTokens(segment) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let escaped = false;
+
+  for (const ch of segment) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      current += ch;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function interpreterName(token) {
+  return path.basename(token.replaceAll('\\', '/'));
+}
+
+function looksLikeScript(token) {
+  return SCRIPT_EXT_RE.test(token);
+}
+
+function fallbackScriptPath(command) {
+  let result = null;
+  for (const raw of shellTokens(command)) {
+    const token = raw.replace(/^["']|["']$/g, '');
+    if (token.includes('/') && looksLikeScript(token)) {
+      result = token;
+    }
+  }
+  return result;
+}
+
 /**
  * Extract the script file path from a hook command.
  * e.g. "node ~/zylos/.claude/skills/foo/scripts/bar.js --flag"
@@ -14,18 +129,30 @@ import os from 'node:os';
  */
 export function extractScriptPath(command) {
   if (typeof command !== 'string') return '';
-  // Use the LAST path-like token so that shell prefixes
-  // (e.g. "source ~/.nvm/nvm.sh && node ~/path/script.js") are skipped
-  let result = null;
-  for (const raw of command.split(/\s+/)) {
-    const token = raw.replace(/^["']|["']$/g, '');
-    if (token.includes('/') && /\.\w+$/.test(token)) {
-      result = token;
+
+  const segments = commandSegments(command);
+  const lastSegment = segments.at(-1) || command;
+  const tokens = shellTokens(lastSegment);
+  const interpreterIndex = tokens.findIndex(token => INTERPRETERS.has(interpreterName(token)));
+  if (interpreterIndex !== -1) {
+    for (const token of tokens.slice(interpreterIndex + 1)) {
+      if (token.startsWith('-')) continue;
+      if (looksLikeScript(token)) return expandHome(token);
+      break;
     }
   }
-  if (!result) return command;
-  // Normalize ~ to absolute path for consistent comparison
-  return result.startsWith('~/') ? path.join(os.homedir(), result.slice(2)) : result;
+
+  const result = fallbackScriptPath(command);
+  return result ? expandHome(result) : command;
+}
+
+function zylosClaudeRoot() {
+  const zylosDir = path.resolve(process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
+  return `${path.resolve(zylosDir, '.claude').replaceAll('\\', '/').replace(/\/+$/, '')}/`;
+}
+
+function normalizedAbsolutePath(scriptPath) {
+  return path.resolve(scriptPath).replaceAll('\\', '/');
 }
 
 /**
@@ -34,10 +161,11 @@ export function extractScriptPath(command) {
  * other paths keep their full normalized path to avoid user hook collisions.
  */
 export function hookScriptKey(command) {
-  const scriptPath = extractScriptPath(command).replaceAll('\\', '/').split(path.sep).join('/');
-  const marker = '/.claude/';
-  const markerIndex = scriptPath.indexOf(marker);
-  if (markerIndex !== -1) return scriptPath.slice(markerIndex + marker.length);
+  const scriptPath = normalizedAbsolutePath(
+    extractScriptPath(command).replaceAll('\\', '/').split(path.sep).join('/')
+  );
+  const root = zylosClaudeRoot();
+  if (scriptPath.startsWith(root)) return scriptPath.slice(root.length);
 
   return scriptPath;
 }

--- a/cli/lib/hook-utils.js
+++ b/cli/lib/hook-utils.js
@@ -29,15 +29,20 @@ export function extractScriptPath(command) {
 }
 
 /**
- * Extract the skill name from a hook command's script path.
- * e.g. "node ~/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js"
- *   -> "comm-bridge"
- * Returns null if the pattern doesn't match.
+ * Return the canonical key used to compare hook script identity. The key is a
+ * normalized path suffix rooted at the zylos-owned skills directory when
+ * possible, so equivalent absolute and ~/ commands compare equal.
  */
-export function extractSkillName(command) {
-  if (typeof command !== 'string') return null;
-  const match = command.match(/skills\/([^/]+)\//);
-  return match ? match[1] : null;
+export function hookScriptKey(command) {
+  const scriptPath = extractScriptPath(command).replaceAll('\\', '/').split(path.sep).join('/');
+  const marker = '/.claude/';
+  const markerIndex = scriptPath.indexOf(marker);
+  if (markerIndex !== -1) return scriptPath.slice(markerIndex + marker.length);
+
+  const skillsIndex = scriptPath.indexOf('skills/');
+  if (skillsIndex !== -1) return scriptPath.slice(skillsIndex);
+
+  return scriptPath;
 }
 
 /**

--- a/cli/lib/hook-utils.js
+++ b/cli/lib/hook-utils.js
@@ -29,18 +29,15 @@ export function extractScriptPath(command) {
 }
 
 /**
- * Return the canonical key used to compare hook script identity. The key is a
- * normalized path suffix rooted at the zylos-owned skills directory when
- * possible, so equivalent absolute and ~/ commands compare equal.
+ * Return the canonical key used to compare hook script identity. Only hooks
+ * under the zylos-owned .claude directory are reduced to registry suffixes;
+ * other paths keep their full normalized path to avoid user hook collisions.
  */
 export function hookScriptKey(command) {
   const scriptPath = extractScriptPath(command).replaceAll('\\', '/').split(path.sep).join('/');
   const marker = '/.claude/';
   const markerIndex = scriptPath.indexOf(marker);
   if (markerIndex !== -1) return scriptPath.slice(markerIndex + marker.length);
-
-  const skillsIndex = scriptPath.indexOf('skills/');
-  if (skillsIndex !== -1) return scriptPath.slice(skillsIndex);
 
   return scriptPath;
 }

--- a/cli/lib/self-upgrade.js
+++ b/cli/lib/self-upgrade.js
@@ -13,7 +13,8 @@ import { downloadArchive, downloadBranch } from './download.js';
 import { generateManifest, saveManifest, saveOriginals } from './manifest.js';
 import { fetchRawFile, fetchLatestTag, compareSemverDesc, sanitizeError } from './github.js';
 import { copyTree, syncTree } from './fs-utils.js';
-import { extractScriptPath, extractSkillName, getCommandHooks } from './hook-utils.js';
+import { getCommandHooks, hookScriptKey } from './hook-utils.js';
+import { isCoreManaged } from './sync-settings-hooks.js';
 import { smartSync, formatMergeResult } from './smart-merge.js';
 import { getAllowedTmpRoots } from './upgrade.js';
 import { runMigrations } from './migrate.js';
@@ -426,18 +427,6 @@ export function generateMigrationHints(templatesDir, deps = {}) {
   const templateHooks = templateSettings.hooks || {};
   const installedHooks = installedSettings.hooks || {};
 
-  // Collect core skill names from template hooks (for removed_hook scoping)
-  const coreSkillNames = new Set();
-  for (const matchers of Object.values(templateHooks)) {
-    if (!Array.isArray(matchers)) continue;
-    for (const m of matchers) {
-      for (const h of getCommandHooks(m)) {
-        const name = extractSkillName(h.command);
-        if (name) coreSkillNames.add(name);
-      }
-    }
-  }
-
   // --- Forward pass: detect missing and modified hooks ---
   for (const [event, matchers] of Object.entries(templateHooks)) {
     if (!Array.isArray(matchers)) continue;
@@ -445,13 +434,13 @@ export function generateMigrationHints(templatesDir, deps = {}) {
 
     for (const matcher of matchers) {
       for (const templateCmd of getCommandHooks(matcher)) {
-        const templateKey = extractScriptPath(templateCmd.command);
+        const templateKey = hookScriptKey(templateCmd.command);
 
         // Find installed hook with the same script path
         let matched = null;
         for (const im of installedMatchers) {
           matched = getCommandHooks(im).find(
-            h => extractScriptPath(h.command) === templateKey
+            h => hookScriptKey(h.command) === templateKey
           );
           if (matched) break;
         }
@@ -528,15 +517,12 @@ export function generateMigrationHints(templatesDir, deps = {}) {
 
     for (const matcher of matchers) {
       for (const installedCmd of getCommandHooks(matcher)) {
-        // Only flag hooks from core skills to avoid false positives
-        // for optional component hooks
-        const skillName = extractSkillName(installedCmd.command);
-        if (!skillName || !coreSkillNames.has(skillName)) continue;
+        if (!isCoreManaged(installedCmd)) continue;
 
-        const installedKey = extractScriptPath(installedCmd.command);
+        const installedKey = hookScriptKey(installedCmd.command);
         const foundInTemplate = templateMatchers.some(tm =>
           getCommandHooks(tm).some(
-            h => extractScriptPath(h.command) === installedKey
+            h => hookScriptKey(h.command) === installedKey
           )
         );
 
@@ -952,14 +938,14 @@ export function applyMigrationHints(hints, deps = {}) {
         const matchers = settings.hooks[hint.event];
         if (!Array.isArray(matchers)) continue;
 
-        const oldScriptPath = extractScriptPath(hint.oldCommand);
+        const oldScriptKey = hookScriptKey(hint.oldCommand);
         let updated = false;
 
         for (const group of matchers) {
           if (!Array.isArray(group.hooks)) continue;
           for (let i = 0; i < group.hooks.length; i++) {
             const h = group.hooks[i];
-            if (h.type === 'command' && extractScriptPath(h.command) === oldScriptPath) {
+            if (h.type === 'command' && hookScriptKey(h.command) === oldScriptKey) {
               // Update command and timeout
               group.hooks[i].command = hint.command;
               if (hint.timeout !== undefined) {
@@ -1001,7 +987,7 @@ export function applyMigrationHints(hints, deps = {}) {
         const matchers = settings.hooks[hint.event];
         if (!Array.isArray(matchers)) continue;
 
-        const scriptPath = extractScriptPath(hint.command);
+        const scriptKey = hookScriptKey(hint.command);
         let removed = false;
 
         for (let gi = matchers.length - 1; gi >= 0; gi--) {
@@ -1009,7 +995,7 @@ export function applyMigrationHints(hints, deps = {}) {
           if (!Array.isArray(group.hooks)) continue;
 
           group.hooks = group.hooks.filter(h => {
-            if (h.type === 'command' && extractScriptPath(h.command) === scriptPath) {
+            if (h.type === 'command' && hookScriptKey(h.command) === scriptKey) {
               removed = true;
               return false;
             }

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -21,7 +21,7 @@ import path from 'path';
 import os from 'os';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { extractScriptPath, extractSkillName, getCommandHooks } from './hook-utils.js';
+import { hookScriptKey, getCommandHooks } from './hook-utils.js';
 import { getZylosConfig, updateZylosConfig } from './config.js';
 import { renderCodexProjectConfig, renderCodexGlobalConfig, writeCodexConfig } from './runtime-setup.js';
 
@@ -31,19 +31,24 @@ const TEMPLATE_SETTINGS = path.join(__dirname, '..', '..', 'templates', '.claude
 const INSTALLED_SETTINGS = path.join(ZYLOS_DIR, '.claude', 'settings.json');
 
 const MAX_SAFE_1M_THRESHOLD = 30;
-const SESSION_START_OLD_SCRIPTS = [
+export const CORE_MANAGED_HOOKS = new Set([
+  // Current template hooks. Keep this append-only: when a core hook is retired,
+  // leave its path here so upgrades can still remove stale installed copies.
+  'skills/activity-monitor/scripts/context-monitor.js',
+  'skills/activity-monitor/scripts/hook-activity.js',
+  'skills/activity-monitor/scripts/hook-auth-prompt.js',
+  'skills/activity-monitor/scripts/session-start-orchestrator.js',
+  // Retired SessionStart hooks replaced by the orchestrator.
   'skills/zylos-memory/scripts/session-start-inject.js',
   'skills/comm-bridge/scripts/c4-session-init.js',
   'skills/activity-monitor/scripts/session-foreground.js',
   'skills/activity-monitor/scripts/session-start-prompt.js',
-];
-const SESSION_START_OLD_TIMEOUT_BY_SCRIPT = new Map([
-  ['skills/zylos-memory/scripts/session-start-inject.js', 10000],
-  ['skills/comm-bridge/scripts/c4-session-init.js', 10000],
-  ['skills/activity-monitor/scripts/session-foreground.js', 5000],
-  ['skills/activity-monitor/scripts/session-start-prompt.js', 5000],
 ]);
-const SESSION_START_MATCHERS = ['startup', 'clear', 'compact'];
+
+export function isCoreManaged(hook) {
+  if (!hook || hook.type !== 'command') return false;
+  return CORE_MANAGED_HOOKS.has(hookScriptKey(hook.command));
+}
 
 function is1mModel(model) {
   return typeof model === 'string' && model.includes('[1m]');
@@ -269,18 +274,6 @@ export function syncCodexConfig({
 export function syncHooks(installedSettings, templateSettings, { dryRun = false, log = console.log } = {}) {
   const templateHooks = templateSettings.hooks || {};
 
-  // Collect core skill names from template
-  const coreSkillNames = new Set();
-  for (const matchers of Object.values(templateHooks)) {
-    if (!Array.isArray(matchers)) continue;
-    for (const m of matchers) {
-      for (const h of getCommandHooks(m)) {
-        const name = extractSkillName(h.command);
-        if (name) coreSkillNames.add(name);
-      }
-    }
-  }
-
   let added = 0;
   let updated = 0;
   let removed = 0;
@@ -288,25 +281,12 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
   // Ensure hooks object exists
   if (!installedSettings.hooks) installedSettings.hooks = {};
 
-  // --- Pre-migration: split catch-all matchers into specific matchers ---
-  const migrated = migrateMatcherSplit(installedSettings, templateSettings, { dryRun, log });
-  if (migrated > 0) {
-    updated += migrated;
-  }
-
-  const sessionStartMigration = migrateSessionStartOrchestrator(installedSettings, templateSettings, { dryRun, log });
-  if (sessionStartMigration.updated > 0) {
-    updated += sessionStartMigration.updated;
-  }
-  const skipEvents = new Set(sessionStartMigration.skipEvents || []);
-
   // --- Forward pass: add missing matcher groups/hooks, update hooks in matched groups ---
   // Strategy: align by matcher group, not by individual hook across all groups.
   //   - If installed has a group with the same matcher → add missing template
   //     hooks and update existing hooks (command/timeout drift)
   //   - If installed has NO group with that matcher → add the whole group from template
   for (const [event, matchers] of Object.entries(templateHooks)) {
-    if (skipEvents.has(event)) continue;
     if (!Array.isArray(matchers)) continue;
     if (!Array.isArray(installedSettings.hooks[event])) {
       installedSettings.hooks[event] = [];
@@ -324,9 +304,9 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
         // (command/timeout drift). This is needed for upgrades where new core
         // hooks are added to an existing matcher group.
         for (const templateCmd of getCommandHooks(templateGroup)) {
-          const templateKey = extractScriptPath(templateCmd.command);
+          const templateKey = hookScriptKey(templateCmd.command);
           const existing = getCommandHooks(installedGroup).find(
-            h => extractScriptPath(h.command) === templateKey
+            h => hookScriptKey(h.command) === templateKey
           );
           if (!existing) {
             if (!dryRun) {
@@ -366,7 +346,6 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
   // A core hook is removed if it's not present in the matching template group,
   // even if it exists in other template groups for the same event.
   for (const [event, matchers] of Object.entries(installedSettings.hooks)) {
-    if (skipEvents.has(event)) continue;
     if (!Array.isArray(matchers)) continue;
 
     const templateMatchers = Array.isArray(templateHooks[event]) ? templateHooks[event] : [];
@@ -384,13 +363,12 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
         const h = group.hooks[hi];
         if (h.type !== 'command') continue;
 
-        const skillName = extractSkillName(h.command);
-        if (!skillName || !coreSkillNames.has(skillName)) continue;
+        if (!isCoreManaged(h)) continue;
 
-        const installedKey = extractScriptPath(h.command);
+        const installedKey = hookScriptKey(h.command);
         // Check only the corresponding template group, not all groups
         const foundInTemplate = correspondingTemplate
-          ? getCommandHooks(correspondingTemplate).some(th => extractScriptPath(th.command) === installedKey)
+          ? getCommandHooks(correspondingTemplate).some(th => hookScriptKey(th.command) === installedKey)
           : false;
 
         if (!foundInTemplate) {
@@ -536,161 +514,6 @@ export function main(argv = process.argv.slice(2)) {
   // package during upgrade (via resolveInstalledSyncScript), so it works even
   // when the calling component.js is an older version without restart logic.
   enqueueRestartIfNeeded();
-}
-
-/**
- * Pre-migration: when a template splits a catch-all matcher ("") into specific
- * matchers (e.g. "startup", "clear", "compact"), transform the installed config
- * to match before the forward/reverse passes run.
- *
- * Without this, the forward pass sees the script paths already exist (under "")
- * and skips adding the specific matchers; the reverse pass sees the script paths
- * in the template and keeps the old catch-all. Result: no migration happens.
- *
- * @returns {number} Number of hook entries migrated
- */
-export function migrateMatcherSplit(installedSettings, templateSettings, { dryRun = false, log = console.log } = {}) {
-  let count = 0;
-  const templateHooks = templateSettings.hooks || {};
-  const installedHooks = installedSettings.hooks || {};
-
-  for (const [event, templateMatchers] of Object.entries(templateHooks)) {
-    if (!Array.isArray(templateMatchers)) continue;
-    const installedMatchers = installedHooks[event];
-    if (!Array.isArray(installedMatchers)) continue;
-
-    // Find catch-all group in installed config
-    const catchAllIdx = installedMatchers.findIndex(g => g.matcher === '' || g.matcher === undefined);
-    if (catchAllIdx === -1) continue;
-
-    // Check if template has NO catch-all but has specific matchers
-    const templateHasCatchAll = templateMatchers.some(g => g.matcher === '' || g.matcher === undefined);
-    if (templateHasCatchAll) continue;
-
-    const templateSpecificMatchers = templateMatchers
-      .filter(g => g.matcher !== '' && g.matcher !== undefined)
-      .map(g => g.matcher);
-    if (templateSpecificMatchers.length === 0) continue;
-
-    // Verify the catch-all hooks match the template hooks (same script paths)
-    const catchAllGroup = installedMatchers[catchAllIdx];
-    const catchAllPaths = new Set(
-      getCommandHooks(catchAllGroup).map(h => extractScriptPath(h.command))
-    );
-    const templatePaths = new Set(
-      templateMatchers.flatMap(g => getCommandHooks(g).map(h => extractScriptPath(h.command)))
-    );
-
-    // Only migrate if all catch-all hooks exist in the template
-    const allCovered = [...catchAllPaths].every(p => templatePaths.has(p));
-    if (!allCovered) continue;
-
-    if (!dryRun) {
-      // Replace catch-all with specific matcher groups, preserving hook content
-      const hooks = catchAllGroup.hooks || [];
-      installedMatchers.splice(catchAllIdx, 1);
-      for (const matcher of templateSpecificMatchers) {
-        // Only add if this matcher doesn't already exist
-        if (!installedMatchers.some(g => g.matcher === matcher)) {
-          installedMatchers.push({
-            matcher,
-            hooks: hooks.map(h => ({ ...h })),
-          });
-        }
-      }
-    }
-
-    count += templateSpecificMatchers.length;
-    log(`  ↔ ${event}: split catch-all matcher into ${templateSpecificMatchers.join(', ')}`);
-  }
-
-  return count;
-}
-
-function scriptPathEndsWith(command, suffix) {
-  const scriptPath = extractScriptPath(command).split(path.sep).join('/');
-  return scriptPath.endsWith(suffix);
-}
-
-function isOrchestratorTemplate(templateSettings) {
-  const groups = templateSettings?.hooks?.SessionStart;
-  if (!Array.isArray(groups)) return false;
-  const expected = new Set(SESSION_START_MATCHERS);
-  if (groups.length !== expected.size) return false;
-  for (const group of groups) {
-    if (!expected.has(group.matcher)) return false;
-    const hooks = getCommandHooks(group);
-    if (hooks.length !== 1) return false;
-    if (!scriptPathEndsWith(hooks[0].command, 'skills/activity-monitor/scripts/session-start-orchestrator.js')) return false;
-  }
-  return true;
-}
-
-function isStandardOldSessionStartGroup(group) {
-  const hooks = getCommandHooks(group);
-  if (hooks.length !== SESSION_START_OLD_SCRIPTS.length) return false;
-  const seen = new Set();
-  for (const hook of hooks) {
-    if (hook.type !== 'command') return false;
-    const suffix = SESSION_START_OLD_SCRIPTS.find(script => scriptPathEndsWith(hook.command, script));
-    if (!suffix || seen.has(suffix)) return false;
-    if (hook.timeout !== SESSION_START_OLD_TIMEOUT_BY_SCRIPT.get(suffix)) return false;
-    seen.add(suffix);
-  }
-  return seen.size === SESSION_START_OLD_SCRIPTS.length;
-}
-
-function containsOldSessionStartScript(groups) {
-  return groups.some(group => getCommandHooks(group).some(h =>
-    SESSION_START_OLD_SCRIPTS.some(suffix => scriptPathEndsWith(h.command, suffix))
-  ));
-}
-
-/**
- * Migrate the standard old SessionStart shape:
- *   startup/clear/compact × [inject, c4-init, foreground, prompt]
- * to:
- *   startup/clear/compact × [orchestrator]
- *
- * Non-standard SessionStart configs are skipped and protected from the generic
- * forward/reverse sync pass, so user-customized running hooks are not silently
- * overwritten during upgrade.
- */
-export function migrateSessionStartOrchestrator(installedSettings, templateSettings, { dryRun = false, log = console.log } = {}) {
-  if (!isOrchestratorTemplate(templateSettings)) {
-    return { updated: 0, skipped: 0, skipEvents: [] };
-  }
-
-  const installedGroups = installedSettings?.hooks?.SessionStart;
-  if (!Array.isArray(installedGroups) || installedGroups.length === 0) {
-    return { updated: 0, skipped: 0, skipEvents: [] };
-  }
-
-  const groupsByMatcher = new Map(installedGroups.map(g => [g.matcher ?? '', g]));
-  const hasAllStandardGroups = SESSION_START_MATCHERS.every((matcher) =>
-    isStandardOldSessionStartGroup(groupsByMatcher.get(matcher))
-  );
-  const onlyStandardGroups = installedGroups.every(group =>
-    SESSION_START_MATCHERS.includes(group.matcher) && isStandardOldSessionStartGroup(group)
-  );
-
-  if (!hasAllStandardGroups || !onlyStandardGroups) {
-    if (containsOldSessionStartScript(installedGroups)) {
-      log('  ! SessionStart: custom/non-standard hooks detected; skipped orchestrator migration');
-      return { updated: 0, skipped: 1, skipEvents: ['SessionStart'] };
-    }
-    return { updated: 0, skipped: 0, skipEvents: [] };
-  }
-
-  if (!dryRun) {
-    installedSettings.hooks.SessionStart = templateSettings.hooks.SessionStart.map(group => ({
-      matcher: group.matcher,
-      hooks: getCommandHooks(group).map(h => ({ ...h })),
-    }));
-  }
-
-  log('  ↔ SessionStart: migrated standard 4-hook groups to orchestrator');
-  return { updated: SESSION_START_MATCHERS.length, skipped: 0, skipEvents: ['SessionStart'] };
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -31,6 +31,14 @@ const TEMPLATE_SETTINGS = path.join(__dirname, '..', '..', 'templates', '.claude
 const INSTALLED_SETTINGS = path.join(ZYLOS_DIR, '.claude', 'settings.json');
 
 const MAX_SAFE_1M_THRESHOLD = 30;
+const SESSION_START_OLD_SCRIPTS = [
+  'skills/zylos-memory/scripts/session-start-inject.js',
+  'skills/comm-bridge/scripts/c4-session-init.js',
+  'skills/activity-monitor/scripts/session-foreground.js',
+  'skills/activity-monitor/scripts/session-start-prompt.js',
+];
+const SESSION_START_OLD_TIMEOUTS = [10000, 10000, 5000, 5000];
+const SESSION_START_MATCHERS = ['startup', 'clear', 'compact'];
 
 function is1mModel(model) {
   return typeof model === 'string' && model.includes('[1m]');
@@ -115,11 +123,25 @@ export function persistInstalledSettingsAndSyncCoupledThreshold({
   modelBackfilled = false,
   mkdirSync = fs.mkdirSync,
   writeFileSync = fs.writeFileSync,
+  existsSync = fs.existsSync,
+  copyFileSync = fs.copyFileSync,
   syncThreshold = syncModelCoupledNewSessionThreshold,
 } = {}) {
   const dir = path.dirname(settingsPath);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(settingsPath, JSON.stringify(installedSettings, null, 2) + '\n');
+  let backupPath = null;
+  if (existsSync(settingsPath)) {
+    backupPath = `${settingsPath}.bak.${Date.now()}`;
+    copyFileSync(settingsPath, backupPath);
+  }
+  try {
+    writeFileSync(settingsPath, JSON.stringify(installedSettings, null, 2) + '\n');
+  } catch (err) {
+    if (backupPath) {
+      try { copyFileSync(backupPath, settingsPath); } catch {}
+    }
+    throw err;
+  }
   return syncThreshold({ modelBackfilled });
 }
 
@@ -228,12 +250,19 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
     updated += migrated;
   }
 
+  const sessionStartMigration = migrateSessionStartOrchestrator(installedSettings, templateSettings, { dryRun, log });
+  if (sessionStartMigration.updated > 0) {
+    updated += sessionStartMigration.updated;
+  }
+  const skipEvents = new Set(sessionStartMigration.skipEvents || []);
+
   // --- Forward pass: add missing matcher groups/hooks, update hooks in matched groups ---
   // Strategy: align by matcher group, not by individual hook across all groups.
   //   - If installed has a group with the same matcher → add missing template
   //     hooks and update existing hooks (command/timeout drift)
   //   - If installed has NO group with that matcher → add the whole group from template
   for (const [event, matchers] of Object.entries(templateHooks)) {
+    if (skipEvents.has(event)) continue;
     if (!Array.isArray(matchers)) continue;
     if (!Array.isArray(installedSettings.hooks[event])) {
       installedSettings.hooks[event] = [];
@@ -293,6 +322,7 @@ export function syncHooks(installedSettings, templateSettings, { dryRun = false,
   // A core hook is removed if it's not present in the matching template group,
   // even if it exists in other template groups for the same event.
   for (const [event, matchers] of Object.entries(installedSettings.hooks)) {
+    if (skipEvents.has(event)) continue;
     if (!Array.isArray(matchers)) continue;
 
     const templateMatchers = Array.isArray(templateHooks[event]) ? templateHooks[event] : [];
@@ -531,6 +561,90 @@ export function migrateMatcherSplit(installedSettings, templateSettings, { dryRu
   }
 
   return count;
+}
+
+function scriptPathEndsWith(command, suffix) {
+  const scriptPath = extractScriptPath(command).split(path.sep).join('/');
+  return scriptPath.endsWith(suffix);
+}
+
+function isOrchestratorTemplate(templateSettings) {
+  const groups = templateSettings?.hooks?.SessionStart;
+  if (!Array.isArray(groups)) return false;
+  const expected = new Set(SESSION_START_MATCHERS);
+  if (groups.length !== expected.size) return false;
+  for (const group of groups) {
+    if (!expected.has(group.matcher)) return false;
+    const hooks = getCommandHooks(group);
+    if (hooks.length !== 1) return false;
+    if (!scriptPathEndsWith(hooks[0].command, 'skills/activity-monitor/scripts/session-start-orchestrator.js')) return false;
+  }
+  return true;
+}
+
+function isStandardOldSessionStartGroup(group) {
+  const hooks = getCommandHooks(group);
+  if (hooks.length !== SESSION_START_OLD_SCRIPTS.length) return false;
+  for (let i = 0; i < SESSION_START_OLD_SCRIPTS.length; i++) {
+    const hook = hooks[i];
+    if (hook.type !== 'command') return false;
+    if (!scriptPathEndsWith(hook.command, SESSION_START_OLD_SCRIPTS[i])) return false;
+    if (hook.timeout !== SESSION_START_OLD_TIMEOUTS[i]) return false;
+  }
+  return true;
+}
+
+function containsOldSessionStartScript(groups) {
+  return groups.some(group => getCommandHooks(group).some(h =>
+    SESSION_START_OLD_SCRIPTS.some(suffix => scriptPathEndsWith(h.command, suffix))
+  ));
+}
+
+/**
+ * Migrate the standard old SessionStart shape:
+ *   startup/clear/compact × [inject, c4-init, foreground, prompt]
+ * to:
+ *   startup/clear/compact × [orchestrator]
+ *
+ * Non-standard SessionStart configs are skipped and protected from the generic
+ * forward/reverse sync pass, so user-customized running hooks are not silently
+ * overwritten during upgrade.
+ */
+export function migrateSessionStartOrchestrator(installedSettings, templateSettings, { dryRun = false, log = console.log } = {}) {
+  if (!isOrchestratorTemplate(templateSettings)) {
+    return { updated: 0, skipped: 0, skipEvents: [] };
+  }
+
+  const installedGroups = installedSettings?.hooks?.SessionStart;
+  if (!Array.isArray(installedGroups) || installedGroups.length === 0) {
+    return { updated: 0, skipped: 0, skipEvents: [] };
+  }
+
+  const groupsByMatcher = new Map(installedGroups.map(g => [g.matcher ?? '', g]));
+  const hasAllStandardGroups = SESSION_START_MATCHERS.every((matcher) =>
+    isStandardOldSessionStartGroup(groupsByMatcher.get(matcher))
+  );
+  const onlyStandardGroups = installedGroups.every(group =>
+    SESSION_START_MATCHERS.includes(group.matcher) && isStandardOldSessionStartGroup(group)
+  );
+
+  if (!hasAllStandardGroups || !onlyStandardGroups) {
+    if (containsOldSessionStartScript(installedGroups)) {
+      log('  ! SessionStart: custom/non-standard hooks detected; skipped orchestrator migration');
+      return { updated: 0, skipped: 1, skipEvents: ['SessionStart'] };
+    }
+    return { updated: 0, skipped: 0, skipEvents: [] };
+  }
+
+  if (!dryRun) {
+    installedSettings.hooks.SessionStart = templateSettings.hooks.SessionStart.map(group => ({
+      matcher: group.matcher,
+      hooks: getCommandHooks(group).map(h => ({ ...h })),
+    }));
+  }
+
+  log('  ↔ SessionStart: migrated standard 4-hook groups to orchestrator');
+  return { updated: SESSION_START_MATCHERS.length, skipped: 0, skipEvents: [] };
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -37,7 +37,12 @@ const SESSION_START_OLD_SCRIPTS = [
   'skills/activity-monitor/scripts/session-foreground.js',
   'skills/activity-monitor/scripts/session-start-prompt.js',
 ];
-const SESSION_START_OLD_TIMEOUTS = [10000, 10000, 5000, 5000];
+const SESSION_START_OLD_TIMEOUT_BY_SCRIPT = new Map([
+  ['skills/zylos-memory/scripts/session-start-inject.js', 10000],
+  ['skills/comm-bridge/scripts/c4-session-init.js', 10000],
+  ['skills/activity-monitor/scripts/session-foreground.js', 5000],
+  ['skills/activity-monitor/scripts/session-start-prompt.js', 5000],
+]);
 const SESSION_START_MATCHERS = ['startup', 'clear', 'compact'];
 
 function is1mModel(model) {
@@ -585,13 +590,15 @@ function isOrchestratorTemplate(templateSettings) {
 function isStandardOldSessionStartGroup(group) {
   const hooks = getCommandHooks(group);
   if (hooks.length !== SESSION_START_OLD_SCRIPTS.length) return false;
-  for (let i = 0; i < SESSION_START_OLD_SCRIPTS.length; i++) {
-    const hook = hooks[i];
+  const seen = new Set();
+  for (const hook of hooks) {
     if (hook.type !== 'command') return false;
-    if (!scriptPathEndsWith(hook.command, SESSION_START_OLD_SCRIPTS[i])) return false;
-    if (hook.timeout !== SESSION_START_OLD_TIMEOUTS[i]) return false;
+    const suffix = SESSION_START_OLD_SCRIPTS.find(script => scriptPathEndsWith(hook.command, script));
+    if (!suffix || seen.has(suffix)) return false;
+    if (hook.timeout !== SESSION_START_OLD_TIMEOUT_BY_SCRIPT.get(suffix)) return false;
+    seen.add(suffix);
   }
-  return true;
+  return seen.size === SESSION_START_OLD_SCRIPTS.length;
 }
 
 function containsOldSessionStartScript(groups) {
@@ -644,7 +651,7 @@ export function migrateSessionStartOrchestrator(installedSettings, templateSetti
   }
 
   log('  ↔ SessionStart: migrated standard 4-hook groups to orchestrator');
-  return { updated: SESSION_START_MATCHERS.length, skipped: 0, skipEvents: [] };
+  return { updated: SESSION_START_MATCHERS.length, skipped: 0, skipEvents: ['SessionStart'] };
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -122,14 +122,46 @@ export function syncModelCoupledNewSessionThreshold({
   return { changed: true };
 }
 
+const DEFAULT_MAX_SETTINGS_BACKUPS = 5;
+
+/**
+ * Prune `<settings>.bak.<ts>` backups, keeping only the most recent `keep`.
+ * Backups accumulate one-per-changed-sync and were never cleaned up. Best
+ * effort: any fs error here must never break the settings write, so the
+ * caller wraps this in a try/catch and we tolerate a missing directory.
+ */
+export function pruneOldBackups({
+  settingsPath,
+  keep = DEFAULT_MAX_SETTINGS_BACKUPS,
+  readdirSync = fs.readdirSync,
+  unlinkSync = fs.unlinkSync,
+} = {}) {
+  const dir = path.dirname(settingsPath);
+  const base = path.basename(settingsPath);
+  const backupRe = new RegExp(`^${base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.bak\\.(\\d+)$`);
+  const backups = readdirSync(dir)
+    .map((name) => {
+      const m = name.match(backupRe);
+      return m ? { name, ts: Number(m[1]) } : null;
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.ts - a.ts); // newest first
+  for (const stale of backups.slice(keep)) {
+    unlinkSync(path.join(dir, stale.name));
+  }
+}
+
 export function persistInstalledSettingsAndSyncCoupledThreshold({
   installedSettings,
   settingsPath = INSTALLED_SETTINGS,
   modelBackfilled = false,
+  maxBackups = DEFAULT_MAX_SETTINGS_BACKUPS,
   mkdirSync = fs.mkdirSync,
   writeFileSync = fs.writeFileSync,
   existsSync = fs.existsSync,
   copyFileSync = fs.copyFileSync,
+  readdirSync = fs.readdirSync,
+  unlinkSync = fs.unlinkSync,
   syncThreshold = syncModelCoupledNewSessionThreshold,
 } = {}) {
   const dir = path.dirname(settingsPath);
@@ -146,6 +178,13 @@ export function persistInstalledSettingsAndSyncCoupledThreshold({
       try { copyFileSync(backupPath, settingsPath); } catch {}
     }
     throw err;
+  }
+  if (backupPath) {
+    try {
+      pruneOldBackups({ settingsPath, keep: maxBackups, readdirSync, unlinkSync });
+    } catch {
+      // best effort — never fail a successful settings write over cleanup
+    }
   }
   return syncThreshold({ modelBackfilled });
 }

--- a/docs/dev-plan-issue-651.md
+++ b/docs/dev-plan-issue-651.md
@@ -11,10 +11,12 @@
 ## Scope
 
 **In scope（本次 PR #668）：**
-- 新增 `CORE_MANAGED_HOOKS` 注册表 + `isCoreManaged()`，作为唯一所有权事实源
-- 引擎 A（声明式 sync）所有权判断切到 registry，删除 `coreSkillNames` 收集步
+- 新增**单一导出的规范化 path-key helper** `hookScriptKey(command)`（`hook-utils.js`），定义 registry 使用的 canonical 后缀/键；所有所有权/路径身份判断统一走它
+- 新增 `CORE_MANAGED_HOOKS` 注册表 + `isCoreManaged()`（基于 `hookScriptKey`），作为唯一所有权事实源
+- 引擎 A（`sync-settings-hooks.js` 声明式 sync）所有权判断切到 registry，删除 `coreSkillNames` 收集步；私有 `scriptPathEndsWith` 并入共享 helper
+- **`self-upgrade.js` 第二条所有权入口同步切到 registry**（plan-review P1）：`generateMigrationHints()` 的 removed-hook 所有权判断 + `applyMigrationHints()` 的路径匹配都复用同一 registry / `isCoreManaged()` / `hookScriptKey`。**决策：保留 shell-out + fallback 机制，但 fallback 路径也走 registry（不废弃，只对齐）**——否则 fallback 时仍是 template 反推、退役 hook 漏判
 - 删除引擎 B 全部专用迁移补丁（registry 下引擎 A 已能覆盖今天的两个迁移）
-- 单测 + 现有 real-smoke 端到端用例验证
+- 单测（含 `self-upgrade.test.js` hint 覆盖）+ 现有 real-smoke 端到端用例验证
 
 **Out of scope（明确不做）：**
 - **Codex runtime（#652）**：不在本次；不做 runtime 无关抽象，registry 就是 Claude `settings.json` 的 core hook 路径表（Howard 决策）
@@ -23,6 +25,7 @@
 
 ## Development Checklist
 
+- [ ] **新增并导出单一 canonical path-key helper**（plan-review P2，**先做，它是 registry 的地基**）：在 `hook-utils.js` 新增 `hookScriptKey(command)`（或 `normalizeHookScriptPath`），输出 = registry 使用的规范化后缀/键。把现 `sync-settings-hooks.js` 私有 `scriptPathEndsWith`（line 610-612）的归一化逻辑收进这个 helper。**所有所有权 / 路径身份判断的入口统一用它**：`CORE_MANAGED_HOOKS`、`isCoreManaged()`、sync forward/reverse、`generateMigrationHints()`、`applyMigrationHints()`——禁止任一入口再用裸 `extractScriptPath()` 做 equality（消除"两套 key 语义"）
 - [ ] **新增注册表** `CORE_MANAGED_HOOKS`（`cli/lib/sync-settings-hooks.js` 或拆到 `hook-utils.js`，由实现者定）：
   - 内容 = **当前 template 所有 event 下的全部 hook 脚本路径** ∪ **历史退役路径**（即现有 `SESSION_START_OLD_SCRIPTS` 的 4 条：`skills/zylos-memory/scripts/session-start-inject.js`、`skills/comm-bridge/scripts/c4-session-init.js`、`skills/activity-monitor/scripts/session-foreground.js`、`skills/activity-monitor/scripts/session-start-prompt.js`）
   - 当前 template SessionStart 已是单 orchestrator：`skills/activity-monitor/scripts/session-start-orchestrator.js`（startup/clear/compact 三组）
@@ -40,7 +43,11 @@
   - `SESSION_START_MATCHERS`（line 46）：若仅迁移代码用，删；若别处复用，保留
 - [ ] **确认引擎 A forward pass 无需改**（line 308-362 仍按 (event,matcher,path) 对齐 add/update），仅 reverse 的所有权判断变了
 - [ ] **确认空组 / 空 event 清理逻辑保留**（reverse 末尾），且仅在组内全部 hook 被删时触发
-- [ ] 自检：删除后无悬挂 import / 无对已删函数的引用（`grep` 验证）
+- [ ] **`self-upgrade.js` 第二条所有权入口对齐**（plan-review P1）：
+  - `generateMigrationHints()`（line 401~）：删除 `coreSkillNames` 收集（430-436）；removed-hook 所有权判断（533-534 的 `extractSkillName`+`coreSkillNames.has`）改为 `isCoreManaged()`；template/installed 路径身份匹配（448-454、536-539）改用 `hookScriptKey`
+  - `applyMigrationHints()`（line 895~）：路径匹配（955-962、1004-1012）改用 `hookScriptKey`
+  - `runSettingsHookSync()`（1088~）：**保留** shell-out 到新装 `sync-settings-hooks.js` + fallback 到 `generateMigrationHints/applyMigrationHints` 的结构；fallback 现在走 registry，所以 fallback 也不再失忆（**不废弃该 fallback**）
+- [ ] 自检：删除后无悬挂 import / 无对已删函数的引用（`grep` 验证）——**`grep` 范围含 `sync-settings-hooks.js` 与 `self-upgrade.js` 两处**，确认无残留 `coreSkillNames` / template 反推 ownership / 裸 `extractScriptPath` equality
 
 ## Test Checklist
 
@@ -58,20 +65,26 @@
   - [ ] 组内混合（用户 hook + core hook）→ 只删 core，组不被误删
 - [ ] **空组清理单测**：组内 core hook 全删 → 组移除；event 下组全空 → event 键移除；组内仍有用户 hook → 组保留
 - [ ] **幂等性单测**：installed == template 时再跑 sync → 无变更
+- [ ] **canonical key helper 回归**（plan-review P2）：`hookScriptKey` 命中**不依赖** full command / `~/` 形式（同一脚本不同书写 → 同一 key）；若覆盖 separator 语义则用显式 backslash fixture 验证
+- [ ] **`self-upgrade.test.js` hint 覆盖**（plan-review P1）：
+  - [ ] 退役 SessionStart hook（在 registry、不在当前 template）→ `generateMigrationHints` 生成 `removed_hook`
+  - [ ] 非 command / 用户自定义 hook（不在 registry）→ **不**生成 removed hint
+  - [ ] fallback 路径（`runSettingsHookSync` 走 `generateMigrationHints/applyMigrationHints`）的所有权判断与 `sync-settings-hooks.js` 一致（同一 registry，无失忆）
 - [ ] **保留并通过现有 real-smoke 端到端用例**（`test:` 系列，line 见近期 commit）
 - [ ] `make ci` / `npm test` 全绿（本地先过，含需要的依赖安装）
 
 ## Assumptions
 
 - [ ] **脚本路径是 hook 所有权的稳定标识**：core hook 的脚本相对路径（规范化后缀）在版本间稳定、可作 registry key。— 由我们自己掌控（脚本由 core 发布），成立。
-- [ ] **`extractScriptPath` / `scriptPathEndsWith` 的归一化口径一致**：registry 存的后缀与 installed hook 抽取的后缀用同一套归一化，才能正确命中。— 需实现时复用同一函数，**不可两套口径**。
+- [ ] ~~路径归一化口径一致~~ **已升级为实现约束（不再是假设）**：plan-review P2——归一化由单一导出 helper `hookScriptKey` 强制，所有入口（registry / `isCoreManaged` / sync / `self-upgrade.js`）共用，从机制上排除"两套 key 语义"。
 - [ ] **非 command hook 无可解析 command path**：故 `isCoreManaged` 对其返回 false、默认保留。— 符合"我们只认领自己装的 command 脚本"语义。
 - [ ] **退役路径不与用户脚本撞名**：用户不会把自定义脚本命名成我们退役的精确路径后缀。— 与现状同一边界（现也靠精确后缀匹配），可接受。
 - [ ] **当前 template SessionStart 已是 orchestrator 形态**（startup/clear/compact × 1 orch）——已确认。
 
 ## Acceptance Checklist
 
-- [ ] 所有权判断走 registry，`coreSkillNames` 收集步与引擎 B 专用迁移代码已删净（grep 无残留引用）
+- [ ] 所有权判断走 registry，`coreSkillNames` 收集步与引擎 B 专用迁移代码已删净——**`grep` 跨 `sync-settings-hooks.js` + `self-upgrade.js` 两处**确认无 template 反推 ownership / 无裸 `extractScriptPath` equality 残留
+- [ ] `self-upgrade.js` 两条所有权入口（hint 生成 + apply）走同一 registry + `hookScriptKey`；focused `self-upgrade.test.js` hint 覆盖通过
 - [ ] 三类历史实例升级均正确收敛到当前 template：catch-all 4-hook / 旧 4-hook 多 matcher / 含非标准 timeout 或非 4 count 的旧实例
 - [ ] Bug #1（timeout 冻结）、Bug #2（count≠4 冻结）、非 command 盲区——均有回归测试覆盖且通过
 - [ ] 用户自定义 hook（含非 command 类型）零丢失

--- a/docs/dev-plan-issue-651.md
+++ b/docs/dev-plan-issue-651.md
@@ -1,0 +1,89 @@
+# Dev Plan: SessionStart Hook 迁移逻辑 registry 重构 (#651 / PR #668)
+
+> 设计共识文档（权威，含完整 rationale + 决策记录）：
+> https://luna.jinglever.com/pages/s/d298490c9bd168607a653a759b641085
+> 本 dev plan 是该设计的**可执行契约**——只列"做什么 / 怎么测 / 怎么验收"，rationale 见上文。
+
+## Summary
+
+把 `cli/lib/sync-settings-hooks.js` 里 SessionStart hook 的"所有权判断"从 **template 反推 `coreSkillNames`** 换成 **源码内 append-only 的 `CORE_MANAGED_HOOKS` 注册表**（path-only）。一次根治当前迁移逻辑的"补丁叠补丁"，并消除 2 个 bug + 1 个盲区。直接落在 **PR #668**，使其成为一个完整自洽的 PR。
+
+## Scope
+
+**In scope（本次 PR #668）：**
+- 新增 `CORE_MANAGED_HOOKS` 注册表 + `isCoreManaged()`，作为唯一所有权事实源
+- 引擎 A（声明式 sync）所有权判断切到 registry，删除 `coreSkillNames` 收集步
+- 删除引擎 B 全部专用迁移补丁（registry 下引擎 A 已能覆盖今天的两个迁移）
+- 单测 + 现有 real-smoke 端到端用例验证
+
+**Out of scope（明确不做）：**
+- **Codex runtime（#652）**：不在本次；不做 runtime 无关抽象，registry 就是 Claude `settings.json` 的 core hook 路径表（Howard 决策）
+- 「结构性迁移」引擎 B 的**位置**保留为定义清晰的空扩展 seam，但本次**不放任何实际迁移逻辑**（留给将来字段级数据迁移 / 跨 event 非 1:1 重组）
+- 不改 SessionStart 之外的 hook 行为
+
+## Development Checklist
+
+- [ ] **新增注册表** `CORE_MANAGED_HOOKS`（`cli/lib/sync-settings-hooks.js` 或拆到 `hook-utils.js`，由实现者定）：
+  - 内容 = **当前 template 所有 event 下的全部 hook 脚本路径** ∪ **历史退役路径**（即现有 `SESSION_START_OLD_SCRIPTS` 的 4 条：`skills/zylos-memory/scripts/session-start-inject.js`、`skills/comm-bridge/scripts/c4-session-init.js`、`skills/activity-monitor/scripts/session-foreground.js`、`skills/activity-monitor/scripts/session-start-prompt.js`）
+  - 当前 template SessionStart 已是单 orchestrator：`skills/activity-monitor/scripts/session-start-orchestrator.js`（startup/clear/compact 三组）
+  - 存**规范化后缀路径**（沿用现有 `extractScriptPath` + `scriptPathEndsWith` 的归一化口径，`split(path.sep).join('/')`）
+  - **append-only 注释约定**：退役 hook 的路径**保留不删**，新增 core hook 时追加一行
+- [ ] **新增 `isCoreManaged(hook)`**：`CORE_MANAGED_HOOKS` 命中 `normalize(extractScriptPath(hook.command))` → bool。非 command 类型 hook（无 `command`）→ 取不到 path → 返回 false（默认保留）
+- [ ] **引擎 A reverse pass 切换所有权判断**（line ~387-388）：
+  - 从 `const skillName = extractSkillName(h.command); if (!skillName || !coreSkillNames.has(skillName)) continue;`
+  - 改为 `if (!isCoreManaged(h)) continue;`
+- [ ] **删除 `coreSkillNames` 收集步**（line ~273-279）及其对 `extractSkillName` 的依赖（若别处不再用，连 import 一起清）
+- [ ] **删除引擎 B 专用迁移补丁**：
+  - 常量 `SESSION_START_OLD_SCRIPTS`（line 34）、`SESSION_START_OLD_TIMEOUT_BY_SCRIPT`（line 40）→ 被 registry 取代后删除（注意：registry 需吸收这 4 条退役路径）
+  - 函数 `migrateMatcherSplit`（line 552）、`migrateSessionStartOrchestrator`（line 659）、`isOrchestratorTemplate`（615）、`isStandardOldSessionStartGroup`（629）、`containsOldSessionStartScript`（643）
+  - `skipEvents` 全部 plumbing（line 292-301、309、369 等）——SessionStart 不再被摘出引擎 A
+  - `SESSION_START_MATCHERS`（line 46）：若仅迁移代码用，删；若别处复用，保留
+- [ ] **确认引擎 A forward pass 无需改**（line 308-362 仍按 (event,matcher,path) 对齐 add/update），仅 reverse 的所有权判断变了
+- [ ] **确认空组 / 空 event 清理逻辑保留**（reverse 末尾），且仅在组内全部 hook 被删时触发
+- [ ] 自检：删除后无悬挂 import / 无对已删函数的引用（`grep` 验证）
+
+## Test Checklist
+
+- [ ] **registry 完整性单测**：断言 `当前 template 内每个 event/matcher 下每个 command hook 的路径 ∈ CORE_MANAGED_HOOKS`（防将来加 hook 漏维护 registry）
+- [ ] **迁移场景单测**（升级旧实例 → 收敛到当前 template）：
+  - [ ] catch-all 空 matcher `""`（旧 4-hook 形态）→ startup/clear/compact 各一个 orchestrator
+  - [ ] 旧 4-hook → 1 orchestrator（4→1 collapse）
+  - [ ] **Bug #1 回归**：用户改过旧 hook 的 timeout（如非标准值）→ 仍正确迁移（不再因 timeout 不匹配而冻结）
+  - [ ] **Bug #2 回归**：旧实例只有 3 个 hook（非恰好 4 个）→ 仍正确迁移（不再因 count≠4 冻结）
+  - [ ] orchestrator timeout 漂移 → forward update 回 template 值
+  - [ ] orchestrator 换脚本（v1→v2 路径，模拟未来）→ 删旧加新
+- [ ] **保留性单测**：
+  - [ ] 用户自定义 hook（不在 registry）→ 保留，不被删
+  - [ ] **非 command 盲区回归**：`type:'url'` 等非 command hook → `isCoreManaged` 取不到 path → 默认保留，不被静默丢失
+  - [ ] 组内混合（用户 hook + core hook）→ 只删 core，组不被误删
+- [ ] **空组清理单测**：组内 core hook 全删 → 组移除；event 下组全空 → event 键移除；组内仍有用户 hook → 组保留
+- [ ] **幂等性单测**：installed == template 时再跑 sync → 无变更
+- [ ] **保留并通过现有 real-smoke 端到端用例**（`test:` 系列，line 见近期 commit）
+- [ ] `make ci` / `npm test` 全绿（本地先过，含需要的依赖安装）
+
+## Assumptions
+
+- [ ] **脚本路径是 hook 所有权的稳定标识**：core hook 的脚本相对路径（规范化后缀）在版本间稳定、可作 registry key。— 由我们自己掌控（脚本由 core 发布），成立。
+- [ ] **`extractScriptPath` / `scriptPathEndsWith` 的归一化口径一致**：registry 存的后缀与 installed hook 抽取的后缀用同一套归一化，才能正确命中。— 需实现时复用同一函数，**不可两套口径**。
+- [ ] **非 command hook 无可解析 command path**：故 `isCoreManaged` 对其返回 false、默认保留。— 符合"我们只认领自己装的 command 脚本"语义。
+- [ ] **退役路径不与用户脚本撞名**：用户不会把自定义脚本命名成我们退役的精确路径后缀。— 与现状同一边界（现也靠精确后缀匹配），可接受。
+- [ ] **当前 template SessionStart 已是 orchestrator 形态**（startup/clear/compact × 1 orch）——已确认。
+
+## Acceptance Checklist
+
+- [ ] 所有权判断走 registry，`coreSkillNames` 收集步与引擎 B 专用迁移代码已删净（grep 无残留引用）
+- [ ] 三类历史实例升级均正确收敛到当前 template：catch-all 4-hook / 旧 4-hook 多 matcher / 含非标准 timeout 或非 4 count 的旧实例
+- [ ] Bug #1（timeout 冻结）、Bug #2（count≠4 冻结）、非 command 盲区——均有回归测试覆盖且通过
+- [ ] 用户自定义 hook（含非 command 类型）零丢失
+- [ ] 幂等：重复 sync 无副作用
+- [ ] `make ci` 本地全绿；GitLab/GitHub CI 全绿
+- [ ] Lint clean
+- [ ] PR #668 描述更新为"完整 registry 重构版"，收口 #651
+- [ ] 非 UI 改动，无需浏览器验证
+
+## Roles（per dev-workflow）
+
+- **PM / QA / dev plan / acceptance**：Luna（zylos01）
+- **Developer**：Jinglever
+- **Code Reviewer**：zylos0t（+ Luna 独立 review）
+- **Decision maker**：Howard

--- a/docs/dev-plan-issue-651.md
+++ b/docs/dev-plan-issue-651.md
@@ -29,9 +29,9 @@
 - [ ] **新增注册表** `CORE_MANAGED_HOOKS`（`cli/lib/sync-settings-hooks.js` 或拆到 `hook-utils.js`，由实现者定）：
   - 内容 = **当前 template 所有 event 下的全部 hook 脚本路径** ∪ **历史退役路径**（即现有 `SESSION_START_OLD_SCRIPTS` 的 4 条：`skills/zylos-memory/scripts/session-start-inject.js`、`skills/comm-bridge/scripts/c4-session-init.js`、`skills/activity-monitor/scripts/session-foreground.js`、`skills/activity-monitor/scripts/session-start-prompt.js`）
   - 当前 template SessionStart 已是单 orchestrator：`skills/activity-monitor/scripts/session-start-orchestrator.js`（startup/clear/compact 三组）
-  - 存**规范化后缀路径**（沿用现有 `extractScriptPath` + `scriptPathEndsWith` 的归一化口径，`split(path.sep).join('/')`）
+  - 键 = `hookScriptKey()` 输出的 canonical 后缀键（registry 内容用同一 helper 生成，禁止手写另一种口径）
   - **append-only 注释约定**：退役 hook 的路径**保留不删**，新增 core hook 时追加一行
-- [ ] **新增 `isCoreManaged(hook)`**：`CORE_MANAGED_HOOKS` 命中 `normalize(extractScriptPath(hook.command))` → bool。非 command 类型 hook（无 `command`）→ 取不到 path → 返回 false（默认保留）
+- [ ] **新增 `isCoreManaged(hook)`**：`CORE_MANAGED_HOOKS.has(hookScriptKey(hook.command))` → bool。非 command 类型 hook（无 `command`）→ `hookScriptKey` 取不到 path → 返回 false（默认保留）
 - [ ] **引擎 A reverse pass 切换所有权判断**（line ~387-388）：
   - 从 `const skillName = extractSkillName(h.command); if (!skillName || !coreSkillNames.has(skillName)) continue;`
   - 改为 `if (!isCoreManaged(h)) continue;`

--- a/docs/impl-session-start-orchestrator.md
+++ b/docs/impl-session-start-orchestrator.md
@@ -1,0 +1,250 @@
+# Issue #651: SessionStart Orchestrator — Design Document
+
+## Problem
+
+SessionStart runs **4 independent hook commands**, copy-pasted across 3 matchers (`startup` / `clear` / `compact`) in `.claude/settings.json`:
+
+| # | Script | Skill | Responsibility | Timeout |
+|---|--------|-------|----------------|---------|
+| 1 | `session-start-inject.js` | zylos-memory | Read identity/state/references → stdout | 10s |
+| 2 | `c4-session-init.js` | comm-bridge | Read C4 checkpoint + recent conversations → stdout | 10s |
+| 3 | `session-foreground.js` | activity-monitor | Write foreground-session.json (session_id, pid) | 5s |
+| 4 | `session-start-prompt.js` | activity-monitor | Enqueue control-queue prompt via c4-control.js | 5s |
+
+This is fragile:
+
+- **No error isolation**: a hang in one hook (known issue #601 with `session-start-prompt.js`) blocks or corrupts the entire startup path.
+- **3× duplication**: the same 4-hook list is repeated across every matcher; changes must be made in 3 places and they drift.
+- **No ordering guarantee**: memory injection should logically run before C4 init (which may reference memory state), but nothing enforces this.
+- **No total time budget**: if multiple hooks are slow, the aggregate startup time is unbounded.
+
+## Goal
+
+Replace the 4 per-matcher hook commands with a **single orchestrator script** that:
+
+1. Is invoked once per matcher (1 command instead of 4).
+2. Runs the startup steps in a defined order with per-step error isolation.
+3. Enforces bounded runtime for async stalls and leaked handles, with explicit limits on what the in-process fallback can guarantee.
+4. Preserves the required net behavior for each source:
+   - `startup` / `clear`: memory injection, C4 init, foreground session write, and startup prompt enqueue.
+   - `compact`: memory injection, C4 init, and foreground session write, but no startup prompt enqueue.
+
+## Design
+
+### 1. Orchestrator Script
+
+**Location**: `skills/activity-monitor/scripts/session-start-orchestrator.js`
+
+Placed in activity-monitor because:
+- activity-monitor already owns 2 of the 4 hooks and is the system-level coordination skill.
+- It avoids creating a new top-level skill just for orchestration.
+- The orchestrator is a startup infrastructure concern, not a memory or communication concern.
+
+**Interface**:
+
+```
+stdin  → JSON payload from Claude Code (session_id, source, etc.)
+stdout → concatenated output from steps 1 + 2 (memory inject + C4 init)
+stderr → diagnostic/error logs (not injected into context)
+```
+
+### 2. Per-Source Behavior Matrix
+
+The orchestrator must preserve the current SessionStart behavior by source, except for the intentional `compact` prompt change:
+
+| Source | Registered in settings? | Memory inject | C4 init | Foreground session | Startup prompt |
+|--------|--------------------------|---------------|---------|--------------------|----------------|
+| `startup` | Yes | Yes | Yes | Yes | Yes |
+| `clear` | Yes | Yes | Yes | Yes | Yes |
+| `compact` | Yes | Yes | Yes | Yes | No |
+| `resume` | No | No | No | No | No |
+
+`resume` stays unregistered. Adding `resume` would be a behavior change and should be handled as a separate decision.
+
+### 3. Step Execution Model
+
+```
+┌─────────────────────────────────────────────────┐
+│              session-start-orchestrator.js        │
+│                                                   │
+│  Total budget: 15s (async/handle-leak backstop)   │
+│                                                   │
+│  Phase 1 — Context output (sequential, stdout)    │
+│  ┌───────────────────────────────────────────┐    │
+│  │ Step 1: memory-inject  (budget: 6s)       │    │
+│  │   Read identity/state/references → stdout │    │
+│  │   On error: stderr only; stdout empty     │    │
+│  └───────────────────────────────────────────┘    │
+│  ┌───────────────────────────────────────────┐    │
+│  │ Step 2: c4-session-init  (budget: 6s)     │    │
+│  │   DB query → stdout                       │    │
+│  │   On error: stderr only; stdout empty     │    │
+│  └───────────────────────────────────────────┘    │
+│                                                   │
+│  Phase 2 — Side effects (parallel, no stdout)     │
+│  ┌──────────────────┐  ┌───────────────────────┐  │
+│  │ Step 3:          │  │ Step 4:               │  │
+│  │ foreground.json  │  │ control-queue prompt  │  │
+│  │ (budget: 3s)     │  │ (budget: 3s)          │  │
+│  │                  │  │ exec timeout: 2.5s    │  │
+│  └──────────────────┘  └───────────────────────┘  │
+│                         skipped on source=compact │
+│                                                   │
+│  Flush stdout before Phase 2 and before exit       │
+└─────────────────────────────────────────────────┘
+```
+
+**Why this ordering**:
+- Steps 1 & 2 produce stdout that Claude Code injects as context. They must run **sequentially** because Claude reads them top-to-bottom and memory context should appear before C4 conversations.
+- Phase 1 writes each successful step's bytes with `fs.writeSync(1, output)` as soon as the step completes. Errors go to stderr only; the orchestrator must not write placeholder text to stdout, because stdout is the injected context payload.
+- Steps 3 & 4 produce **no stdout** (only side effects: file write + control-queue enqueue). They can run in **parallel** after context output is done.
+- Step 4 is skipped when `source === 'compact'`. A compact happens mid-session; the new context still needs memory and C4 startup context, but it should not enqueue a fresh "startup / resume work" control prompt that can duplicate work or revive stale tasks.
+- Total budget (15s) covers the planned worst case: Phase 1 is 6s + 6s, then Phase 2 is up to 3s in parallel. The settings hook timeout must be higher than the internal budget (recommended: 20s) so Claude's hook harness does not kill the process before the orchestrator's own cleanup and diagnostics run.
+
+**Per-step isolation**:
+- Each step runs in a `try/catch` with its own budget.
+- Dynamic import happens inside that `try/catch`; a missing or broken skill module skips only that step instead of crashing the whole orchestrator.
+- `AbortSignal.timeout()` is only a hard timeout for async, signal-aware work. It cannot interrupt synchronous JavaScript, synchronous filesystem calls, synchronous SQLite queries, or a synchronous infinite loop.
+- The total budget `setTimeout` is a last-resort backstop for async stalls and handle-leak hangs, including the known #601 class where the event loop is still alive. It does **not** protect against synchronous event-loop blocking.
+- `session-start-prompt.js` must not introduce a non-killable synchronous wait. If it shells out to `c4-control.js`, use `execFileSync` with a hard `timeout` and `killSignal`, or use async `execFile` / `spawn` with an explicit timer that kills the child process.
+- Happy path must clear or `unref()` timers, remove stdin listeners, and reap any child process so the orchestrator exits naturally in under roughly 2-3 seconds instead of waiting for the 15s fallback.
+
+### 4. Implementation Approach: Dynamic In-Process Import
+
+Instead of spawning 4 hook child processes, the orchestrator **dynamically imports step functions inside the step runner**:
+
+```javascript
+async function runMemoryInject(payload) {
+  const { injectMemory } = await import('../../zylos-memory/scripts/session-start-inject.js');
+  return injectMemory(payload);
+}
+```
+
+This preserves step isolation across module load failures. Static top-level imports are not acceptable here: if `zylos-memory` or `comm-bridge` is missing or throws during module initialization, a static import would crash the orchestrator before per-step `try/catch` can run.
+
+This also requires refactoring the existing scripts to **export callable functions** alongside their CLI entry points, and to ensure import-time side effects are zero.
+
+**What needs to be exported**:
+
+| Script | Current | Change |
+|--------|---------|--------|
+| `session-start-inject.js` | `main()` is internal, writes to stdout | Export `injectMemory()` that returns string |
+| `c4-session-init.js` | Top-level unconditional `main()` | Add CLI guard; export `initC4Session()` that returns string; move stdin/timer/main side effects into functions |
+| `session-foreground.js` | Already exports `handleSessionForeground()` | No change |
+| `session-start-prompt.js` | Top-level unconditional `main()`, calls `execFileSync` | Add CLI guard; export `enqueueStartupPrompt(source)`; move stdin/timer/main side effects into functions; add hard child-process timeout |
+
+Each script retains its standalone CLI entry point using `if (process.argv[1] === fileURLToPath(import.meta.url))` for backward compatibility and testing. Importing any step module must be side-effect-free: no stdout writes, no control-queue enqueue, no timer registration, and no `main()` call at module load.
+
+### 5. Settings.json Change
+
+**Before** (4 hooks × 3 matchers = 12 entries):
+
+This is the current standard template signature that upgrade migration should match exactly.
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {"type": "command", "command": "node .../session-start-inject.js", "timeout": 10000},
+          {"type": "command", "command": "node .../c4-session-init.js", "timeout": 10000},
+          {"type": "command", "command": "node .../session-foreground.js", "timeout": 5000},
+          {"type": "command", "command": "node .../session-start-prompt.js", "timeout": 5000}
+        ]
+      },
+      {"matcher": "clear", "hooks": [/* same 4 */]},
+      {"matcher": "compact", "hooks": [/* same 4 */]}
+    ]
+  }
+}
+```
+
+**After** (1 hook × 3 matchers = 3 entries):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {"type": "command", "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js", "timeout": 20000}
+        ]
+      },
+      {"matcher": "clear", "hooks": [/* same 1 */]},
+      {"matcher": "compact", "hooks": [/* same 1 */]}
+    ]
+  }
+}
+```
+
+Matchers remain separate because Claude Code dispatches different payloads per source. The orchestrator receives the source via stdin and uses it to skip prompt enqueue on compact while preserving memory injection, C4 init, and foreground-session side effects. The hook harness timeout must remain above the orchestrator's internal total budget.
+
+### 6. Diagnostics
+
+The orchestrator logs per-step timing to `c4-diagnostic.js` (same as today's individual hooks), plus an overall timing entry. On error, it logs:
+
+```
+[session-start-orchestrator] step "memory-inject" failed (1234ms): Error message
+```
+
+Each step log should include step name, source, status (`ok` / `failed` / `timeout` / `skipped`), duration, and whether stdout bytes were emitted. Compact prompt skip and dynamic import failures must be visible in diagnostics. This gives visibility into which step failed without breaking the startup path.
+
+### 7. Testing
+
+New test file: `skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js`
+
+Test cases:
+1. **Happy path (`startup` / `clear`)**: all 4 steps run, stdout contains memory + C4 output.
+2. **Step 1 failure**: memory inject throws → step 2/3/4 still run, stdout contains C4 output only.
+3. **Step 2 failure**: C4 init throws → stdout contains memory output only, steps 3/4 still run.
+4. **Step 3 failure**: foreground write throws → no effect on stdout or step 4.
+5. **Step 4 failure**: prompt enqueue throws → no effect on stdout or other steps.
+6. **Step timeout**: async, signal-aware step timeout is logged and remaining steps proceed.
+7. **Prompt child timeout**: a hung `c4-control.js` child is killed by the prompt step timeout.
+8. **Total timeout**: leaked handles / async stall are stopped by the 15s backstop, without corrupting stdout already flushed from completed Phase 1 steps.
+9. **Import guard**: importing `c4-session-init.js` and `session-start-prompt.js` has zero side effects.
+10. **Dynamic import failure**: missing/broken memory or C4 module skips only that step.
+11. **Compact source**: memory inject, C4 init, and foreground write run; prompt enqueue is not called.
+12. **Per-source parity**: `startup`, `clear`, `compact`, and unregistered `resume` match the behavior matrix above.
+13. **Stdout byte order**: stdout is exactly memory output followed by C4 output, with no stderr diagnostics or placeholders mixed in.
+14. **Happy-path exit time**: process exits naturally in under roughly 2-3s and does not wait for the 15s fallback.
+15. **Migration**: standard 4-hook groups migrate idempotently; custom groups are skipped with warning; backup is written before modification; failure rolls back.
+
+### 8. Migration
+
+1. Refactor the 4 scripts to export callable functions (backward-compatible, CLI still works).
+2. Create `session-start-orchestrator.js` that imports and runs them.
+3. Add tests.
+4. Update `templates/.claude/settings.json` to use the single orchestrator command.
+5. Update `zylos upgrade` to migrate existing standard 4-hook settings configs into the orchestrator format.
+   - Reuse or improve the existing settings migration/sync path where possible.
+   - Match the standard 4-hook signature precisely by matcher, command script path, command type, and expected hook shape.
+   - Make the migration idempotent and conservative: automatically migrate recognized standard hook groups, but preserve and warn on custom/non-standard hook configurations instead of blindly overwriting them.
+   - Write a backup before modifying `settings.json`.
+   - Ensure migration failure rolls back through the normal upgrade failure path so a failed upgrade does not leave a partially migrated `settings.json`.
+
+### 9. Issue #652 (Codex parity)
+
+Issue #652 asks for Codex runtime to use the same SessionStart mechanism. This is a follow-up — once #651 lands with the orchestrator, #652 becomes "wire up the same orchestrator in Codex's session init path." The orchestrator's function exports make this straightforward.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `skills/zylos-memory/scripts/session-start-inject.js` | Export `injectMemory()` returning string |
+| `skills/comm-bridge/scripts/c4-session-init.js` | Add CLI guard; export `initC4Session()` returning string |
+| `skills/activity-monitor/scripts/session-start-prompt.js` | Add CLI guard; export `enqueueStartupPrompt(source)` with hard child-process timeout |
+| `skills/activity-monitor/scripts/session-start-orchestrator.js` | **New** — orchestrator |
+| `skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js` | **New** — tests |
+| `templates/.claude/settings.json` | Consolidate to 1 hook per matcher; set orchestrator hook timeout above internal budget |
+
+## Resolved Decisions
+
+1. **Compact behavior**: `compact` must still run memory injection and C4 session init because the new compacted context needs identity/state/references plus C4 checkpoint/recent conversation context. It must skip the control-queue startup prompt because compact is an in-session context refresh, not a fresh startup/resume event.
+
+2. **Settings migration**: `zylos upgrade` must migrate existing standard `settings.json` hooks from the 4-hook format to the 1-hook orchestrator format. Template-only updates are insufficient because existing installs would keep the old duplicated hooks. The migration should be conservative, idempotent, and rollback-safe under the normal upgrade failure handling.
+
+3. **Hang guarantee boundary**: the design does not claim to make startup impossible to hang. It bounds async stalls, leaked handles, and killable child-process hangs. It cannot stop synchronous event-loop blocking inside the orchestrator process; implementation should minimize synchronous work in step bodies and keep the prompt enqueue child process killable.

--- a/docs/impl-session-start-orchestrator.md
+++ b/docs/impl-session-start-orchestrator.md
@@ -106,7 +106,7 @@ The orchestrator must preserve the current SessionStart behavior by source, exce
 - Dynamic import happens inside that `try/catch`; a missing or broken skill module skips only that step instead of crashing the whole orchestrator.
 - `AbortSignal.timeout()` is only a hard timeout for async, signal-aware work. It cannot interrupt synchronous JavaScript, synchronous filesystem calls, synchronous SQLite queries, or a synchronous infinite loop.
 - The total budget `setTimeout` is a last-resort backstop for async stalls and handle-leak hangs, including the known #601 class where the event loop is still alive. It does **not** protect against synchronous event-loop blocking.
-- `session-start-prompt.js` must not introduce a non-killable synchronous wait. If it shells out to `c4-control.js`, use `execFileSync` with a hard `timeout` and `killSignal`, or use async `execFile` / `spawn` with an explicit timer that kills the child process.
+- `session-start-prompt.js` must not introduce a non-killable synchronous wait. It shells out to `c4-control.js` via **async `execFile`** (promisified) with a hard `timeout` + `killSignal`, so the step yields the event loop (genuinely parallel with the foreground write) and the orchestrator's per-step budget can preempt it; the child's own `timeout`/`killSignal` is the hard backstop for an `execFile` that never returns.
 - Happy path must clear or `unref()` timers, remove stdin listeners, and reap any child process so the orchestrator exits naturally in under roughly 2-3 seconds instead of waiting for the 15s fallback.
 
 ### 4. Implementation Approach: Dynamic In-Process Import
@@ -131,7 +131,7 @@ This also requires refactoring the existing scripts to **export callable functio
 | `session-start-inject.js` | `main()` is internal, writes to stdout | Export `injectMemory()` that returns string |
 | `c4-session-init.js` | Top-level unconditional `main()` | Add CLI guard; export `initC4Session()` that returns string; move stdin/timer/main side effects into functions |
 | `session-foreground.js` | Already exports `handleSessionForeground()` | No change |
-| `session-start-prompt.js` | Top-level unconditional `main()`, calls `execFileSync` | Add CLI guard; export `enqueueStartupPrompt(source)`; move stdin/timer/main side effects into functions; add hard child-process timeout |
+| `session-start-prompt.js` | Top-level unconditional `main()`, calls `execFileSync` | Add CLI guard; export **async** `enqueueStartupPrompt(source)` using async `execFile` (not `execFileSync`); move stdin/timer/main side effects into functions; hard child-process `timeout` + `killSignal` |
 
 Each script retains its standalone CLI entry point using `if (process.argv[1] === fileURLToPath(import.meta.url))` for backward compatibility and testing. Importing any step module must be side-effect-free: no stdout writes, no control-queue enqueue, no timer registration, and no `main()` call at module load.
 
@@ -247,6 +247,8 @@ Issue #652 asks for Codex runtime to use the same SessionStart mechanism. This i
 
 2. **Settings migration**: `zylos upgrade` must migrate existing standard `settings.json` hooks from the 4-hook format to the 1-hook orchestrator format. Template-only updates are insufficient because existing installs would keep the old duplicated hooks. The migration should be conservative, idempotent, and rollback-safe under the normal upgrade failure handling.
 
-3. **Hang guarantee boundary**: the design does not claim to make startup impossible to hang. It bounds async stalls, leaked handles, and killable child-process hangs. It cannot stop synchronous event-loop blocking inside the orchestrator process; implementation should minimize synchronous work in step bodies and keep the prompt enqueue child process killable.
+3. **Hang guarantee boundary**: the design does not claim to make startup impossible to hang. It bounds async stalls, leaked handles, and killable child-process hangs. It cannot stop synchronous event-loop blocking inside the orchestrator process; implementation should minimize synchronous work in step bodies. The prompt enqueue — previously the one synchronous (`execFileSync`) step that the per-step budget could not preempt — now uses **async `execFile`**, so it both runs genuinely in parallel with the foreground write and is preemptible by the per-step budget, with the child's own `timeout`+`killSignal` as the hard backstop.
 
 4. **Budget margin**: implementation should not make the planned path equal the total fallback. Use a 17s backstop with 5.5s + 5.5s + 3s step budgets, leaving margin for natural exit and cleanup while still fitting under the 20s Claude hook harness timeout.
+
+5. **Settings backup retention**: each settings-changing sync writes a timestamped `settings.json.bak.<ts>`. These are pruned after a successful write, keeping only the most recent `maxBackups` (default 5); pruning is best-effort and never fails the write.

--- a/docs/impl-session-start-orchestrator.md
+++ b/docs/impl-session-start-orchestrator.md
@@ -67,16 +67,16 @@ The orchestrator must preserve the current SessionStart behavior by source, exce
 ┌─────────────────────────────────────────────────┐
 │              session-start-orchestrator.js        │
 │                                                   │
-│  Total budget: 15s (async/handle-leak backstop)   │
+│  Total budget: 17s (async/handle-leak backstop)   │
 │                                                   │
 │  Phase 1 — Context output (sequential, stdout)    │
 │  ┌───────────────────────────────────────────┐    │
-│  │ Step 1: memory-inject  (budget: 6s)       │    │
+│  │ Step 1: memory-inject  (budget: 5.5s)     │    │
 │  │   Read identity/state/references → stdout │    │
 │  │   On error: stderr only; stdout empty     │    │
 │  └───────────────────────────────────────────┘    │
 │  ┌───────────────────────────────────────────┐    │
-│  │ Step 2: c4-session-init  (budget: 6s)     │    │
+│  │ Step 2: c4-session-init  (budget: 5.5s)   │    │
 │  │   DB query → stdout                       │    │
 │  │   On error: stderr only; stdout empty     │    │
 │  └───────────────────────────────────────────┘    │
@@ -99,7 +99,7 @@ The orchestrator must preserve the current SessionStart behavior by source, exce
 - Phase 1 writes each successful step's bytes with `fs.writeSync(1, output)` as soon as the step completes. Errors go to stderr only; the orchestrator must not write placeholder text to stdout, because stdout is the injected context payload.
 - Steps 3 & 4 produce **no stdout** (only side effects: file write + control-queue enqueue). They can run in **parallel** after context output is done.
 - Step 4 is skipped when `source === 'compact'`. A compact happens mid-session; the new context still needs memory and C4 startup context, but it should not enqueue a fresh "startup / resume work" control prompt that can duplicate work or revive stale tasks.
-- Total budget (15s) covers the planned worst case: Phase 1 is 6s + 6s, then Phase 2 is up to 3s in parallel. The settings hook timeout must be higher than the internal budget (recommended: 20s) so Claude's hook harness does not kill the process before the orchestrator's own cleanup and diagnostics run.
+- Total budget (17s) leaves cleanup margin above the planned worst case: Phase 1 is 5.5s + 5.5s, then Phase 2 is up to 3s in parallel. The settings hook timeout must be higher than the internal budget (recommended: 20s) so Claude's hook harness does not kill the process before the orchestrator's own cleanup and diagnostics run.
 
 **Per-step isolation**:
 - Each step runs in a `try/catch` with its own budget.
@@ -204,7 +204,7 @@ Test cases:
 5. **Step 4 failure**: prompt enqueue throws → no effect on stdout or other steps.
 6. **Step timeout**: async, signal-aware step timeout is logged and remaining steps proceed.
 7. **Prompt child timeout**: a hung `c4-control.js` child is killed by the prompt step timeout.
-8. **Total timeout**: leaked handles / async stall are stopped by the 15s backstop, without corrupting stdout already flushed from completed Phase 1 steps.
+8. **Total timeout**: leaked handles / async stall are stopped by the 17s backstop, without corrupting stdout already flushed from completed Phase 1 steps.
 9. **Import guard**: importing `c4-session-init.js` and `session-start-prompt.js` has zero side effects.
 10. **Dynamic import failure**: missing/broken memory or C4 module skips only that step.
 11. **Compact source**: memory inject, C4 init, and foreground write run; prompt enqueue is not called.
@@ -248,3 +248,5 @@ Issue #652 asks for Codex runtime to use the same SessionStart mechanism. This i
 2. **Settings migration**: `zylos upgrade` must migrate existing standard `settings.json` hooks from the 4-hook format to the 1-hook orchestrator format. Template-only updates are insufficient because existing installs would keep the old duplicated hooks. The migration should be conservative, idempotent, and rollback-safe under the normal upgrade failure handling.
 
 3. **Hang guarantee boundary**: the design does not claim to make startup impossible to hang. It bounds async stalls, leaked handles, and killable child-process hangs. It cannot stop synchronous event-loop blocking inside the orchestrator process; implementation should minimize synchronous work in step bodies and keep the prompt enqueue child process killable.
+
+4. **Budget margin**: implementation should not make the planned path equal the total fallback. Use a 17s backstop with 5.5s + 5.5s + 3s step budgets, leaving margin for natural exit and cleanup while still fitting under the 20s Claude hook harness timeout.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js || true",
+    "pretest": "node scripts/install-skill-deps.js",
     "test": "npm run test:jest && npm run test:node",
     "test:jest": "node --experimental-vm-modules node_modules/.bin/jest",
     "test:node": "node scripts/run-node-tests.js"

--- a/scripts/install-skill-deps.js
+++ b/scripts/install-skill-deps.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Install dependencies for skills that have their own package.json.
+ * Runs as a pretest hook so `npm test` works out of the box.
+ */
+
+import { readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const root = join(fileURLToPath(import.meta.url), '..', '..');
+const skillsDir = join(root, 'skills');
+
+for (const name of readdirSync(skillsDir, { withFileTypes: true })) {
+  if (!name.isDirectory()) continue;
+  const dir = join(skillsDir, name.name);
+  const pkg = join(dir, 'package.json');
+  const modules = join(dir, 'node_modules');
+  if (!existsSync(pkg) || existsSync(modules)) continue;
+  console.log(`[pretest] Installing deps for skills/${name.name}`);
+  execFileSync('npm', ['install', '--omit=dev'], { cwd: dir, stdio: 'inherit' });
+}

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -270,6 +270,23 @@ describe('session-start-orchestrator', () => {
     assert.equal(calls[0][2].killSignal, 'SIGKILL');
   });
 
+  it('awaits the prompt child asynchronously (genuinely parallelizable)', async () => {
+    let resolveChild;
+    let settled = false;
+    const pending = enqueueStartupPrompt('startup', {
+      controlPath: '/tmp/c4-control.js',
+      execFile: () => new Promise((resolve) => { resolveChild = resolve; }),
+    }).then(() => { settled = true; });
+
+    // The async child has not resolved yet → enqueue must still be pending,
+    // proving it does not block synchronously like the old execFileSync.
+    await Promise.resolve();
+    assert.equal(settled, false);
+    resolveChild();
+    await pending;
+    assert.equal(settled, true);
+  });
+
   it('imports c4-session-init without CLI side effects', () => {
     const result = spawnSync(process.execPath, ['-e', `import(${JSON.stringify(C4_SESSION_INIT)})`], {
       env: { ...process.env, ZYLOS_DIR: fs.mkdtempSync(path.join(os.tmpdir(), 'c4-import-')) },

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -8,8 +8,10 @@ import { fileURLToPath } from 'node:url';
 
 import {
   installProcessBackstop,
+  readStdinPayload,
   runSessionStartOrchestrator,
   runStep,
+  writeAllSync,
 } from '../session-start-orchestrator.js';
 import { enqueueStartupPrompt } from '../session-start-prompt.js';
 
@@ -58,7 +60,7 @@ function actions(overrides = {}) {
   };
 }
 
-async function runWithActions(source, overrides = {}) {
+async function runWithActions(source, overrides = {}, options = {}) {
   const out = tempStdout();
   const harness = actions(overrides);
   try {
@@ -72,6 +74,7 @@ async function runWithActions(source, overrides = {}) {
         startupPrompt: 50,
       },
       actions: harness.actions,
+      ...options,
     });
     return { calls: harness.calls, stdout: out.read() };
   } finally {
@@ -150,6 +153,18 @@ describe('session-start-orchestrator', () => {
     assert.deepEqual(result.calls.map(([name]) => name), ['c4', 'foreground', 'prompt']);
   });
 
+  it('continues when a dynamic-import-style step fails before producing context', async () => {
+    const result = await runWithActions('startup', {
+      memoryInject: async () => {
+        const err = new Error('Cannot find module');
+        err.code = 'ERR_MODULE_NOT_FOUND';
+        throw err;
+      },
+    });
+    assert.equal(result.stdout, 'C4\n');
+    assert.deepEqual(result.calls.map(([name]) => name), ['c4', 'foreground', 'prompt']);
+  });
+
   it('runStep records successful stdout writes', async () => {
     const out = tempStdout();
     try {
@@ -168,6 +183,50 @@ describe('session-start-orchestrator', () => {
     }
   });
 
+  it('writeAllSync retries short writes and EAGAIN until the full buffer is written', () => {
+    const chunks = [];
+    let calls = 0;
+    const written = writeAllSync(1, 'abcdef', {
+      writeSync: (fd, buffer, offset, length) => {
+        assert.equal(fd, 1);
+        calls++;
+        if (calls === 2) {
+          const err = new Error('temporarily unavailable');
+          err.code = 'EAGAIN';
+          throw err;
+        }
+        const size = Math.min(2, length);
+        chunks.push(buffer.toString('utf8', offset, offset + size));
+        return size;
+      },
+    });
+
+    assert.equal(written, 6);
+    assert.equal(chunks.join(''), 'abcdef');
+    assert.equal(calls, 4);
+  });
+
+  it('writes payloads larger than pipe buffers without truncation', () => {
+    const payload = 'x'.repeat(150 * 1024);
+    const script = `
+      import { runStep } from ${JSON.stringify(path.resolve(SCRIPT_DIR, '../session-start-orchestrator.js'))};
+      await runStep({
+        name: 'large',
+        source: 'startup',
+        budgetMs: 1000,
+        action: async () => ${JSON.stringify(payload)},
+        writeStdout: true,
+      });
+    `;
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+      encoding: 'utf8',
+      maxBuffer: payload.length + 64 * 1024,
+    });
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.length, payload.length);
+    assert.equal(result.stdout, payload);
+  });
+
   it('runStep reports timeout failures', async () => {
     const result = await runStep({
       name: 'unit-timeout',
@@ -177,6 +236,23 @@ describe('session-start-orchestrator', () => {
     });
     assert.equal(result.ok, false);
     assert.match(result.error.message, /timed out/);
+  });
+
+  it('readStdinPayload pauses and unrefs stdin when the read times out', async () => {
+    const calls = [];
+    const stdin = {
+      setEncoding: encoding => calls.push(['setEncoding', encoding]),
+      on: event => calls.push(['on', event]),
+      off: event => calls.push(['off', event]),
+      pause: () => calls.push(['pause']),
+      unref: () => calls.push(['unref']),
+    };
+
+    const payload = await readStdinPayload({ stdin, timeoutMs: 5 });
+
+    assert.deepEqual(payload, {});
+    assert.ok(calls.some(call => call[0] === 'pause'));
+    assert.ok(calls.some(call => call[0] === 'unref'));
   });
 
   it('passes a hard timeout and kill signal to prompt child process', () => {
@@ -226,6 +302,46 @@ describe('session-start-orchestrator', () => {
     });
     try {
       await new Promise(resolve => setTimeout(resolve, 25));
+      assert.equal(exitCode, 0);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  it('runSessionStartOrchestrator can use a caller-owned hard backstop timer', async () => {
+    const timer = installProcessBackstop({
+      totalBudgetMs: 1000,
+      exit: () => { throw new Error('should not exit'); },
+    });
+    try {
+      const result = await runWithActions('startup', {}, { hardBackstopTimer: timer });
+      assert.equal(result.stdout, 'MEM\nC4\n');
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  it('caller-owned hard backstop can fire while orchestration is still running', async () => {
+    let exitCode = null;
+    const timer = installProcessBackstop({
+      totalBudgetMs: 5,
+      exit: (code) => { exitCode = code; },
+    });
+    try {
+      await runWithActions('startup', {
+        memoryInject: async () => {
+          await new Promise(resolve => setTimeout(resolve, 25));
+          return 'late';
+        },
+      }, {
+        hardBackstopTimer: timer,
+        budgets: {
+          memoryInject: 100,
+          c4SessionInit: 50,
+          foreground: 50,
+          startupPrompt: 50,
+        },
+      });
       assert.equal(exitCode, 0);
     } finally {
       clearTimeout(timer);

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -207,24 +207,24 @@ describe('session-start-orchestrator', () => {
   });
 
   it('writes payloads larger than pipe buffers without truncation', () => {
-    const payload = 'x'.repeat(150 * 1024);
+    const payloadLength = 150 * 1024;
     const script = `
       import { runStep } from ${JSON.stringify(path.resolve(SCRIPT_DIR, '../session-start-orchestrator.js'))};
       await runStep({
         name: 'large',
         source: 'startup',
         budgetMs: 1000,
-        action: async () => ${JSON.stringify(payload)},
+        action: async () => 'x'.repeat(${payloadLength}),
         writeStdout: true,
       });
     `;
     const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
       encoding: 'utf8',
-      maxBuffer: payload.length + 64 * 1024,
+      maxBuffer: payloadLength + 64 * 1024,
     });
     assert.equal(result.status, 0);
-    assert.equal(result.stdout.length, payload.length);
-    assert.equal(result.stdout, payload);
+    assert.equal(result.stdout.length, payloadLength);
+    assert.equal(result.stdout, 'x'.repeat(payloadLength));
   });
 
   it('runStep reports timeout failures', async () => {

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  installProcessBackstop,
+  runSessionStartOrchestrator,
+  runStep,
+} from '../session-start-orchestrator.js';
+import { enqueueStartupPrompt } from '../session-start-prompt.js';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const C4_SESSION_INIT = path.resolve(SCRIPT_DIR, '../../../comm-bridge/scripts/c4-session-init.js');
+const SESSION_START_PROMPT = path.resolve(SCRIPT_DIR, '../session-start-prompt.js');
+
+function tempStdout() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-start-orch-'));
+  const filePath = path.join(tmpDir, 'stdout.txt');
+  const fd = fs.openSync(filePath, 'w+');
+  return {
+    stdout: { fd },
+    read() {
+      fs.closeSync(fd);
+      return fs.readFileSync(filePath, 'utf8');
+    },
+    cleanup() {
+      try { fs.closeSync(fd); } catch {}
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function actions(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    actions: {
+      memoryInject: async (payload) => {
+        calls.push(['memory', payload.source]);
+        return 'MEM\n';
+      },
+      c4SessionInit: async (payload) => {
+        calls.push(['c4', payload.source]);
+        return 'C4\n';
+      },
+      foreground: async (payload) => {
+        calls.push(['foreground', payload.source]);
+      },
+      startupPrompt: async (payload) => {
+        calls.push(['prompt', payload.source]);
+      },
+      ...overrides,
+    },
+  };
+}
+
+async function runWithActions(source, overrides = {}) {
+  const out = tempStdout();
+  const harness = actions(overrides);
+  try {
+    await runSessionStartOrchestrator({ source, session_id: 's1' }, {
+      stdout: out.stdout,
+      totalBudgetMs: 1000,
+      budgets: {
+        memoryInject: 50,
+        c4SessionInit: 50,
+        foreground: 50,
+        startupPrompt: 50,
+      },
+      actions: harness.actions,
+    });
+    return { calls: harness.calls, stdout: out.read() };
+  } finally {
+    out.cleanup();
+  }
+}
+
+describe('session-start-orchestrator', () => {
+  it('runs startup source with all four steps', async () => {
+    const result = await runWithActions('startup');
+    assert.deepEqual(result.calls, [
+      ['memory', 'startup'],
+      ['c4', 'startup'],
+      ['foreground', 'startup'],
+      ['prompt', 'startup'],
+    ]);
+    assert.equal(result.stdout, 'MEM\nC4\n');
+  });
+
+  it('runs clear source with all four steps', async () => {
+    const result = await runWithActions('clear');
+    assert.deepEqual(result.calls.map(([name]) => name), ['memory', 'c4', 'foreground', 'prompt']);
+  });
+
+  it('runs compact source without prompt enqueue', async () => {
+    const result = await runWithActions('compact');
+    assert.deepEqual(result.calls.map(([name]) => name), ['memory', 'c4', 'foreground']);
+    assert.equal(result.stdout, 'MEM\nC4\n');
+  });
+
+  it('preserves stdout byte order as memory then C4', async () => {
+    const result = await runWithActions('startup', {
+      memoryInject: async () => 'A',
+      c4SessionInit: async () => 'B',
+    });
+    assert.equal(result.stdout, 'AB');
+  });
+
+  it('does not write stdout for failed memory step', async () => {
+    const result = await runWithActions('startup', {
+      memoryInject: async () => { throw new Error('memory failed'); },
+    });
+    assert.equal(result.stdout, 'C4\n');
+    assert.deepEqual(result.calls.map(([name]) => name), ['c4', 'foreground', 'prompt']);
+  });
+
+  it('does not write stdout for failed C4 step', async () => {
+    const result = await runWithActions('startup', {
+      c4SessionInit: async () => { throw new Error('c4 failed'); },
+    });
+    assert.equal(result.stdout, 'MEM\n');
+    assert.deepEqual(result.calls.map(([name]) => name), ['memory', 'foreground', 'prompt']);
+  });
+
+  it('continues when foreground side effect fails', async () => {
+    const result = await runWithActions('startup', {
+      foreground: async () => { throw new Error('foreground failed'); },
+    });
+    assert.equal(result.stdout, 'MEM\nC4\n');
+    assert.deepEqual(result.calls.map(([name]) => name), ['memory', 'c4', 'prompt']);
+  });
+
+  it('continues when prompt side effect fails', async () => {
+    const result = await runWithActions('startup', {
+      startupPrompt: async () => { throw new Error('prompt failed'); },
+    });
+    assert.equal(result.stdout, 'MEM\nC4\n');
+    assert.deepEqual(result.calls.map(([name]) => name), ['memory', 'c4', 'foreground']);
+  });
+
+  it('times out async signal-style step bodies without blocking later steps', async () => {
+    const result = await runWithActions('startup', {
+      memoryInject: () => new Promise(() => {}),
+    });
+    assert.equal(result.stdout, 'C4\n');
+    assert.deepEqual(result.calls.map(([name]) => name), ['c4', 'foreground', 'prompt']);
+  });
+
+  it('runStep records successful stdout writes', async () => {
+    const out = tempStdout();
+    try {
+      const result = await runStep({
+        name: 'unit',
+        source: 'startup',
+        budgetMs: 50,
+        action: async () => 'payload',
+        writeStdout: true,
+        stdout: out.stdout,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(out.read(), 'payload');
+    } finally {
+      out.cleanup();
+    }
+  });
+
+  it('runStep reports timeout failures', async () => {
+    const result = await runStep({
+      name: 'unit-timeout',
+      source: 'startup',
+      budgetMs: 5,
+      action: () => new Promise(() => {}),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error.message, /timed out/);
+  });
+
+  it('passes a hard timeout and kill signal to prompt child process', () => {
+    const calls = [];
+    enqueueStartupPrompt('startup', {
+      controlPath: '/tmp/c4-control.js',
+      childTimeoutMs: 1234,
+      execFile: (...args) => calls.push(args),
+    });
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0][0], 'node');
+    assert.deepEqual(calls[0][1].slice(0, 2), ['/tmp/c4-control.js', 'enqueue']);
+    assert.equal(calls[0][2].timeout, 1234);
+    assert.equal(calls[0][2].killSignal, 'SIGKILL');
+  });
+
+  it('imports c4-session-init without CLI side effects', () => {
+    const result = spawnSync(process.execPath, ['-e', `import(${JSON.stringify(C4_SESSION_INIT)})`], {
+      env: { ...process.env, ZYLOS_DIR: fs.mkdtempSync(path.join(os.tmpdir(), 'c4-import-')) },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, '');
+  });
+
+  it('imports session-start-prompt without CLI side effects', () => {
+    const result = spawnSync(process.execPath, ['-e', `import(${JSON.stringify(SESSION_START_PROMPT)})`], {
+      env: { ...process.env, ZYLOS_DIR: fs.mkdtempSync(path.join(os.tmpdir(), 'prompt-import-')) },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, '');
+  });
+
+  it('happy path returns quickly instead of waiting for the backstop', async () => {
+    const start = Date.now();
+    await runWithActions('startup');
+    assert.ok(Date.now() - start < 500);
+  });
+
+  it('process backstop can force a clean exit after the total budget', async () => {
+    let exitCode = null;
+    const timer = installProcessBackstop({
+      totalBudgetMs: 5,
+      exit: (code) => { exitCode = code; },
+    });
+    try {
+      await new Promise(resolve => setTimeout(resolve, 25));
+      assert.equal(exitCode, 0);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+});

--- a/skills/activity-monitor/scripts/session-foreground.js
+++ b/skills/activity-monitor/scripts/session-foreground.js
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { getClaudePid } from './claude-pid.js';
 
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
@@ -38,7 +39,7 @@ export function handleSessionForeground(payload, {
   return record;
 }
 
-if (process.env.SESSION_FOREGROUND_DISABLE_MAIN !== '1') {
+function runCli() {
   let input = '';
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', (chunk) => {
@@ -52,4 +53,8 @@ if (process.env.SESSION_FOREGROUND_DISABLE_MAIN !== '1') {
       // Best-effort.
     }
   });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runCli();
 }

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * SessionStart orchestrator.
+ *
+ * Runs context-producing startup steps first, then side-effect-only steps.
+ * Stdout is reserved for context injection payloads.
+ */
+
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_TOTAL_BUDGET_MS = 17_000;
+export const STEP_BUDGETS_MS = {
+  memoryInject: 5_500,
+  c4SessionInit: 5_500,
+  foreground: 3_000,
+  startupPrompt: 3_000,
+};
+
+export function installProcessBackstop({
+  totalBudgetMs = DEFAULT_TOTAL_BUDGET_MS,
+  exit = process.exit,
+} = {}) {
+  const timer = setTimeout(() => {
+    console.error(`[session-start-orchestrator] total budget ${totalBudgetMs}ms exceeded; exiting`);
+    exit(0);
+  }, totalBudgetMs);
+  timer.unref?.();
+  return timer;
+}
+
+export function readStdinPayload({
+  stdin = process.stdin,
+  timeoutMs = 500,
+} = {}) {
+  return new Promise((resolve) => {
+    let input = '';
+    let done = false;
+    const finish = (payload) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      stdin.off?.('data', onData);
+      stdin.off?.('end', onEnd);
+      resolve(payload);
+    };
+    const onData = chunk => { input += chunk; };
+    const onEnd = () => {
+      try {
+        finish(JSON.parse(input || '{}'));
+      } catch {
+        finish({});
+      }
+    };
+    const timer = setTimeout(() => finish({}), timeoutMs);
+    timer.unref?.();
+    stdin.setEncoding?.('utf8');
+    stdin.on?.('data', onData);
+    stdin.on?.('end', onEnd);
+  });
+}
+
+async function logStep({ name, source, status, durationMs, stdoutBytes = 0, error }) {
+  try {
+    const { logHookTiming } = await import('../../comm-bridge/scripts/c4-diagnostic.js');
+    const detail = [
+      `session-start-orchestrator:${name}`,
+      source ? `[${source}]` : '',
+      `status=${status}`,
+      `stdout=${stdoutBytes}`,
+      error ? `error=${String(error.message || error).replace(/\s+/g, '_').slice(0, 120)}` : '',
+    ].filter(Boolean).join(':');
+    logHookTiming(detail, durationMs);
+  } catch {
+    // Diagnostics are best-effort.
+  }
+}
+
+function withTimeout(promise, timeoutMs, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    timer.unref?.();
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+export async function runStep({
+  name,
+  source,
+  budgetMs,
+  action,
+  writeStdout = false,
+  stdout = process.stdout,
+}) {
+  const startMs = Date.now();
+  try {
+    const output = await withTimeout(Promise.resolve().then(action), budgetMs, name);
+    const text = output == null ? '' : String(output);
+    if (writeStdout && text.length > 0) {
+      fs.writeSync(stdout.fd ?? 1, text);
+    }
+    await logStep({
+      name,
+      source,
+      status: 'ok',
+      durationMs: Date.now() - startMs,
+      stdoutBytes: writeStdout ? Buffer.byteLength(text) : 0,
+    });
+    return { ok: true, output: text };
+  } catch (error) {
+    const timedOut = /timed out/.test(String(error?.message || error));
+    console.error(`[session-start-orchestrator] step "${name}" ${timedOut ? 'timed out' : 'failed'} (${Date.now() - startMs}ms): ${error?.message || error}`);
+    await logStep({
+      name,
+      source,
+      status: timedOut ? 'timeout' : 'failed',
+      durationMs: Date.now() - startMs,
+      error,
+    });
+    return { ok: false, error };
+  }
+}
+
+async function runMemoryInject(payload) {
+  const { injectMemory } = await import('../../zylos-memory/scripts/session-start-inject.js');
+  return injectMemory(payload);
+}
+
+async function runC4SessionInit(payload) {
+  const { initC4Session } = await import('../../comm-bridge/scripts/c4-session-init.js');
+  return initC4Session(payload);
+}
+
+async function runForeground(payload) {
+  const { handleSessionForeground } = await import('./session-foreground.js');
+  handleSessionForeground(payload);
+}
+
+async function runStartupPrompt(payload) {
+  const { enqueueStartupPrompt } = await import('./session-start-prompt.js');
+  enqueueStartupPrompt(payload?.source || null);
+}
+
+export async function runSessionStartOrchestrator(payload = {}, {
+  totalBudgetMs = DEFAULT_TOTAL_BUDGET_MS,
+  budgets = STEP_BUDGETS_MS,
+  stdout = process.stdout,
+  actions = {
+    memoryInject: runMemoryInject,
+    c4SessionInit: runC4SessionInit,
+    foreground: runForeground,
+    startupPrompt: runStartupPrompt,
+  },
+} = {}) {
+  const source = payload?.source || null;
+  const totalTimer = installProcessBackstop({ totalBudgetMs });
+
+  try {
+    await runStep({
+      name: 'memory-inject',
+      source,
+      budgetMs: budgets.memoryInject,
+      action: () => actions.memoryInject(payload),
+      writeStdout: true,
+      stdout,
+    });
+
+    await runStep({
+      name: 'c4-session-init',
+      source,
+      budgetMs: budgets.c4SessionInit,
+      action: () => actions.c4SessionInit(payload),
+      writeStdout: true,
+      stdout,
+    });
+
+    const sideEffects = [
+      runStep({
+        name: 'session-foreground',
+        source,
+        budgetMs: budgets.foreground,
+        action: () => actions.foreground(payload),
+      }),
+    ];
+
+    if (source === 'compact') {
+      await logStep({
+        name: 'session-start-prompt',
+        source,
+        status: 'skipped',
+        durationMs: 0,
+      });
+    } else {
+      sideEffects.push(runStep({
+        name: 'session-start-prompt',
+        source,
+        budgetMs: budgets.startupPrompt,
+        action: () => actions.startupPrompt(payload),
+      }));
+    }
+
+    await Promise.all(sideEffects);
+  } finally {
+    clearTimeout(totalTimer);
+  }
+}
+
+async function main() {
+  installProcessBackstop();
+  const payload = await readStdinPayload();
+  await runSessionStartOrchestrator(payload, { totalBudgetMs: DEFAULT_TOTAL_BUDGET_MS });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`[session-start-orchestrator] fatal: ${error?.stack || error?.message || error}`);
+    process.exitCode = 0;
+  });
+}

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -162,7 +162,7 @@ async function runForeground(payload) {
 
 async function runStartupPrompt(payload) {
   const { enqueueStartupPrompt } = await import('./session-start-prompt.js');
-  enqueueStartupPrompt(payload?.source || null);
+  return enqueueStartupPrompt(payload?.source || null);
 }
 
 export async function runSessionStartOrchestrator(payload = {}, {

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -29,6 +29,26 @@ export function installProcessBackstop({
   return timer;
 }
 
+export function writeAllSync(fd, text, {
+  writeSync = fs.writeSync,
+} = {}) {
+  const buffer = Buffer.isBuffer(text) ? text : Buffer.from(String(text));
+  let offset = 0;
+  while (offset < buffer.length) {
+    try {
+      const written = writeSync(fd, buffer, offset, buffer.length - offset);
+      if (written <= 0) {
+        throw new Error(`writeSync made no progress at offset ${offset}`);
+      }
+      offset += written;
+    } catch (error) {
+      if (error?.code === 'EAGAIN') continue;
+      throw error;
+    }
+  }
+  return offset;
+}
+
 export function readStdinPayload({
   stdin = process.stdin,
   timeoutMs = 500,
@@ -42,6 +62,8 @@ export function readStdinPayload({
       clearTimeout(timer);
       stdin.off?.('data', onData);
       stdin.off?.('end', onEnd);
+      stdin.pause?.();
+      stdin.unref?.();
       resolve(payload);
     };
     const onData = chunk => { input += chunk; };
@@ -92,13 +114,14 @@ export async function runStep({
   action,
   writeStdout = false,
   stdout = process.stdout,
+  writeSync = fs.writeSync,
 }) {
   const startMs = Date.now();
   try {
     const output = await withTimeout(Promise.resolve().then(action), budgetMs, name);
     const text = output == null ? '' : String(output);
     if (writeStdout && text.length > 0) {
-      fs.writeSync(stdout.fd ?? 1, text);
+      writeAllSync(stdout.fd ?? 1, text, { writeSync });
     }
     await logStep({
       name,
@@ -146,6 +169,7 @@ export async function runSessionStartOrchestrator(payload = {}, {
   totalBudgetMs = DEFAULT_TOTAL_BUDGET_MS,
   budgets = STEP_BUDGETS_MS,
   stdout = process.stdout,
+  hardBackstopTimer = null,
   actions = {
     memoryInject: runMemoryInject,
     c4SessionInit: runC4SessionInit,
@@ -154,7 +178,7 @@ export async function runSessionStartOrchestrator(payload = {}, {
   },
 } = {}) {
   const source = payload?.source || null;
-  const totalTimer = installProcessBackstop({ totalBudgetMs });
+  const totalTimer = hardBackstopTimer || installProcessBackstop({ totalBudgetMs });
 
   try {
     await runStep({
@@ -202,14 +226,17 @@ export async function runSessionStartOrchestrator(payload = {}, {
 
     await Promise.all(sideEffects);
   } finally {
-    clearTimeout(totalTimer);
+    if (!hardBackstopTimer) clearTimeout(totalTimer);
   }
 }
 
 async function main() {
-  installProcessBackstop();
+  const hardBackstopTimer = installProcessBackstop();
   const payload = await readStdinPayload();
-  await runSessionStartOrchestrator(payload, { totalBudgetMs: DEFAULT_TOTAL_BUDGET_MS });
+  await runSessionStartOrchestrator(payload, {
+    totalBudgetMs: DEFAULT_TOTAL_BUDGET_MS,
+    hardBackstopTimer,
+  });
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/skills/activity-monitor/scripts/session-start-prompt.js
+++ b/skills/activity-monitor/scripts/session-start-prompt.js
@@ -10,10 +10,11 @@
 import { execFileSync } from 'child_process';
 import path from 'path';
 import os from 'os';
+import { fileURLToPath } from 'node:url';
 
-const startMs = Date.now();
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const C4_CONTROL = path.join(ZYLOS_DIR, '.claude/skills/comm-bridge/scripts/c4-control.js');
+const DEFAULT_CHILD_TIMEOUT_MS = 2500;
 let diagnosticModule;
 let diagnosticLoadAttempted = false;
 
@@ -43,18 +44,32 @@ async function logHookTimingSafe(name, durationMs) {
 function readStdinSource() {
   return new Promise((resolve) => {
     let input = '';
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => { input += chunk; });
-    process.stdin.on('end', () => {
+    let done = false;
+    const cleanup = () => {
+      clearTimeout(timer);
+      process.stdin.off('data', onData);
+      process.stdin.off('end', onEnd);
+    };
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      cleanup();
+      resolve(value);
+    };
+    const onData = chunk => { input += chunk; };
+    const onEnd = () => {
       try {
-        const data = JSON.parse(input);
-        resolve(data.source || null);
+        const data = JSON.parse(input || '{}');
+        finish(data.source || null);
       } catch {
-        resolve(null);
+        finish(null);
       }
-    });
-    // If stdin is already closed or empty, resolve after a short timeout
-    setTimeout(() => resolve(null), 500);
+    };
+    const timer = setTimeout(() => finish(null), 500);
+    timer.unref?.();
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
   });
 }
 
@@ -64,19 +79,32 @@ const prompt = [
   'and do not query c4.db for recent conversations unless explicitly required.'
 ].join(' ');
 
+export function enqueueStartupPrompt(source, {
+  execFile = execFileSync,
+  controlPath = C4_CONTROL,
+  childTimeoutMs = DEFAULT_CHILD_TIMEOUT_MS,
+} = {}) {
+  execFile('node', [
+    controlPath, 'enqueue',
+    '--content', prompt,
+    '--priority', '2',
+    '--no-ack-suffix'
+  ], {
+    stdio: 'pipe',
+    timeout: childTimeoutMs,
+    killSignal: 'SIGKILL',
+  });
+}
+
 async function main() {
+  const startMs = Date.now();
   const source = await readStdinSource();
   const hookName = source
     ? `session-start-prompt[${source}]`
     : 'session-start-prompt';
 
   try {
-    execFileSync('node', [
-      C4_CONTROL, 'enqueue',
-      '--content', prompt,
-      '--priority', '2',
-      '--no-ack-suffix'
-    ], { stdio: 'pipe' });
+    enqueueStartupPrompt(source);
   } catch {
     // Silently fail — session still starts even if enqueue fails
   } finally {
@@ -84,6 +112,8 @@ async function main() {
   }
 }
 
-main().catch(() => {
-  // Best-effort.
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(() => {
+    // Best-effort.
+  });
+}

--- a/skills/activity-monitor/scripts/session-start-prompt.js
+++ b/skills/activity-monitor/scripts/session-start-prompt.js
@@ -7,10 +7,13 @@
  * not just given passive context.
  */
 
-import { execFileSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'node:util';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
 
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const C4_CONTROL = path.join(ZYLOS_DIR, '.claude/skills/comm-bridge/scripts/c4-control.js');
@@ -79,18 +82,22 @@ const prompt = [
   'and do not query c4.db for recent conversations unless explicitly required.'
 ].join(' ');
 
-export function enqueueStartupPrompt(source, {
-  execFile = execFileSync,
+export async function enqueueStartupPrompt(source, {
+  execFile = execFileAsync,
   controlPath = C4_CONTROL,
   childTimeoutMs = DEFAULT_CHILD_TIMEOUT_MS,
 } = {}) {
-  execFile('node', [
+  // Async execFile (not execFileSync): keeps the event loop free so this step
+  // genuinely runs in parallel with the foreground step, and so the
+  // orchestrator's per-step withTimeout budget can actually preempt it.
+  // The child's own timeout + SIGKILL remains the hard backstop (bounds the
+  // #601-class enqueue hang even if the orchestrator budget is generous).
+  await execFile('node', [
     controlPath, 'enqueue',
     '--content', prompt,
     '--priority', '2',
     '--no-ack-suffix'
   ], {
-    stdio: 'pipe',
     timeout: childTimeoutMs,
     killSignal: 'SIGKILL',
   });
@@ -104,7 +111,7 @@ async function main() {
     : 'session-start-prompt';
 
   try {
-    enqueueStartupPrompt(source);
+    await enqueueStartupPrompt(source);
   } catch {
     // Silently fail — session still starts even if enqueue fails
   } finally {

--- a/skills/comm-bridge/scripts/c4-session-init.js
+++ b/skills/comm-bridge/scripts/c4-session-init.js
@@ -9,20 +9,22 @@
  * Usage: node c4-session-init.js
  */
 
-import {
-  getLastCheckpoint,
-  getUnsummarizedRange,
-  getUnsummarizedConversations,
-  formatConversations,
-  close
-} from './c4-db.js';
-import { CHECKPOINT_THRESHOLD, SESSION_INIT_RECENT_COUNT } from './c4-config.js';
 import { logHookTiming } from './c4-diagnostic.js';
+import { fileURLToPath } from 'node:url';
 
-const startMs = Date.now();
-
-function main() {
+export async function initC4Session() {
+  let close = () => {};
   try {
+    const {
+      getLastCheckpoint,
+      getUnsummarizedRange,
+      getUnsummarizedConversations,
+      formatConversations,
+      close: closeDb,
+    } = await import('./c4-db.js');
+    close = closeDb;
+    const { CHECKPOINT_THRESHOLD, SESSION_INIT_RECENT_COUNT } = await import('./c4-config.js');
+
     const checkpoint = getLastCheckpoint();
     const range = getUnsummarizedRange();
     const lines = [];
@@ -35,8 +37,7 @@ function main() {
 
     if (range.count === 0) {
       lines.push('No new conversations since last checkpoint.');
-      console.log(lines.join('\n'));
-      return;
+      return `${lines.join('\n')}\n`;
     }
 
     const needsSync = range.count > CHECKPOINT_THRESHOLD;
@@ -54,14 +55,34 @@ function main() {
       lines.push(`[Action Required] There are ${range.count} unsummarized conversations (conversation id ${range.begin_id} ~ ${range.end_id}). Please use zylos-memory skill to process them.`);
     }
 
-    console.log(lines.join('\n'));
+    return `${lines.join('\n')}\n`;
   } catch (err) {
-    console.error(`Error in session init: ${err.stack}`);
-    process.exit(1);
+    const wrapped = new Error(`Error in session init: ${err.message}`);
+    wrapped.cause = err;
+    throw wrapped;
   } finally {
     close();
-    logHookTiming('c4-session-init', Date.now() - startMs);
   }
 }
 
-main();
+function main() {
+  const startMs = Date.now();
+  (async () => {
+    try {
+      process.stdout.write(await initC4Session());
+    } catch (err) {
+      console.error(err.cause?.stack || err.stack || err.message);
+      process.exitCode = 1;
+    } finally {
+      logHookTiming('c4-session-init', Date.now() - startMs);
+    }
+  })().catch((err) => {
+    console.error(err?.stack || err?.message || err);
+    process.exitCode = 1;
+    logHookTiming('c4-session-init', Date.now() - startMs);
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/skills/zylos-memory/scripts/session-start-inject.js
+++ b/skills/zylos-memory/scripts/session-start-inject.js
@@ -10,7 +10,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { MEMORY_DIR } from './shared.js';
 
-const startMs = Date.now();
 let diagnosticModule;
 let diagnosticLoadAttempted = false;
 
@@ -59,19 +58,20 @@ function section(label, filePath) {
   return lines.join('\n');
 }
 
-function main() {
+export function injectMemory() {
   const parts = [
     section('BOT IDENTITY', path.join(MEMORY_DIR, 'identity.md')),
     section('ACTIVE STATE', path.join(MEMORY_DIR, 'state.md')),
     section('REFERENCES', path.join(MEMORY_DIR, 'references.md'))
   ];
 
-  process.stdout.write(`${parts.join('\n\n')}\n`);
+  return `${parts.join('\n\n')}\n`;
 }
 
 async function runCli() {
+  const startMs = Date.now();
   try {
-    main();
+    process.stdout.write(injectMemory());
   } catch (err) {
     console.error(`session-start-inject error: ${err.message}`);
   } finally {

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -9,23 +9,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-foreground.js",
-            "timeout": 5000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js",
-            "timeout": 5000
+            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js",
+            "timeout": 20000
           }
         ]
       },
@@ -34,23 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-foreground.js",
-            "timeout": 5000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js",
-            "timeout": 5000
+            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js",
+            "timeout": 20000
           }
         ]
       },
@@ -59,23 +29,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-foreground.js",
-            "timeout": 5000
-          },
-          {
-            "type": "command",
-            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js",
-            "timeout": 5000
+            "command": "node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js",
+            "timeout": 20000
           }
         ]
       }

--- a/test/integration/runtime/run.sh
+++ b/test/integration/runtime/run.sh
@@ -12,6 +12,10 @@ REAL_CLAUDE_AUTH_FILE="$SCRIPT_DIR/real-claude-auth.local.env"
 # credential is provisioned as a gitignored seed file the operator copies from
 # their own ~/.codex/auth.json. Mounted into the container for real codex scenarios.
 REAL_CODEX_AUTH_FILE="$SCRIPT_DIR/real-codex-auth.local.json"
+# Claude Code authenticates from ~/.claude/.credentials.json (OAuth) or env vars.
+# For real-smoke scenarios that run `claude -p` (not just `zylos runtime`), the
+# OAuth credentials file must be mounted. Falls back to the operator's own file.
+REAL_CLAUDE_CREDS_FILE="${REAL_CLAUDE_CREDS_FILE:-$HOME/.claude/.credentials.json}"
 DEFAULT_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 FAKE_PATH="/runtime/bin:$DEFAULT_PATH"
 
@@ -58,6 +62,9 @@ has_claude_credentials() {
     grep -Eq '^(ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN)=.+' "$REAL_CLAUDE_AUTH_FILE"
     return $?
   fi
+
+  # OAuth credentials file (for scenarios that run `claude -p` directly)
+  [[ -f "$REAL_CLAUDE_CREDS_FILE" ]] && return 0
 
   [[ -n "${ANTHROPIC_API_KEY:-}" || -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]
 }
@@ -162,6 +169,9 @@ run_one() {
   case "${RUNTIME_MODE:-fake}" in
     real)
       docker_args+=(-e "PATH=$DEFAULT_PATH")
+      # Use host networking so localhost-bound proxies (e.g. mihomo on
+      # 127.0.0.1:7890) are reachable from inside the container.
+      docker_args+=(--network host)
       # Forward host proxy settings so the in-container live probe reaches the
       # Anthropic API the same way the host does. The bare `-e NAME` form passes
       # the host value through when set and is a no-op when unset — so a host
@@ -191,6 +201,11 @@ run_one() {
       # genuine codex CLI then authenticates from it (apikey or chatgpt mode).
       if [[ -f "$REAL_CODEX_AUTH_FILE" ]]; then
         docker_args+=(-v "$REAL_CODEX_AUTH_FILE:/seed/codex-auth.json:ro")
+      fi
+      # Claude Code reads ~/.claude/.credentials.json for OAuth auth. Mount
+      # the operator's credentials so `claude -p` scenarios can authenticate.
+      if [[ -f "$REAL_CLAUDE_CREDS_FILE" ]]; then
+        docker_args+=(-v "$REAL_CLAUDE_CREDS_FILE:/seed/claude-credentials.json:ro")
       fi
       ;;
     fake|"")
@@ -226,6 +241,13 @@ mkdir -p "$HOME" "$ZYLOS_DIR/.zylos" "$ZYLOS_DIR/pm2"
 if [ -f /seed/codex-auth.json ]; then
   mkdir -p "$HOME/.codex"
   cp /seed/codex-auth.json "$HOME/.codex/auth.json"
+fi
+
+# Stage Claude Code OAuth credentials similarly. Claude reads
+# ~/.claude/.credentials.json for OAuth-based auth (claude.ai subscription).
+if [ -f /seed/claude-credentials.json ]; then
+  mkdir -p "$HOME/.claude"
+  cp /seed/claude-credentials.json "$HOME/.claude/.credentials.json"
 fi
 
 case "${SETUP:-minimal}" in

--- a/test/integration/runtime/scenarios/real/session-start-real-hook.env
+++ b/test/integration/runtime/scenarios/real/session-start-real-hook.env
@@ -1,0 +1,13 @@
+# Real SessionStart hook: verify the orchestrator fires via Claude Code's
+# hook mechanism (not direct script invocation). claude -p triggers the
+# SessionStart startup hook; we check hook-timing.log for orchestrator
+# entries rather than parsing LLM output (deterministic verification).
+# Debug artifacts (claude response, hook timing log) are copied to the
+# shared mount at /tmp/zylos-run/ for post-mortem inspection on failure.
+REAL_REQUIRES=claude
+RUNTIME_MODE=real
+SETUP=init
+SCENARIO_CMD=cd "$ZYLOS_DIR" && timeout 120 claude -p "Reply with the single word OK" --max-turns 1 > /tmp/zylos-run/claude-response.txt 2>&1 || true; cp "$ZYLOS_DIR/activity-monitor/hook-timing.log" /tmp/zylos-run/ 2>/dev/null; test -f "$ZYLOS_DIR/activity-monitor/hook-timing.log" && grep -q "session-start-orchestrator:memory-inject" "$ZYLOS_DIR/activity-monitor/hook-timing.log" && grep -q "session-start-orchestrator:c4-session-init" "$ZYLOS_DIR/activity-monitor/hook-timing.log" && echo "SESSION_START_HOOK_VERIFIED"
+EXPECT_EXIT=0
+EXPECT_STDOUT=SESSION_START_HOOK_VERIFIED
+EXPECT_STDERR=

--- a/test/integration/runtime/scenarios/real/session-start-real-hook.env
+++ b/test/integration/runtime/scenarios/real/session-start-real-hook.env
@@ -1,13 +1,16 @@
-# Real SessionStart hook: verify the orchestrator fires via Claude Code's
-# hook mechanism (not direct script invocation). claude -p triggers the
-# SessionStart startup hook; we check hook-timing.log for orchestrator
-# entries rather than parsing LLM output (deterministic verification).
-# Debug artifacts (claude response, hook timing log) are copied to the
-# shared mount at /tmp/zylos-run/ for post-mortem inspection on failure.
+# Real SessionStart hook end-to-end: verify the orchestrator fires via
+# Claude Code's hook mechanism AND that memory context is actually injected
+# into Claude's prompt. The golden identity.md contains "I am Zylos" — we
+# ask Claude a question that can only be answered if the SessionStart hook
+# successfully injected that memory. This validates the full chain:
+#   hook fires → orchestrator runs → memory-inject reads identity.md →
+#   stdout piped to Claude as system context → Claude answers correctly.
+# Additionally checks hook-timing.log for orchestrator entries.
+# Debug artifacts saved to /tmp/zylos-run/ for post-mortem on failure.
 REAL_REQUIRES=claude
 RUNTIME_MODE=real
 SETUP=init
-SCENARIO_CMD=cd "$ZYLOS_DIR" && timeout 120 claude -p "Reply with the single word OK" --max-turns 1 > /tmp/zylos-run/claude-response.txt 2>&1 || true; cp "$ZYLOS_DIR/activity-monitor/hook-timing.log" /tmp/zylos-run/ 2>/dev/null; test -f "$ZYLOS_DIR/activity-monitor/hook-timing.log" && grep -q "session-start-orchestrator:memory-inject" "$ZYLOS_DIR/activity-monitor/hook-timing.log" && grep -q "session-start-orchestrator:c4-session-init" "$ZYLOS_DIR/activity-monitor/hook-timing.log" && echo "SESSION_START_HOOK_VERIFIED"
+SCENARIO_CMD=cd "$ZYLOS_DIR" && timeout 120 claude -p "Your system context contains a BOT IDENTITY section. What name does it say you are? Reply with ONLY the name, nothing else." --max-turns 1 > /tmp/zylos-run/claude-response.txt 2>&1 || true; cp "$ZYLOS_DIR/activity-monitor/hook-timing.log" /tmp/zylos-run/ 2>/dev/null; PASS=0; if test -f "$ZYLOS_DIR/activity-monitor/hook-timing.log" && grep -q "session-start-orchestrator:memory-inject" "$ZYLOS_DIR/activity-monitor/hook-timing.log"; then PASS=$((PASS+1)); echo "HOOK_TIMING_OK"; fi; if grep -qi "zylos" /tmp/zylos-run/claude-response.txt 2>/dev/null; then PASS=$((PASS+1)); echo "CONTEXT_INJECTION_OK"; fi; test "$PASS" -ge 2 && echo "SESSION_START_HOOK_VERIFIED"
 EXPECT_EXIT=0
 EXPECT_STDOUT=SESSION_START_HOOK_VERIFIED
 EXPECT_STDERR=

--- a/test/integration/runtime/scenarios/session-start-compact.env
+++ b/test/integration/runtime/scenarios/session-start-compact.env
@@ -1,0 +1,8 @@
+# SessionStart orchestrator in compact mode — skips the startup prompt step.
+# Verifies orchestrator still produces memory + C4 context but logs a skip
+# for the prompt step.
+SETUP=init
+SCENARIO_CMD=echo '{"source":"compact"}' | node "$ZYLOS_DIR/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js"
+EXPECT_EXIT=0
+EXPECT_STDOUT=BOT IDENTITY
+EXPECT_STDERR=

--- a/test/integration/runtime/scenarios/session-start-orchestrator.env
+++ b/test/integration/runtime/scenarios/session-start-orchestrator.env
@@ -1,0 +1,10 @@
+# SessionStart orchestrator integration test.
+# Runs the orchestrator script in a post-init workspace and verifies it
+# produces memory and C4 context on stdout without hanging.
+# The orchestrator reads a JSON payload from stdin; we send an empty object.
+SETUP=init
+SCENARIO_CMD=echo '{}' | node "$ZYLOS_DIR/.claude/skills/activity-monitor/scripts/session-start-orchestrator.js"
+EXPECT_EXIT=0
+EXPECT_STDOUT=BOT IDENTITY
+EXPECT_STDOUT_2=ACTIVE STATE
+EXPECT_STDERR=

--- a/test/integration/runtime/scenarios/session-start-settings-migration.env
+++ b/test/integration/runtime/scenarios/session-start-settings-migration.env
@@ -1,0 +1,9 @@
+# SessionStart settings migration test.
+# Seeds the installed settings.json with the old 4-hook SessionStart layout,
+# then runs sync-settings-hooks.js which triggers migrateSessionStartOrchestrator.
+# Verifies the migration replaces the 4 hooks with the single orchestrator hook.
+SETUP=init
+SCENARIO_CMD=node -e "const fs=require('fs'),p=process.env.ZYLOS_DIR+'/.claude/settings.json',s=JSON.parse(fs.readFileSync(p,'utf8'));const h=[{type:'command',command:'node ~/zylos/.claude/skills/zylos-memory/scripts/session-start-inject.js',timeout:10000},{type:'command',command:'node ~/zylos/.claude/skills/comm-bridge/scripts/c4-session-init.js',timeout:10000},{type:'command',command:'node ~/zylos/.claude/skills/activity-monitor/scripts/session-foreground.js',timeout:5000},{type:'command',command:'node ~/zylos/.claude/skills/activity-monitor/scripts/session-start-prompt.js',timeout:5000}];s.hooks=s.hooks||{};s.hooks.SessionStart=['startup','clear','compact'].map(m=>({matcher:m,hooks:h.map(x=>({...x}))}));fs.writeFileSync(p,JSON.stringify(s,null,2));" && node /repo/cli/lib/sync-settings-hooks.js && grep -c 'session-start-orchestrator' "$ZYLOS_DIR/.claude/settings.json"
+EXPECT_EXIT=0
+EXPECT_STDOUT=3
+EXPECT_STDERR=


### PR DESCRIPTION
## Summary

- Design document for consolidating 4 SessionStart hook commands into a single orchestrator script
- Addresses fragility (no error isolation, #601 hang bug), 3× duplication across matchers, and unbounded startup time
- Orchestrator runs steps in defined order: memory inject → C4 init (sequential, stdout) → foreground + prompt (parallel, side effects)
- Per-step timeout + total 15s budget ensures startup never hangs

This PR starts with the design doc only. Implementation follows after review.

## Design highlights

- **In-process imports** instead of 4 child process spawns (refactor existing scripts to export callable functions)
- **Phase 1** (sequential): memory inject + C4 init → stdout for Claude context
- **Phase 2** (parallel): foreground session file + control-queue prompt → side effects only
- **Error isolation**: each step wrapped in try/catch + AbortSignal.timeout; failure logged and skipped

## Test plan

- [ ] Review design document (`docs/impl-session-start-orchestrator.md`)
- [ ] Confirm approach for open questions (compact skip prompt? settings migration?)

Fixes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)