### PR TITLE
fix: remove unnecessary path quoting in desiredClaudeHooks

### DIFF
--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -60,7 +60,7 @@ describe('desiredClaudeHooks', () => {
     assert.equal(groups.length, 3);
     for (const group of groups) {
       assert.equal(group.hooks.length, 1);
-      assert.match(group.hooks[0].command, /session-start-orchestrator\.js"/);
+      assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
       assert.equal(path.isAbsolute(extractScriptPath(group.hooks[0].command)), true);
       assert.equal(group.hooks[0].timeout, 20000);
     }

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -52,7 +52,7 @@ export function isCoreManaged(hook) {
 
 function zylosClaudeScript(relativePath) {
   const scriptPath = path.resolve(ZYLOS_DIR, '.claude', relativePath);
-  return `node ${JSON.stringify(scriptPath)}`;
+  return `node ${scriptPath}`;
 }
 
 function commandHook(relativePath, options = {}) {


### PR DESCRIPTION
## Summary
- Remove `JSON.stringify()` wrapping in `zylosClaudeScript()` so hook commands use `node /path/to/script.js` instead of `node "/path/to/script.js"`
- Aligns with #678's format unification — all hooks now use unquoted absolute paths

## Test plan
- [x] 53/53 sync-settings-hooks tests pass
- [x] 599/600 full suite (1 pre-existing failure in runtime-launch.test.js, unrelated)

Closes follow-up to #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)