### PR TITLE
fix: unify hook command format in hooks.json

### DIFF
--- a/cli/lib/codex-hooks.js
+++ b/cli/lib/codex-hooks.js
@@ -81,7 +81,7 @@ export function coreSessionStartCommand(zylosDir) {
     'scripts',
     'session-start-orchestrator.js'
   );
-  return `node ${JSON.stringify(script)}`;
+  return `node ${script}`;
 }
 
 export function isCoreCodexHook(command, zylosDir) {


### PR DESCRIPTION
## Summary
- Remove unnecessary `JSON.stringify()` quoting from `coreSessionStartCommand()` in `codex-hooks.js`
- Before: `node "/home/howard/zylos/.claude/skills/.../session-start-orchestrator.js"` (quoted)
- After: `node /home/howard/zylos/.claude/skills/.../session-start-orchestrator.js` (unquoted, matches dashboard hook format)

One-line change. All 11 codex-hooks tests pass.

Closes #678