### PR TITLE
fix: lower Memory Sync checkpoint threshold 30→15 + single source of truth (#673)

### DIFF
--- a/skills/activity-monitor/scripts/context-monitor.js
+++ b/skills/activity-monitor/scripts/context-monitor.js
@@ -19,6 +19,7 @@ import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { CHECKPOINT_THRESHOLD } from '../../comm-bridge/scripts/c4-config.js';
 
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const AM_DIR = path.join(ZYLOS_DIR, 'activity-monitor');
@@ -38,7 +39,7 @@ const COOLDOWN_SECONDS = 300;   // Re-trigger after 5 minutes if still above thr
 // completes in the background before new-session fires.
 const MEMORY_SYNC_RATIO = 0.8;
 const MEMORY_SYNC_THRESHOLD = Math.round(RESTART_THRESHOLD * MEMORY_SYNC_RATIO);
-const CHECKPOINT_THRESHOLD = 30;  // must match c4-config.js CHECKPOINT_THRESHOLD
+// CHECKPOINT_THRESHOLD imported from c4-config.js (single source of truth).
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
 
 function readThresholdFromConfig() {

--- a/skills/activity-monitor/scripts/monitor.js
+++ b/skills/activity-monitor/scripts/monitor.js
@@ -147,6 +147,7 @@ import {
 } from './adapters/runtime-components.js';
 import { createActivityMonitorTaskScheduler } from './tasks/activity-monitor-tasks.js';
 import { readTmuxInputState } from '../../comm-bridge/scripts/tmux-input-state.js';
+import { CHECKPOINT_THRESHOLD } from '../../comm-bridge/scripts/c4-config.js';
 // activity-monitor runs as a deployed skill at ~/zylos/.claude/skills/activity-monitor/scripts/.
 // A relative import to cli/lib/runtime/ resolves correctly in the repo (dev) but NOT from
 // the deployed path — the CLI lives in the globally installed zylos npm package.
@@ -565,7 +566,7 @@ function getTmuxActivity() {
   }
 }
 
-const CHECKPOINT_THRESHOLD = 30;  // must match c4-config.js CHECKPOINT_THRESHOLD
+// CHECKPOINT_THRESHOLD imported from c4-config.js (single source of truth).
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
 let lastMemorySyncTriggerAt = 0;
 

--- a/skills/comm-bridge/scripts/__tests__/c4-session-init-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-session-init-cli.test.js
@@ -107,7 +107,7 @@ describe('c4-session-init', () => {
 
   it('triggers Memory Sync instruction when over threshold', () => {
     withTmpDir(({ env }) => {
-      // CHECKPOINT_THRESHOLD is 30; insert 31 messages
+      // CHECKPOINT_THRESHOLD is 15; insert 31 messages (well over threshold)
       for (let i = 1; i <= 31; i++) {
         receive(['--channel', 'system', '--no-reply', '--content', `msg${i}`], env);
       }

--- a/skills/comm-bridge/scripts/c4-config.js
+++ b/skills/comm-bridge/scripts/c4-config.js
@@ -54,7 +54,10 @@ export const PENDING_CHANNELS_FILE = path.join(ACTIVITY_MONITOR_DIR, 'pending-ch
 export const ATTACHMENTS_DIR = path.join(DATA_DIR, 'attachments');
 export const SKILLS_DIR = path.join(ZYLOS_DIR, '.claude', 'skills');
 
-export const CHECKPOINT_THRESHOLD = 30;      // unsummarized conversation count to trigger Memory Sync
+// Single source of truth for the Memory Sync checkpoint threshold (unsummarized
+// conversation count that triggers a sync). Imported by the activity-monitor
+// context-monitor / monitor scripts — do NOT re-declare it as a literal elsewhere.
+export const CHECKPOINT_THRESHOLD = 15;
 export const SESSION_INIT_RECENT_COUNT = 6;  // max conversations returned by session-init when above threshold
 
 export const STALE_STATUS_THRESHOLD = 5000; // ms


### PR DESCRIPTION
## What

- Lower the Memory Sync checkpoint threshold **30 → 15**.
- Eliminate the **three** hardcoded copies of `CHECKPOINT_THRESHOLD` (`c4-config.js`, `context-monitor.js`, `monitor.js`) → single source of truth in `c4-config.js`, imported by the two activity-monitor files.

## Why

`CHECKPOINT_THRESHOLD` does double duty:
1. **Session-start injection** — under threshold, *all* unsummarized messages are injected verbatim (up to 30 raw messages with `reply via:` boilerplate, on top of identity/state/references). 30 is too large.
2. **Early in-session sync** — fires when context is in `[round(new_session_threshold×0.8), new_session_threshold)` and unsummarized > threshold.

Lowering to 15 ~halves worst-case session-start injection while preserving the invariant that the agent always sees every message not yet folded into a checkpoint summary (just a shorter tail). Cost: slightly more frequent Memory Syncs, each a cheap background subagent.

The constant was duplicated with "must match c4-config.js" comments — a silent-divergence hazard. Consolidated to one export; the activity-monitor files import it via the same sibling cross-package path already used for `tmux-input-state.js`. The context-monitor engine (`adapters/runtime-components.js`) is already parameter-driven, no change needed.

## Test

- Jest: 111/111 ✓
- Node: 587/587 ✓
- Existing session-init threshold tests still valid (3 msgs < 15 → no sync; 31 msgs > 15 → sync); stale "is 30" comment updated.

## Notes for reviewer

- `SESSION_INIT_RECENT_COUNT` (6) unchanged.
- Not made config-driven (kept simple); trivial to add later if it needs frequent tuning.

Closes #673
