### PR TITLE
fix: unify session-start context format + surface failures and null summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Unified session-start context format**: memory injection (`session-start-inject.js`) and C4 session init (`c4-session-init.js`) now share a single `formatSection()` helper, emitting consistent `=== LABEL ===` … `=== END LABEL ===` blocks instead of the previous mixed `=== LABEL ===` (header-only) / `[Bracket Label]` styles, so the combined injected context reads uniformly. (#651)
+- **Unified session-start context format**: memory injection (`session-start-inject.js`) and C4 session init (`c4-session-init.js`) now share a single `formatSection()` helper, emitting consistent `=== LABEL ===` … `=== END LABEL ===` blocks instead of the previous mixed `=== LABEL ===` (header-only) / `[Bracket Label]` styles, so the combined injected context reads uniformly. (#671)
 
 ### Fixed
-- **Visible session-start step failures**: the orchestrator now writes a visible `=== <STEP> UNAVAILABLE ===` notice to the injected stdout stream when a context-producing step fails or times out, instead of silently dropping the section. (#651)
-- **Checkpoint null-summary fallback**: the last-checkpoint block now renders a `(no summary — checkpoint #id, ts)` fallback when a checkpoint exists with a null summary, so the block never silently disappears. (#651)
+- **Visible session-start step failures**: the orchestrator now writes a visible `=== <STEP> UNAVAILABLE ===` notice to the injected stdout stream when a context-producing step fails or times out, instead of silently dropping the section. (#671)
+- **Checkpoint null-summary fallback**: the last-checkpoint block now renders a `(no summary — checkpoint #id, ts)` fallback when a checkpoint exists with a null summary, so the block never silently disappears. (#671)
 
 ## [0.5.3] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Unified session-start context format**: memory injection (`session-start-inject.js`) and C4 session init (`c4-session-init.js`) now share a single `formatSection()` helper, emitting consistent `=== LABEL ===` … `=== END LABEL ===` blocks instead of the previous mixed `=== LABEL ===` (header-only) / `[Bracket Label]` styles, so the combined injected context reads uniformly. (#651)
+
+### Fixed
+- **Visible session-start step failures**: the orchestrator now writes a visible `=== <STEP> UNAVAILABLE ===` notice to the injected stdout stream when a context-producing step fails or times out, instead of silently dropping the section. (#651)
+- **Checkpoint null-summary fallback**: the last-checkpoint block now renders a `(no summary — checkpoint #id, ts)` fallback when a checkpoint exists with a null summary, so the block never silently disappears. (#651)
+
 ## [0.5.3] - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **Unified session-start context format**: memory injection (`session-start-inject.js`) and C4 session init (`c4-session-init.js`) now share a single `formatSection()` helper, emitting consistent `=== LABEL ===` … `=== END LABEL ===` blocks instead of the previous mixed `=== LABEL ===` (header-only) / `[Bracket Label]` styles, so the combined injected context reads uniformly. (#671)
-
-### Fixed
-- **Visible session-start step failures**: the orchestrator now writes a visible `=== <STEP> UNAVAILABLE ===` notice to the injected stdout stream when a context-producing step fails or times out, instead of silently dropping the section. (#671)
-- **Checkpoint null-summary fallback**: the last-checkpoint block now renders a `(no summary — checkpoint #id, ts)` fallback when a checkpoint exists with a null summary, so the block never silently disappears. (#671)
-
 ## [0.5.3] - 2026-06-17
 
 ### Added

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -113,19 +113,25 @@ describe('session-start-orchestrator', () => {
     assert.equal(result.stdout, 'AB');
   });
 
-  it('does not write stdout for failed memory step', async () => {
+  it('emits a visible failure notice for a failed memory step', async () => {
     const result = await runWithActions('startup', {
       memoryInject: async () => { throw new Error('memory failed'); },
     });
-    assert.equal(result.stdout, 'C4\n');
+    assert.match(result.stdout, /=== MEMORY-INJECT UNAVAILABLE ===/);
+    assert.match(result.stdout, /failed: memory failed/);
+    assert.match(result.stdout, /=== END MEMORY-INJECT UNAVAILABLE ===/);
+    // C4 context still follows the notice.
+    assert.ok(result.stdout.endsWith('C4\n'));
     assert.deepEqual(result.calls.map(([name]) => name), ['c4', 'foreground', 'prompt']);
   });
 
-  it('does not write stdout for failed C4 step', async () => {
+  it('emits a visible failure notice for a failed C4 step after the memory context', async () => {
     const result = await runWithActions('startup', {
       c4SessionInit: async () => { throw new Error('c4 failed'); },
     });
-    assert.equal(result.stdout, 'MEM\n');
+    assert.ok(result.stdout.startsWith('MEM\n'));
+    assert.match(result.stdout, /=== C4-SESSION-INIT UNAVAILABLE ===/);
+    assert.match(result.stdout, /failed: c4 failed/);
     assert.deepEqual(result.calls.map(([name]) => name), ['memory', 'foreground', 'prompt']);
   });
 
@@ -149,7 +155,9 @@ describe('session-start-orchestrator', () => {
     const result = await runWithActions('startup', {
       memoryInject: () => new Promise(() => {}),
     });
-    assert.equal(result.stdout, 'C4\n');
+    assert.match(result.stdout, /=== MEMORY-INJECT UNAVAILABLE ===/);
+    assert.match(result.stdout, /timed out/);
+    assert.ok(result.stdout.endsWith('C4\n'));
     assert.deepEqual(result.calls.map(([name]) => name), ['c4', 'foreground', 'prompt']);
   });
 
@@ -161,7 +169,9 @@ describe('session-start-orchestrator', () => {
         throw err;
       },
     });
-    assert.equal(result.stdout, 'C4\n');
+    assert.match(result.stdout, /=== MEMORY-INJECT UNAVAILABLE ===/);
+    assert.match(result.stdout, /Cannot find module/);
+    assert.ok(result.stdout.endsWith('C4\n'));
     assert.deepEqual(result.calls.map(([name]) => name), ['c4', 'foreground', 'prompt']);
   });
 
@@ -178,6 +188,45 @@ describe('session-start-orchestrator', () => {
       });
       assert.equal(result.ok, true);
       assert.equal(out.read(), 'payload');
+    } finally {
+      out.cleanup();
+    }
+  });
+
+  it('runStep writes a visible notice to stdout when a writeStdout step fails', async () => {
+    const out = tempStdout();
+    try {
+      const result = await runStep({
+        name: 'memory-inject',
+        source: 'startup',
+        budgetMs: 50,
+        action: async () => { throw new Error('boom'); },
+        writeStdout: true,
+        stdout: out.stdout,
+      });
+      assert.equal(result.ok, false);
+      const text = out.read();
+      assert.match(text, /=== MEMORY-INJECT UNAVAILABLE ===/);
+      assert.match(text, /failed: boom/);
+      assert.match(text, /=== END MEMORY-INJECT UNAVAILABLE ===/);
+    } finally {
+      out.cleanup();
+    }
+  });
+
+  it('runStep stays silent on stdout when a side-effect (non-writeStdout) step fails', async () => {
+    const out = tempStdout();
+    try {
+      const result = await runStep({
+        name: 'session-foreground',
+        source: 'startup',
+        budgetMs: 50,
+        action: async () => { throw new Error('boom'); },
+        writeStdout: false,
+        stdout: out.stdout,
+      });
+      assert.equal(result.ok, false);
+      assert.equal(out.read(), '');
     } finally {
       out.cleanup();
     }

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -8,6 +8,7 @@
 
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { formatSection } from '../../comm-bridge/scripts/session-format.js';
 
 export const DEFAULT_TOTAL_BUDGET_MS = 17_000;
 export const STEP_BUDGETS_MS = {
@@ -134,6 +135,16 @@ export async function runStep({
   } catch (error) {
     const timedOut = /timed out/.test(String(error?.message || error));
     console.error(`[session-start-orchestrator] step "${name}" ${timedOut ? 'timed out' : 'failed'} (${Date.now() - startMs}ms): ${error?.message || error}`);
+    // For context-producing steps, make the failure visible in the injected
+    // stream instead of silently dropping the section — otherwise a failed
+    // step reads as "this context simply doesn't exist".
+    if (writeStdout) {
+      const notice = formatSection(
+        `${name.toUpperCase()} UNAVAILABLE`,
+        `session-start step "${name}" ${timedOut ? 'timed out' : 'failed'}: ${error?.message || error}`,
+      );
+      writeAllSync(stdout.fd ?? 1, `${notice}\n`, { writeSync });
+    }
     await logStep({
       name,
       source,

--- a/skills/comm-bridge/scripts/__tests__/c4-session-init-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-session-init-cli.test.js
@@ -63,8 +63,27 @@ describe('c4-session-init', () => {
 
       const { stdout, status } = cli([], env);
       assert.equal(status, 0);
+      assert.ok(stdout.includes('=== LAST CHECKPOINT SUMMARY ==='));
+      assert.ok(stdout.includes('=== END LAST CHECKPOINT SUMMARY ==='));
       assert.ok(stdout.includes('Synced first batch'));
       assert.ok(stdout.includes('msg2'));
+    });
+  });
+
+  it('emits a fallback block when the last checkpoint has no summary', () => {
+    withTmpDir(({ env }) => {
+      receive(['--channel', 'system', '--no-reply', '--content', 'msg1'], env);
+      // Checkpoint created without --summary → summary is null.
+      checkpoint(['create', '1'], env);
+      receive(['--channel', 'system', '--no-reply', '--content', 'msg2'], env);
+
+      const { stdout, status } = cli([], env);
+      assert.equal(status, 0);
+      // The checkpoint block must still appear (not silently vanish).
+      assert.ok(stdout.includes('=== LAST CHECKPOINT ==='));
+      assert.ok(stdout.includes('no summary'));
+      // And it must NOT masquerade as a summary block.
+      assert.ok(!stdout.includes('=== LAST CHECKPOINT SUMMARY ==='));
     });
   });
 
@@ -76,11 +95,13 @@ describe('c4-session-init', () => {
 
       const { stdout, status } = cli([], env);
       assert.equal(status, 0);
+      assert.ok(stdout.includes('=== RECENT CONVERSATIONS ==='));
+      assert.ok(stdout.includes('=== END RECENT CONVERSATIONS ==='));
       assert.ok(stdout.includes('msg1'));
       assert.ok(stdout.includes('msg2'));
       assert.ok(stdout.includes('msg3'));
       // Should NOT trigger Memory Sync instruction
-      assert.ok(!stdout.includes('Action Required'));
+      assert.ok(!stdout.includes('ACTION REQUIRED'));
     });
   });
 
@@ -93,13 +114,13 @@ describe('c4-session-init', () => {
 
       const { stdout, status } = cli([], env);
       assert.equal(status, 0);
-      assert.ok(stdout.includes('Action Required'));
+      assert.ok(stdout.includes('=== ACTION REQUIRED ==='));
       assert.ok(stdout.includes('zylos-memory'));
       // Should show limited conversations (SESSION_INIT_RECENT_COUNT = 6)
       assert.ok(stdout.includes('msg31'));
       assert.ok(stdout.includes('msg26'));
       // msg1 should NOT be included (limited to recent)
-      assert.ok(!stdout.includes('[Recent Conversations]\nmsg1') && !stdout.match(/IN \(system\):\nmsg1\n/));
+      assert.ok(!stdout.match(/IN \(system\):\nmsg1\n/));
     });
   });
 });

--- a/skills/comm-bridge/scripts/__tests__/session-format.test.js
+++ b/skills/comm-bridge/scripts/__tests__/session-format.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { formatSection } from '../session-format.js';
+
+describe('formatSection', () => {
+  it('wraps content with matching header and footer', () => {
+    assert.equal(
+      formatSection('BOT IDENTITY', 'I am Zylos'),
+      '=== BOT IDENTITY ===\nI am Zylos\n=== END BOT IDENTITY ===',
+    );
+  });
+
+  it('trims surrounding whitespace in the body', () => {
+    assert.equal(
+      formatSection('X', '\n  hello \n\n'),
+      '=== X ===\nhello\n=== END X ===',
+    );
+  });
+
+  it('renders (empty) for empty, whitespace-only, or nullish content', () => {
+    for (const value of ['', '   \n ', null, undefined]) {
+      assert.equal(formatSection('X', value), '=== X ===\n(empty)\n=== END X ===');
+    }
+  });
+
+  it('preserves multi-line bodies between the header and footer', () => {
+    const out = formatSection('RECENT CONVERSATIONS', 'line1\nline2\nline3');
+    assert.equal(out, '=== RECENT CONVERSATIONS ===\nline1\nline2\nline3\n=== END RECENT CONVERSATIONS ===');
+  });
+});

--- a/skills/comm-bridge/scripts/c4-session-init.js
+++ b/skills/comm-bridge/scripts/c4-session-init.js
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 /**
  * C4 Communication Bridge - Session Init
- * Called by session start hook. Outputs context prompt for Claude Code:
- * - Last checkpoint summary (always)
+ * Called by session start hook. Outputs context prompt for Claude Code as
+ * uniform `=== LABEL ===` blocks (see session-format.js), shared with the
+ * memory injection step so the combined session-start context reads
+ * consistently:
+ * - Last checkpoint (summary if present, else a `(no summary …)` fallback so
+ *   the block never silently disappears when a checkpoint has a null summary)
  * - Unsummarized conversations (all if ≤ threshold, last N if > threshold)
  * - Memory Sync instruction (only if > threshold)
  *
@@ -10,6 +14,7 @@
  */
 
 import { logHookTiming } from './c4-diagnostic.js';
+import { formatSection } from './session-format.js';
 import { fileURLToPath } from 'node:url';
 
 export async function initC4Session() {
@@ -27,17 +32,24 @@ export async function initC4Session() {
 
     const checkpoint = getLastCheckpoint();
     const range = getUnsummarizedRange();
-    const lines = [];
+    const sections = [];
 
-    // Always output last checkpoint summary
-    if (checkpoint?.summary) {
-      lines.push(`[Last Checkpoint Summary] ${checkpoint.summary}`);
-      lines.push('');
+    // Always surface the last checkpoint. Summary present → show it; summary
+    // null → emit a fallback so the block never silently disappears.
+    if (checkpoint) {
+      if (checkpoint.summary) {
+        sections.push(formatSection('LAST CHECKPOINT SUMMARY', checkpoint.summary));
+      } else {
+        sections.push(formatSection(
+          'LAST CHECKPOINT',
+          `(no summary — checkpoint #${checkpoint.id}, ${checkpoint.timestamp})`,
+        ));
+      }
     }
 
     if (range.count === 0) {
-      lines.push('No new conversations since last checkpoint.');
-      return `${lines.join('\n')}\n`;
+      sections.push(formatSection('RECENT CONVERSATIONS', 'No new conversations since last checkpoint.'));
+      return `${sections.join('\n\n')}\n`;
     }
 
     const needsSync = range.count > CHECKPOINT_THRESHOLD;
@@ -47,15 +59,17 @@ export async function initC4Session() {
       ? getUnsummarizedConversations(SESSION_INIT_RECENT_COUNT)
       : getUnsummarizedConversations();
 
-    lines.push('[Recent Conversations]');
-    lines.push(formatConversations(conversations));
+    sections.push(formatSection('RECENT CONVERSATIONS', formatConversations(conversations)));
 
     // If over threshold, append Memory Sync instruction
     if (needsSync) {
-      lines.push(`[Action Required] There are ${range.count} unsummarized conversations (conversation id ${range.begin_id} ~ ${range.end_id}). Please use zylos-memory skill to process them.`);
+      sections.push(formatSection(
+        'ACTION REQUIRED',
+        `There are ${range.count} unsummarized conversations (conversation id ${range.begin_id} ~ ${range.end_id}). Please use zylos-memory skill to process them.`,
+      ));
     }
 
-    return `${lines.join('\n')}\n`;
+    return `${sections.join('\n\n')}\n`;
   } catch (err) {
     const wrapped = new Error(`Error in session init: ${err.message}`);
     wrapped.cause = err;

--- a/skills/comm-bridge/scripts/session-format.js
+++ b/skills/comm-bridge/scripts/session-format.js
@@ -1,0 +1,25 @@
+/**
+ * Shared formatter for session-start context injection.
+ *
+ * Both memory injection (zylos-memory/session-start-inject.js) and C4 session
+ * init (comm-bridge/c4-session-init.js) emit labeled blocks into the same
+ * stdout stream consumed at session start. Historically each script had its
+ * own ad-hoc style (`=== LABEL ===` header-only vs `[Bracket Label]`), so the
+ * combined injection read inconsistently. This module is the single source of
+ * truth for that framing so every section looks the same.
+ *
+ * The orchestrator (activity-monitor/session-start-orchestrator.js) also uses
+ * it to render visible failure notices when a context step fails.
+ */
+
+/**
+ * Wrap a labeled section with a matching header and footer.
+ *
+ * @param {string} label   - Section label, rendered verbatim. Convention: UPPERCASE.
+ * @param {string} content - Section body. Trimmed; nullish/empty renders as `(empty)`.
+ * @returns {string} `=== LABEL ===\n<content>\n=== END LABEL ===`
+ */
+export function formatSection(label, content) {
+  const body = (content == null ? '' : String(content)).trim();
+  return `=== ${label} ===\n${body.length > 0 ? body : '(empty)'}\n=== END ${label} ===`;
+}

--- a/skills/zylos-memory/scripts/session-start-inject.js
+++ b/skills/zylos-memory/scripts/session-start-inject.js
@@ -9,6 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { MEMORY_DIR } from './shared.js';
+import { formatSection } from '../../comm-bridge/scripts/session-format.js';
 
 let diagnosticModule;
 let diagnosticLoadAttempted = false;
@@ -46,16 +47,8 @@ function readFileSafe(filePath) {
 
 function section(label, filePath) {
   const result = readFileSafe(filePath);
-  const lines = [`=== ${label} ===`];
-
-  if (result.ok) {
-    const text = (result.content || '').trim();
-    lines.push(text.length > 0 ? text : '(empty)');
-  } else {
-    lines.push(`(${result.reason})`);
-  }
-
-  return lines.join('\n');
+  const content = result.ok ? (result.content || '') : `(${result.reason})`;
+  return formatSection(label, content);
 }
 
 export function injectMemory() {


### PR DESCRIPTION
## Background

Howard ran the merged `session-start-orchestrator.js` and noticed the injected context construction was inconsistent: memory sections use `=== XXX ===` (header only, no footer) while C4 sections use `[Recent Conversations]` / `[Last Checkpoint Summary]`. He also asked to confirm the checkpoint-summary extraction — which works, but had a silent-drop edge.

Follow-up to #651 / #668 (the SessionStart orchestrator line). Scope confirmed by Howard ("按建议来").

## What changed

**1. Unified format (core)** — new shared `formatSection(label, content)` in `comm-bridge/scripts/session-format.js`, used by:
- `zylos-memory/session-start-inject.js` (memory sections)
- `comm-bridge/c4-session-init.js` (checkpoint / conversations / action-required)
- `activity-monitor/session-start-orchestrator.js` (failure notices)

Every block is now `=== LABEL ===` … `=== END LABEL ===` (head **and** tail), uppercase labels throughout.

**2. Visible step failures** — `runStep` now writes a visible `=== <STEP> UNAVAILABLE ===` notice to the injected stdout stream when a context-producing step fails or times out, instead of silently dropping the section (the previous behavior is exactly why a failed step read as "this context simply doesn't exist"). Side-effect steps (foreground/prompt) stay silent on stdout as before.

**3. Checkpoint null-summary fallback** — when a checkpoint exists but `summary` is null, emit `=== LAST CHECKPOINT ===\n(no summary — checkpoint #id, ts)` so the block never silently disappears.

## Dependency direction

`session-format.js` lives in comm-bridge (the most foundational of the three skills — zylos-memory already imports comm-bridge's `c4-diagnostic.js`, and the orchestrator already imports from comm-bridge). comm-bridge itself gains no new cross-skill dependency.

## Out of scope

`c4-fetch.js` also emits a `[Last Checkpoint Summary]` line, but that's the Memory-Sync fetch path, not session-start injection — left untouched.

## Tests

- New `session-format.test.js` unit suite (header/footer, trim, empty fallback, multi-line).
- `session-start-orchestrator.test.js`: the 4 tests that asserted silent-drop now assert the visible failure notice; +2 unit tests (writeStdout step emits notice; side-effect step stays silent).
- `c4-session-init-cli.test.js`: updated for the new uppercase labels + footers; new null-summary fallback test.
- Full suite green: **Jest 111/111, Node 587/587**.
- Real-system smoke: memory + C4 both render uniform `=== LABEL ===`/`=== END ===`, null-summary fallback renders `(no summary — checkpoint #N, ts)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)