### PR TITLE
chore(release): v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-07-02
+
+### Added
+- **SessionStart hook orchestrator**: all SessionStart hooks consolidated into a single orchestrator script. (#651, #668)
+
+### Fixed
+- **Session-start context format**: unified context injection format across runtimes; hook failures and null checkpoint summaries are now surfaced instead of silently swallowed. (#671)
+- **Memory Sync checkpoint threshold**: lowered 30 → 15 with a single source of truth for the value. (#674)
+- **Codex bootstrap via native SessionStart hook**: Codex bootstrap migrated to the native SessionStart hook, and a kick message is sent after Codex launch to trigger it. (#652, #675, #680, #681)
+- **Claude hooks generated at runtime**: `sync-settings-hooks.js` is now the sole source of Claude hooks, generating them at runtime instead of from a static template; hook command format unified with unnecessary path quoting removed. (#676, #678, #679, #682, #684)
+- **C4 canonical message storage**: comm-bridge stores full inbound messages and strips `reply via:` routing metadata from DB content. (#618, #685)
+- **Web console session-handoff privacy**: session-handoff messages are excluded from console display queries with NULL-safe filtering. (#621, #687)
+- **Component upgrade PM2 persistence**: `pm2 dump` persisted after component upgrade restart so the process list survives reboot. (#669)
+- **Rate limit detection**: broadened rate-limit detection patterns and reset-time parsing. (#666, #667)
+- **opus[1m] model backfill guard**: backfill skipped when paired with an incompatible `new_session_threshold`. (#662)
+
 ## [0.5.3] - 2026-06-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
## Summary

Version bump + CHANGELOG for the v0.5.4 release, bundling the fixes merged since v0.5.3:

- SessionStart hook orchestrator consolidation (#651, #668) and unified session-start context format (#671)
- Memory Sync checkpoint threshold 30 → 15 (#674)
- Codex bootstrap via native SessionStart hook + post-launch kick message (#652, #675, #680, #681)
- Claude hooks generated at runtime by sync-settings-hooks.js; hook command format unified (#676, #678, #679, #682, #684)
- C4 canonical message storage — full inbound messages, reply-via stripped from DB (#618, #685)
- Web console session-handoff privacy with NULL-safe filtering (#621, #687)
- pm2 dump persisted after component upgrade restart (#669)
- Broader rate-limit detection + reset-time parsing (#666, #667)
- opus[1m] backfill guard (#662)

No code changes in this PR — only `package.json`, `package-lock.json`, `CHANGELOG.md`.

## Release plan (after merge)

1. Tag `v0.5.4` on main + GitHub release with notes from the CHANGELOG
2. Deploy here via `zylos upgrade --self`

🤖 Generated with [Claude Code](https://claude.com/claude-code)