### PR TITLE
fix(web-console): hide session-handoff messages from console display

### DIFF
--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -232,7 +232,7 @@ function getNewMessages(sinceId) {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = 'web-console' AND id > ?
+      WHERE channel = 'web-console' AND id > ? AND endpoint_id != 'session-handoff'
       ORDER BY timestamp ASC
     `);
     return stmt.all(sinceId).map(cleanMessageForDisplay);
@@ -491,7 +491,7 @@ app.get('/api/conversations', (req, res) => {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = ?
+      WHERE channel = ? AND endpoint_id != 'session-handoff'
       ORDER BY timestamp DESC
       LIMIT ?
     `);
@@ -513,7 +513,7 @@ app.get('/api/conversations/recent', (req, res) => {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = 'web-console'
+      WHERE channel = 'web-console' AND endpoint_id != 'session-handoff'
       ORDER BY timestamp DESC
       LIMIT ?
     `);

--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -232,7 +232,7 @@ function getNewMessages(sinceId) {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = 'web-console' AND id > ? AND endpoint_id != 'session-handoff'
+      WHERE channel = 'web-console' AND id > ? AND endpoint_id IS NOT 'session-handoff'
       ORDER BY timestamp ASC
     `);
     return stmt.all(sinceId).map(cleanMessageForDisplay);
@@ -491,7 +491,7 @@ app.get('/api/conversations', (req, res) => {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = ? AND endpoint_id != 'session-handoff'
+      WHERE channel = ? AND endpoint_id IS NOT 'session-handoff'
       ORDER BY timestamp DESC
       LIMIT ?
     `);
@@ -513,7 +513,7 @@ app.get('/api/conversations/recent', (req, res) => {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = 'web-console' AND endpoint_id != 'session-handoff'
+      WHERE channel = 'web-console' AND endpoint_id IS NOT 'session-handoff'
       ORDER BY timestamp DESC
       LIMIT ?
     `);


### PR DESCRIPTION
## Problem
Fixes #621. Session-handoff notes (`channel=web-console, endpoint=session-handoff`) are internal continuity messages, but the web console renders every row on the `web-console` channel — task state, pending work, and internal IDs are visible to any client viewing the console.

## Fix
Exclude `endpoint_id = 'session-handoff'` from the three display query paths in `server.js`:
- `getNewMessages()` — feeds both the WebSocket broadcast and `/api/poll`
- `GET /api/conversations`
- `GET /api/conversations/recent`

The handoff row stays persisted in c4.db untouched, so next-session startup injection (`c4-session-init` reads the DB directly) is unaffected — only console display changes.

## Note
This fix had been applied live on Luna's install once before but never committed; a later component upgrade silently reverted it (live file was byte-identical to repo when re-checked). Landing it in the repo closes that loop.

## Verification
Deployed live on Luna: authenticated `/api/conversations/recent?limit=200` returns 0 handoff messages (was showing them before), normal console messages unaffected, WS/poll path uses the same filtered query. Handoff rows still present in c4.db (205 rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)