### PR TITLE
feat(zylos-memory): content rules + sync-time audit for references.md

### DIFF
--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -74,9 +74,15 @@ exist, report them as historical records and do not create a replacement.
 4. Extract and classify updates from conversations into the correct files.
 5. Write memory updates (always — even without new conversations,
    update `state.md` and `sessions/current.md` with current context).
-6. Create checkpoint (only if conversations were fetched in step 2):
+6. Audit `references.md` against its content rules
+   (`references/references-file-format.md`): relocate rule-violating
+   entries to their routed destination (`reference/decisions.md`,
+   `archive/`, or a pointer to the config file) instead of leaving or
+   appending them. If the file exceeds the 8KB warn threshold
+   (`memory-status.js` reports WARN), trim until it is back under.
+7. Create checkpoint (only if conversations were fetched in step 2):
    `node ~/zylos/.claude/skills/comm-bridge/scripts/c4-checkpoint.js create <end_id> --summary "SUMMARY"`
-7. Confirm completion.
+8. Confirm completion.
 
 ## Classification Rules
 
@@ -86,7 +92,9 @@ exist, report them as historical records and do not create a replacement.
 - `reference/ideas.md`: uncommitted proposals.
 - `users/<id>/profile.md`: user-specific preferences.
 - `state.md`: active focus and pending tasks.
-- `references.md`: pointers only; do not duplicate `.env` values.
+- `references.md`: pointers and stable identifiers only, per the content
+  rules in `references/references-file-format.md`; never duplicate config
+  values, never accumulate narrative history.
 
 ## File Formats and Examples
 
@@ -139,7 +147,9 @@ Review the report and apply these rules:
     Move completed or historical detail to `sessions/current.md` or
     `reference/`.
   - `references.md`: keep pointers and lookup facts only. Move prose,
-    project history, and detailed decisions to `reference/`.
+    project history, and detailed decisions to `reference/`. Apply the
+    content rules in `references/references-file-format.md`; the sync-time
+    audit (Sync Flow step 6) should keep it under the 8KB warn threshold.
 
 ### Session Logs
 - Logs in `archiveCandidatesOlderThan30Days`: move from `sessions/` to `archive/`.

--- a/skills/zylos-memory/references/references-file-format.md
+++ b/skills/zylos-memory/references/references-file-format.md
@@ -11,7 +11,10 @@ Always loaded at session start via SessionStart hook.
 
 ## Size Guideline
 
-~16KB. Pointer/index only, not prose.
+Target ≤8KB (warn threshold, reported as WARN by `memory-status.js`);
+hard budget 16KB. Pointer/index only, not prose. A healthy instance core
+is ~4-5KB — sustained growth past the warn threshold means narrative
+content is leaking in and the content rules below are being violated.
 
 ## Update Frequency
 
@@ -29,11 +32,33 @@ When services or paths change. Not every sync cycle.
 
 See `examples/references.md` for a full example.
 
-## Rules
+## Content Rules
+
+### Allowed
+
+- Stable identifiers: bot/app/member IDs, account handles
+- Endpoints, ports, domains, webhook routes
+- Key paths (memory, skills, data directories)
+- Active policy pointers: `dmPolicy=owner, see config.json`
+- Pointers to source-of-truth files (`.env`, `config.json`, registries)
+
+### Disallowed — route instead of appending
+
+| Content class | Route to |
+|---------------|----------|
+| Version/upgrade history, breaking-change notes | `reference/decisions.md` |
+| Incident caveats, lessons learned | `reference/decisions.md` |
+| Entries for uninstalled/dead components | `archive/` |
+| Values already present in a config file | replace with a pointer |
+
+### Rules
 
 1. NEVER duplicate a value that exists in `.env` or another config file.
 2. Point to the source instead:
    - Instead of `TZ: Asia/Shanghai`, write `TZ: see .env`
    - Instead of listing API keys, write `API keys: see .env`
-3. Keep entries as terse pointers, not explanations.
+3. Keep entries as terse pointers, not explanations. One line per entry;
+   no narrative sentences attached to identifiers.
 4. Active IDs section is for IDs needed in current context only.
+5. Memory Sync audits this file against these rules on every sync
+   (see SKILL.md Sync Flow): violations are relocated, not left in place.

--- a/skills/zylos-memory/scripts/consolidate.js
+++ b/skills/zylos-memory/scripts/consolidate.js
@@ -9,7 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { MEMORY_DIR, SESSIONS_DIR, BUDGETS, REFERENCE_FILES, walkFiles, loadTimezoneFromEnv, dateInTimeZone } from './shared.js';
+import { MEMORY_DIR, SESSIONS_DIR, BUDGETS, WARN_THRESHOLDS, REFERENCE_FILES, walkFiles, loadTimezoneFromEnv, dateInTimeZone } from './shared.js';
 
 export function parseSessionDate(fileName) {
   const match = fileName.match(/^(\d{4}-\d{2}-\d{2})(?:-\d+)?\.md$/);
@@ -57,12 +57,15 @@ function coreBudgetChecks() {
     }
 
     const stat = fs.statSync(filePath);
+    const warnAt = WARN_THRESHOLDS[name] ?? null;
     checks.push({
       file: name,
       exists: true,
       sizeBytes: stat.size,
       budgetBytes: budget,
+      warnBytes: warnAt,
       overBudget: stat.size > budget,
+      nearBudget: warnAt !== null && stat.size > warnAt && stat.size <= budget,
       budgetUsagePct: Math.round((stat.size / budget) * 100),
       modifiedAt: stat.mtime.toISOString()
     });
@@ -114,6 +117,7 @@ function main() {
   const files = walkFiles(MEMORY_DIR);
   const budgetChecks = coreBudgetChecks();
   const overBudget = budgetChecks.filter((item) => item.overBudget).map((item) => item.file);
+  const nearBudget = budgetChecks.filter((item) => item.nearBudget).map((item) => item.file);
 
   const report = {
     timestamp: new Date().toISOString(),
@@ -124,8 +128,10 @@ function main() {
     },
     budgets: {
       rules: BUDGETS,
+      warnThresholds: WARN_THRESHOLDS,
       checks: budgetChecks,
-      overBudget
+      overBudget,
+      nearBudget
     },
     referenceFiles: referenceFileFreshness(),
     sessions: {

--- a/skills/zylos-memory/scripts/memory-status.js
+++ b/skills/zylos-memory/scripts/memory-status.js
@@ -6,7 +6,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { MEMORY_DIR, BUDGETS, walkFiles } from './shared.js';
+import { MEMORY_DIR, BUDGETS, WARN_THRESHOLDS, walkFiles } from './shared.js';
 
 export function formatBytes(bytes) {
   if (bytes < 1024) {
@@ -33,6 +33,7 @@ function main() {
   lines.push('============');
 
   let overBudgetCount = 0;
+  let warnCount = 0;
   let missingCount = 0;
 
   for (const [name, budget] of Object.entries(BUDGETS)) {
@@ -44,9 +45,14 @@ function main() {
     }
 
     const pct = Math.round((info.sizeBytes / budget) * 100);
-    const status = info.sizeBytes > budget ? 'OVER' : 'OK';
-    if (status === 'OVER') {
+    const warnAt = WARN_THRESHOLDS[name];
+    let status = 'OK';
+    if (info.sizeBytes > budget) {
+      status = 'OVER';
       overBudgetCount += 1;
+    } else if (warnAt && info.sizeBytes > warnAt) {
+      status = 'WARN';
+      warnCount += 1;
     }
 
     const modified = info.modifiedAt.toISOString().slice(0, 16).replace('T', ' ');
@@ -63,6 +69,9 @@ function main() {
   const issues = [];
   if (overBudgetCount > 0) {
     issues.push(`${overBudgetCount} over budget`);
+  }
+  if (warnCount > 0) {
+    issues.push(`${warnCount} near budget (audit on next sync)`);
   }
   if (missingCount > 0) {
     issues.push(`${missingCount} missing`);

--- a/skills/zylos-memory/scripts/shared.js
+++ b/skills/zylos-memory/scripts/shared.js
@@ -17,6 +17,13 @@ export const BUDGETS = {
   'references.md': 16 * 1024
 };
 
+// Early-warning thresholds below the hard budget: a file over its warn
+// threshold is still within budget, but must be audited on the next
+// Memory Sync before the always-loaded set bloats (#696).
+export const WARN_THRESHOLDS = {
+  'references.md': 8 * 1024
+};
+
 export const REFERENCE_FILES = [
   'reference/decisions.md',
   'reference/projects.md',

--- a/skills/zylos-memory/scripts/tests/test-shared.js
+++ b/skills/zylos-memory/scripts/tests/test-shared.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { dateInTimeZone, BUDGETS, ZYLOS_DIR, MEMORY_DIR, SESSIONS_DIR } from '../shared.js';
+import { dateInTimeZone, BUDGETS, WARN_THRESHOLDS, ZYLOS_DIR, MEMORY_DIR, SESSIONS_DIR } from '../shared.js';
 import path from 'path';
 
 // ---------------------------------------------------------------------------
@@ -90,6 +90,22 @@ describe('BUDGETS', () => {
     for (const [key, value] of Object.entries(BUDGETS)) {
       assert.equal(typeof value, 'number', `${key} should be a number`);
       assert.ok(value > 0, `${key} should be positive`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WARN_THRESHOLDS
+// ---------------------------------------------------------------------------
+describe('WARN_THRESHOLDS', () => {
+  it('warns for references.md at 8KB', () => {
+    assert.equal(WARN_THRESHOLDS['references.md'], 8 * 1024);
+  });
+
+  it('every warn threshold is below its hard budget', () => {
+    for (const [key, value] of Object.entries(WARN_THRESHOLDS)) {
+      assert.ok(BUDGETS[key] !== undefined, `${key} must also have a hard budget`);
+      assert.ok(value < BUDGETS[key], `${key} warn threshold must be below budget`);
     }
   });
 });

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -112,7 +112,10 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
 1. **At session start:** identity + state + references are auto-injected.
 2. **During work:** Update appropriate memory files immediately when you learn something important.
 3. **Memory Sync:** When triggered, launch a background subagent using the current runtime's supported subagent/task mechanism. The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. This also applies in Codex and in `new-session` handoff flows: do not run Memory Sync inline in the main loop.
-4. **references.md is a pointer file.** Never duplicate .env values in it — point to the source config file instead.
+4. **references.md is a pointer file with strict content rules.**
+   - **Allowed:** stable identifiers (bot/app/member IDs), endpoints and ports, key paths, active policy pointers ("dmPolicy=owner, see config.json"), pointers to source-of-truth files (.env, config.json).
+   - **Disallowed — route instead of appending:** version/upgrade history and breaking-change notes → `reference/decisions.md`; incident caveats and lessons → `reference/decisions.md`; entries for uninstalled/dead components → `archive/`; any value that already lives in a config file → replace with a pointer to that file.
+   - Keep entries terse. Target ≤8KB; Memory Sync audits this file against these rules (see zylos-memory skill).
 
 ### Classification Rules for reference/ Files
 


### PR DESCRIPTION
## Summary

`references.md` is one of the three always-loaded memory files, but the only content rule was "never duplicate `.env` values". Memory Sync kept appending operational narrative to it, and a long-running production instance measured **14KB against a ~4-5KB genuine core** (see #696). With the session-start shard design (#686) giving references its own injection budget, keeping this file lean becomes a structural requirement rather than best-effort hygiene.

This PR adds explicit content rules and a sync-time audit so the file cannot silently regrow:

- **`templates/ZYLOS.md`** — memory section now defines *allowed* content classes (stable identifiers, endpoints/ports, key paths, active policy pointers, pointers to source-of-truth files) and *disallowed* classes with routing: version/upgrade history & breaking-change notes → `reference/decisions.md`; incident caveats/lessons → `reference/decisions.md`; uninstalled/dead components → `archive/`; config-file duplicates → replace with a pointer.
- **`skills/zylos-memory/SKILL.md`** — new Sync Flow step: audit `references.md` against the content rules on every Memory Sync and **relocate violations instead of appending**; trim when over the warn threshold.
- **`skills/zylos-memory/references/references-file-format.md`** — full allowed/disallowed table; target **≤8KB warn** under the existing 16KB hard budget.
- **Scripts** — `WARN_THRESHOLDS` in `shared.js` (references.md at 8KB); `memory-status.js` reports `WARN` between warn threshold and budget; `consolidate.js` report includes `warnThresholds` / `nearBudget` so the sync subagent sees the signal.
- **Tests** — cover the threshold value and the warn-below-budget invariant.

Closes #696

## Relationship to #686

Companion small PR that lands ahead of the shard-implementation main PR. The one-time slimming of live instances (<12KB per #686 AC) is an instance-side action guided by these rules; this PR changes the instructions/tooling so the slimming sticks.

## Test plan

- `node --test skills/zylos-memory/scripts/tests/*.js` — 56/56 pass
- Full `npm test` — only pre-existing environment failures unrelated to this diff (`runtime-launch` fails identically on clean `main`; `session-start-orchestrator` passes standalone, flaky under full-suite load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)