### PR TITLE
C4: first-class void channel for internal messages (#689)

### DIFF
--- a/cli/lib/__tests__/session-handoff.test.js
+++ b/cli/lib/__tests__/session-handoff.test.js
@@ -42,7 +42,7 @@ after(() => {
 });
 
 describe('enqueueNewSession', () => {
-  it('tells Codex to send handoff summaries to the internal web console', () => {
+  it('tells Codex to send handoff summaries to the internal void channel', () => {
     const result = enqueueNewSession({
       ratio: 0.75,
       used: 75_000,
@@ -57,7 +57,8 @@ describe('enqueueNewSession', () => {
     const content = args[args.indexOf('--content') + 1];
 
     assert.match(content, /do not skip checklist steps/);
-    assert.match(content, /internal web-console channel/);
+    assert.match(content, /internal void channel/);
+    assert.match(content, /c4-send "void" "session-handoff"/);
     assert.match(content, /do not post it to the active external user channel/);
   });
 });

--- a/cli/lib/runtime/session-handoff.js
+++ b/cli/lib/runtime/session-handoff.js
@@ -41,7 +41,7 @@ export function enqueueNewSession({ ratio = 0, used = 0, ceiling = 0, runtime = 
     `(${used.toLocaleString()} / ${ceiling.toLocaleString()} tokens), ` +
     'exceeding threshold.';
   const content = runtime === 'codex'
-    ? `${base} Run $new-session now and follow SKILL.md in order. Write/send the session handoff summary before the final session-switch command; do not skip checklist steps. Send the full session handoff summary only to the internal web-console channel; do not post it to the active external user channel.`
+    ? `${base} Run $new-session now and follow SKILL.md in order. Write/send the session handoff summary before the final session-switch command; do not skip checklist steps. Send the full session handoff summary only to the internal void channel (c4-send "void" "session-handoff"); do not post it to the active external user channel.`
     : `${base} Use the new-session skill to start a fresh session.`;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {

--- a/skills/comm-bridge/references/c4-send.md
+++ b/skills/comm-bridge/references/c4-send.md
@@ -53,6 +53,16 @@ C4MSG
 
 **Note**: Endpoint structure depends on the channel implementation. Some channels use multi-part endpoints with pipe-separated values. Always quote multi-part endpoints as a single argument.
 
+## The `void` Channel (internal-only messages)
+
+`void` is a virtual channel for internal memos (e.g. session handoffs). Messages sent to it are recorded in c4.db like any other conversation row — so session-start context injection and Memory Sync pick them up — but they are **never dispatched** to any channel send script, and display surfaces (web console, etc.) never show them. The endpoint carries the purpose/topic and is **mandatory**:
+
+```bash
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "void" "session-handoff"
+Handoff summary for the next session...
+EOF
+```
+
 ## Channel Interface Contract
 
 Channels are skills installed in `~/zylos/.claude/skills/`. Each channel must provide:

--- a/skills/comm-bridge/scripts/__tests__/c4-db-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-db-cli.test.js
@@ -51,3 +51,27 @@ describe('c4-db recent', () => {
     });
   });
 });
+
+describe('void channel migration (#689)', () => {
+  it('re-tags legacy web-console session-handoff rows to the void channel', () => {
+    withTmpDir(({ env }) => {
+      // Seed legacy rows. The migration runs when the DB is opened, so rows
+      // inserted here keep their legacy shape until the next invocation.
+      assert.equal(dbCli(['insert', 'out', 'web-console', 'session-handoff', 'handoff note'], env).status, 0);
+      assert.equal(dbCli(['insert', 'out', 'web-console', 'console', 'normal console message'], env).status, 0);
+      assert.equal(dbCli(['insert', 'out', 'telegram', 'session-handoff', 'not a web-console row'], env).status, 0);
+
+      // Any subsequent DB open runs the migration before reads.
+      const { stdout, status } = dbCli(['recent', '10'], env);
+      assert.equal(status, 0);
+
+      const rows = JSON.parse(stdout);
+      const byContent = (content) => rows.find((row) => row.content === content);
+
+      assert.equal(byContent('handoff note').channel, 'void');
+      assert.equal(byContent('handoff note').endpoint_id, 'session-handoff');
+      assert.equal(byContent('normal console message').channel, 'web-console');
+      assert.equal(byContent('not a web-console row').channel, 'telegram');
+    });
+  });
+});

--- a/skills/comm-bridge/scripts/__tests__/c4-send-cli.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-send-cli.test.js
@@ -7,14 +7,27 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const CLI_PATH = fileURLToPath(new URL('../c4-send.js', import.meta.url));
+const DB_CLI_PATH = fileURLToPath(new URL('../c4-db.js', import.meta.url));
 
-function cli(args, env = {}) {
+function cli(args, env = {}, input = undefined) {
   const result = spawnSync('node', [CLI_PATH, ...args], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    timeout: 5000,
+    ...(input !== undefined ? { input } : {})
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+}
+
+function dbRecent(env, limit = 10) {
+  const result = spawnSync('node', [DB_CLI_PATH, 'recent', String(limit)], {
     env: { ...process.env, ...env },
     encoding: 'utf8',
     timeout: 5000
   });
-  return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+  // Skip the "[C4-DB] Database initialized" banner printed on first open.
+  const json = result.stdout.split('\n').filter((line) => !line.startsWith('[C4-DB]')).join('\n');
+  return JSON.parse(json);
 }
 
 function withTmpDir(fn) {
@@ -105,6 +118,63 @@ describe('c4-send validation', () => {
       const { stderr, status } = cli(['fake-channel', 'Hello'], env);
       assert.equal(status, 1);
       assert.ok(stderr.includes('Channel script not found'));
+    });
+  });
+});
+
+// -- void channel (#689) --
+
+describe('c4-send void channel', () => {
+  it('records the message in c4.db and exits 0 without a skill directory', () => {
+    withTmpDir(({ env }) => {
+      const { stdout, status } = cli(['void', 'session-handoff', 'handoff summary'], env);
+      assert.equal(status, 0);
+      assert.ok(stdout.includes('recorded on void channel'));
+      assert.ok(!stdout.includes('Message sent via'));
+
+      const rows = dbRecent(env);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].direction, 'out');
+      assert.equal(rows[0].channel, 'void');
+      assert.equal(rows[0].endpoint_id, 'session-handoff');
+      assert.equal(rows[0].content, 'handoff summary');
+      assert.equal(rows[0].status, 'delivered');
+    });
+  });
+
+  it('does not spawn a channel send script even if one exists', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      const sentFile = setupMockChannel(tmpDir, 'void');
+
+      const { status } = cli(['void', 'session-handoff', 'handoff summary'], env);
+      assert.equal(status, 0);
+      assert.ok(!fs.existsSync(sentFile), 'void must never dispatch to a send script');
+    });
+  });
+
+  it('supports stdin/heredoc message input', () => {
+    withTmpDir(({ env }) => {
+      const message = 'multi-line handoff\nwith "quotes" and $vars';
+      const { stdout, status } = cli(['void', 'session-handoff'], env, message);
+      assert.equal(status, 0);
+      assert.ok(stdout.includes('recorded on void channel'));
+
+      const rows = dbRecent(env);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].channel, 'void');
+      assert.equal(rows[0].content, message);
+    });
+  });
+
+  it('rejects a void send without an endpoint', () => {
+    withTmpDir(({ env }) => {
+      // --stdin with a single arg is the only reachable no-endpoint form
+      const { stderr, status } = cli(['void', '--stdin'], env, 'orphan message');
+      assert.equal(status, 1);
+      assert.ok(stderr.includes('Endpoint is required for the void channel'));
+
+      const rows = dbRecent(env);
+      assert.equal(rows.length, 0);
     });
   });
 });

--- a/skills/comm-bridge/scripts/c4-db.js
+++ b/skills/comm-bridge/scripts/c4-db.js
@@ -41,6 +41,7 @@ export function getDb() {
     ensureConversationsSchema(db);
     ensureControlQueueSchema(db);
     ensureStatusNoticeCooldownSchema(db);
+    ensureVoidChannelMigration(db);
   }
   return db;
 }
@@ -101,6 +102,21 @@ function ensureConversationsSchema(database) {
   if (!columnNames.has('delivery_action')) {
     database.exec('ALTER TABLE conversations ADD COLUMN delivery_action TEXT');
   }
+}
+
+/**
+ * #689: session-handoff summaries used to be piggybacked on the web-console
+ * channel (channel='web-console', endpoint_id='session-handoff'). They now
+ * live on the internal record-only 'void' channel; re-tag existing rows so
+ * display surfaces no longer need endpoint-name special cases. Idempotent —
+ * once re-tagged, no rows match.
+ */
+function ensureVoidChannelMigration(database) {
+  database.prepare(`
+    UPDATE conversations
+    SET channel = 'void'
+    WHERE channel = 'web-console' AND endpoint_id = 'session-handoff'
+  `).run();
 }
 
 function ensureStatusNoticeCooldownSchema(database) {

--- a/skills/comm-bridge/scripts/c4-send.js
+++ b/skills/comm-bridge/scripts/c4-send.js
@@ -14,6 +14,15 @@
  *
  * When no message argument is provided, the message is read from stdin.
  * This avoids shell escaping issues with quotes and special characters.
+ *
+ * Special channel 'void' (#689): internal-only messages (e.g. session
+ * handoffs). The message is recorded in c4.db like any other conversation
+ * row — so session-init context injection and Memory Sync pick it up — but
+ * it is never dispatched to a channel send script. The endpoint carries the
+ * purpose/topic and is mandatory, e.g.:
+ *   node c4-send.js void session-handoff <<'EOF'
+ *   ...handoff summary...
+ *   EOF
  */
 
 import path from 'path';
@@ -87,6 +96,37 @@ async function main() {
   if (!message) {
     console.error('Error: Message is required');
     process.exit(1);
+  }
+
+  // Virtual 'void' channel (#689): record-only, never dispatched.
+  // No skill directory exists for it, so skip channel-path validation and
+  // the channel send script entirely.
+  if (channel === 'void') {
+    if (!endpoint) {
+      console.error('Error: Endpoint is required for the void channel (e.g. c4-send.js void session-handoff)');
+      process.exit(1);
+    }
+
+    try {
+      validateEndpoint(endpoint);
+    } catch (err) {
+      console.error(`[C4] Invalid endpoint: ${err.stack}`);
+      process.exit(1);
+    }
+
+    try {
+      insertConversation('out', 'void', endpoint, message);
+    } catch (err) {
+      // Unlike real channels (where the DB row is an audit trail), the DB
+      // write IS the delivery for void — fail loudly.
+      console.error(`[C4] Failed to record void message: ${err.stack}`);
+      process.exit(1);
+    } finally {
+      close();
+    }
+
+    console.log('[C4] Message recorded on void channel (not dispatched)');
+    process.exit(0);
   }
 
   try {

--- a/skills/new-session/SKILL.md
+++ b/skills/new-session/SKILL.md
@@ -45,16 +45,18 @@ Write a brief message covering:
 
 ### 3. Send the handoff summary
 
-Send the full handoff summary to the internal web console channel via C4:
+Send the full handoff summary to the internal `void` channel via C4:
 
 ```bash
-cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "web-console" "session-handoff"
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "void" "session-handoff"
 <handoff summary>
 EOF
 ```
 
-This records the handoff in C4 conversation history so the new session's
-startup hook (`c4-session-init`) can include it in startup context.
+The `void` channel is record-only: the message is stored in C4 conversation
+history (so the new session's startup hook, `c4-session-init`, includes it in
+startup context) but is never delivered to any real channel or display
+surface.
 
 Do not send the full handoff summary to the active external user channel
 (Telegram, Lark, Feishu, HXA, etc.). Handoff summaries are operational context

--- a/skills/restart-claude/SKILL.md
+++ b/skills/restart-claude/SKILL.md
@@ -35,16 +35,18 @@ Write a brief message covering:
 
 ### 4. Send the handoff summary
 
-Send the full handoff summary to the internal web console channel via C4:
+Send the full handoff summary to the internal `void` channel via C4:
 
 ```bash
-cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "web-console" "session-handoff"
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "void" "session-handoff"
 <handoff summary>
 EOF
 ```
 
-This records the handoff in C4 conversation history so the restarted session's
-startup hook (`c4-session-init`) can include it in startup context.
+The `void` channel is record-only: the message is stored in C4 conversation
+history (so the restarted session's startup hook, `c4-session-init`, includes
+it in startup context) but is never delivered to any real channel or display
+surface.
 
 Do not send the full handoff summary to the active external user channel
 (Telegram, Lark, Feishu, HXA, etc.). Handoff summaries are operational context

--- a/skills/upgrade-claude/SKILL.md
+++ b/skills/upgrade-claude/SKILL.md
@@ -34,16 +34,18 @@ Write a brief message covering:
 
 ### 4. Send the handoff summary
 
-Send the full handoff summary to the internal web console channel via C4:
+Send the full handoff summary to the internal `void` channel via C4:
 
 ```bash
-cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "web-console" "session-handoff"
+cat <<'EOF' | node ~/zylos/.claude/skills/comm-bridge/scripts/c4-send.js "void" "session-handoff"
 <handoff summary>
 EOF
 ```
 
-This records the handoff in C4 conversation history so the upgraded session's
-startup hook (`c4-session-init`) can include it in startup context.
+The `void` channel is record-only: the message is stored in C4 conversation
+history (so the upgraded session's startup hook, `c4-session-init`, includes
+it in startup context) but is never delivered to any real channel or display
+surface.
 
 Do not send the full handoff summary to the active external user channel
 (Telegram, Lark, Feishu, HXA, etc.). Handoff summaries are operational context

--- a/skills/web-console/scripts/server.js
+++ b/skills/web-console/scripts/server.js
@@ -232,7 +232,7 @@ function getNewMessages(sinceId) {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = 'web-console' AND id > ? AND endpoint_id IS NOT 'session-handoff'
+      WHERE channel = 'web-console' AND id > ?
       ORDER BY timestamp ASC
     `);
     return stmt.all(sinceId).map(cleanMessageForDisplay);
@@ -488,10 +488,12 @@ app.get('/api/conversations', (req, res) => {
     const limit = parseInt(req.query.limit) || 50;
     const channel = req.query.channel || 'web-console';
 
+    // channel is caller-controlled; 'void' is the internal record-only
+    // channel (#689) and must never reach a display surface.
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = ? AND endpoint_id IS NOT 'session-handoff'
+      WHERE channel = ? AND channel != 'void'
       ORDER BY timestamp DESC
       LIMIT ?
     `);
@@ -513,7 +515,7 @@ app.get('/api/conversations/recent', (req, res) => {
     const stmt = db.prepare(`
       SELECT id, direction, channel, endpoint_id, content, timestamp
       FROM conversations
-      WHERE channel = 'web-console' AND endpoint_id IS NOT 'session-handoff'
+      WHERE channel = 'web-console'
       ORDER BY timestamp DESC
       LIMIT ?
     `);

--- a/test/web-console-routes.test.js
+++ b/test/web-console-routes.test.js
@@ -315,6 +315,36 @@ describe('web-console attachment routes', () => {
     expect(traversal.status).toBe(404);
   });
 
+  test('display queries exclude void channel rows (#689)', async () => {
+    ctx = await startServer();
+
+    const db = new Database(ctx.dbPath);
+    const insert = db.prepare('INSERT INTO conversations (direction, channel, endpoint_id, content, timestamp) VALUES (?, ?, ?, ?, ?)');
+    insert.run('out', 'web-console', 'console', 'visible console message', new Date().toISOString());
+    insert.run('out', 'web-console', null, 'null endpoint stays visible', new Date().toISOString());
+    insert.run('out', 'void', 'session-handoff', 'internal handoff summary', new Date().toISOString());
+    db.close();
+
+    // /api/conversations/recent is scoped to web-console — void rows never appear.
+    const recentRes = await fetch(`${ctx.baseUrl}/api/conversations/recent?limit=50`);
+    expect(recentRes.status).toBe(200);
+    const recentContents = (await recentRes.json()).map((row) => row.content);
+    expect(recentContents).toContain('visible console message');
+    expect(recentContents).toContain('null endpoint stays visible');
+    expect(recentContents).not.toContain('internal handoff summary');
+
+    // The parameterized channel query must not expose void even when asked directly.
+    const voidRes = await fetch(`${ctx.baseUrl}/api/conversations?channel=void&limit=50`);
+    expect(voidRes.status).toBe(200);
+    expect(await voidRes.json()).toEqual([]);
+
+    // Default channel query still returns web-console traffic.
+    const defaultRes = await fetch(`${ctx.baseUrl}/api/conversations?limit=50`);
+    const defaultContents = (await defaultRes.json()).map((row) => row.content);
+    expect(defaultContents).toContain('visible console message');
+    expect(defaultContents).not.toContain('internal handoff summary');
+  });
+
   test('GET /api/conversations/recent includes inbound image href', async () => {
     ctx = await startServer();
     const mediaDir = path.join(ctx.root, 'web-console', 'media');


### PR DESCRIPTION
## What / Why

Implements #689. Session-handoff summaries were piggybacked on the web-console channel, and #687 (fixing #621) hid them with `endpoint_id IS NOT 'session-handoff'` filters on each display query — an endpoint-name special case every current and future display surface must remember. This PR models the message correctly: an internal memo goes to a virtual **`void` channel** that is recorded in c4.db but never dispatched or displayed.

Refs #687, #621, #619.

## Implementation

1. **`skills/comm-bridge/scripts/c4-send.js`** — `channel === 'void'` is special-cased: endpoint is validated and **mandatory** (per #619; it carries the purpose/topic, e.g. `session-handoff`), the row is written via `insertConversation('out', 'void', endpoint, message)`, success is printed, exit 0. The `skills/<channel>/scripts/send.js` spawn is skipped entirely (void has no skill dir), as is the skill-directory channel validation. Stdin/heredoc message input works unchanged. Unlike real channels (where the DB row is an audit trail and write failure is a warning), a failed DB write for void exits 1 — the DB write *is* the delivery. Documented in `references/c4-send.md`.
2. **`cli/lib/runtime/session-handoff.js`** — the Codex rotation prompt now instructs `c4-send "void" "session-handoff"`. The same handoff-send step was updated in `skills/new-session/SKILL.md`, and also in `skills/restart-claude/SKILL.md` and `skills/upgrade-claude/SKILL.md`, which contain the identical `c4-send "web-console" "session-handoff"` block (all three are the handoff senders listed in #621).
3. **`skills/web-console/scripts/server.js`** — reverted the three `endpoint_id IS NOT 'session-handoff'` filters from #687 (`getNewMessages`, `/api/conversations`, `/api/conversations/recent`). Audit of the parameterized query: `/api/conversations` takes `req.query.channel` (caller-controlled, arbitrary channels), so it now carries `AND channel != 'void'` — a single channel-level rule instead of endpoint-name matching. The other two queries are hard-scoped to `channel = 'web-console'` and can never see void rows.
4. **Session-start / Memory Sync verification** (see findings below).
5. **Migration** — `ensureVoidChannelMigration()` in `c4-db.js`, following the repo's existing migration pattern (the `ensure*` functions that run on every `getDb()` open, same as `ensureConversationsSchema` / `ensureControlQueueSchema`): re-tags `channel='web-console' AND endpoint_id='session-handoff'` rows to `channel='void'`. Idempotent — once re-tagged, no rows match.

## Step-4 verification findings

The mechanism that carries handoffs into the next session is channel-agnostic, so void rows flow through unchanged:

- **Session-start context injection**: `c4-session-init.js` → `getUnsummarizedRange()` / `getUnsummarizedConversations()` in `c4-db.js` — both query `WHERE id > ?` (checkpoint boundary) with **no channel filter**. Void rows are included.
- **Memory Sync**: `zylos-memory/SKILL.md` fetches via `c4-fetch.js --unsummarized` / `--begin/--end` → `getUnsummarizedConversations()` / `getConversationsByRange()` — `WHERE id >= ? AND id <= ?`, **no channel filter**. Void rows are included.
- `getRecentConversations()` (debug/CLI `recent`) also has no channel filter.
- The C4 dispatcher only delivers `direction='in' AND status='pending'` rows; void rows are `direction='out', status='delivered'`, so nothing tries to deliver them. No query needed fixing.

## Notes / deviations from the issue sketch

- **"Legacy re-tagged rows" in the migration**: I checked PR #687 (body, commits, review comments) and issue #621 for a distinct legacy row shape — none is documented; #687 explicitly left all rows untouched (`channel='web-console', endpoint_id='session-handoff'`, 205 rows live). The migration therefore targets exactly that shape, which also covers any rows previously re-tagged *to* it. Handoff-endpoint rows on real user channels (pre-#571 behavior allowed sending handoffs to the active user channel) are genuine deliveries and are deliberately **not** re-tagged.
- The endpoint-missing error path is only reachable via the `--stdin`/1-arg form, because the current arg parser (pre-#619) maps every ≥2-arg form to an endpoint or errors earlier; the guard is in place for when #619 lands.

## Tests

New tests (matching existing styles in each suite):
- `c4-send-cli.test.js` (comm-bridge node:test): void records row in c4.db and exits 0 with no skill dir; never spawns a send script even if a `skills/void/scripts/send.js` exists; stdin/heredoc input; rejects void without endpoint (nothing written).
- `c4-db-cli.test.js`: migration re-tags legacy `web-console`/`session-handoff` rows to `void`, leaves normal web-console rows and non-web-console channels alone.
- `test/web-console-routes.test.js` (jest): display queries exclude void rows, NULL-endpoint rows stay visible, `?channel=void` returns `[]`.
- `cli/lib/__tests__/session-handoff.test.js`: rotation prompt now asserts `internal void channel` + `c4-send "void" "session-handoff"`.

Results:
- `npm run test:node`: **599 pass / 1 fail (600 total)** — the single failure (`runtime-launch.test.js` › "launch spec does not contain the retired text bootstrap prompt") is identical on clean `origin/main` (c5b4745) and unrelated to this change (Codex kick-message, see branch `fix/680-codex-kick-message`).
- `npm run test:jest`: **112/112 pass** (includes the new web-console void test).
- comm-bridge skill suite (`node --test scripts/__tests__/*.test.js`): **233 pass / 3 fail (236 total)** — the 3 failures are pre-existing on `origin/main` and are exactly the c4-send stdin-ambiguity bugs documented in open issue #619 (broadcast form misreads args under non-TTY stdin); out of scope here. All 6 new void/migration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)