### PR TITLE
feat(session-start): shard injection into per-section hooks with ordered flag chain (fixes #686)

### DIFF
--- a/cli/lib/__tests__/codex-hooks.test.js
+++ b/cli/lib/__tests__/codex-hooks.test.js
@@ -77,8 +77,16 @@ describe('Codex core hook installer', () => {
       group.hooks?.some(h => h.command.includes('session-start-orchestrator.js'))
     );
     assert.ok(coreGroup);
-    assert.equal(coreGroup.hooks[0].timeout, 25);
-    assert.equal(coreGroup.hooks[0].async, undefined);
+    // Codex injects in config order, so the shard commands must appear as
+    // one contiguous group in chain order.
+    assert.deepEqual(
+      coreGroup.hooks.map(h => h.command.match(/--shard (\S+)$/)?.[1]),
+      ['identity', 'references', 'state', 'c4-checkpoint', 'c4-conversations', 'fg', 'start-prompt']
+    );
+    for (const hook of coreGroup.hooks) {
+      assert.equal(hook.timeout, 25);
+      assert.equal(hook.async, undefined);
+    }
     assert.ok(config.hooks.SessionStart.some(group =>
       group.hooks?.some(h => h.command.includes('dashboard/hook-ingest.cjs'))
     ));
@@ -93,10 +101,17 @@ describe('Codex core hook installer', () => {
       { event: 'SessionStart', command: `node ${path.join(zylosDir, '.claude', 'skills', 'activity-monitor', 'scripts', 'session-start-orchestrator.js')}`, timeout: 10 },
     ], null, 2) + '\n');
 
-    installCoreCodexHook({ zylosDir });
+    const installed = installCoreCodexHook({ zylosDir });
+    // Install replaces the retired no-arg command with the shard command set.
+    assert.equal(installed.commands.length, 7);
+    const migrated = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    const migratedCommands = migrated.hooks.SessionStart.flatMap(group => group.hooks.map(h => h.command));
+    assert.equal(migratedCommands.filter(c => c.includes('session-start-orchestrator.js')).length, 7);
+    assert.equal(migratedCommands.some(c => c.includes('session-start-orchestrator.js') && !c.includes('--shard')), false);
+
     const removed = uninstallCoreCodexHook({ zylosDir });
 
-    assert.equal(removed.removed, 1);
+    assert.equal(removed.removed, 7);
     const config = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
     assert.equal(config.hooks.SessionStart.length, 1);
     assert.equal(config.hooks.SessionStart[0].hooks[0].command, 'node /tmp/other.js');

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -17,7 +17,7 @@ const {
   syncTemplateSetting,
   syncTemplateModelSetting,
 } = await import('../sync-settings-hooks.js');
-const { extractScriptPath, getCommandHooks, hookScriptKey } = await import('../hook-utils.js');
+const { extractScriptPath, getCommandHooks, hookScriptKey, hookScriptBaseKey, extractShardArg } = await import('../hook-utils.js');
 const {
   renderCodexGlobalConfig,
   renderCodexProjectConfig,
@@ -53,16 +53,28 @@ describe('Claude settings template', () => {
   });
 });
 
+const CORE_SHARD_SEQUENCE = [
+  'identity',
+  'references',
+  'state',
+  'c4-checkpoint',
+  'c4-conversations',
+  'fg',
+  'start-prompt',
+];
+
 describe('desiredClaudeHooks', () => {
-  it('uses absolute SessionStart orchestrator commands for all matchers', () => {
+  it('uses absolute per-shard SessionStart orchestrator commands for all matchers', () => {
     const hooks = desiredClaudeHooks();
     const groups = hooks.SessionStart;
     assert.equal(groups.length, 3);
     for (const group of groups) {
-      assert.equal(group.hooks.length, 1);
-      assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
-      assert.equal(path.isAbsolute(extractScriptPath(group.hooks[0].command)), true);
-      assert.equal(group.hooks[0].timeout, 20000);
+      assert.deepEqual(group.hooks.map(h => extractShardArg(h.command)), CORE_SHARD_SEQUENCE);
+      for (const hook of group.hooks) {
+        assert.match(hook.command, /session-start-orchestrator\.js --shard /);
+        assert.equal(path.isAbsolute(extractScriptPath(hook.command)), true);
+        assert.equal(hook.timeout, 20000);
+      }
     }
   });
 
@@ -567,9 +579,11 @@ function makeOrchestratorTemplate() {
 function assertSessionStartUsesOrchestrator(settings) {
   assert.equal(settings.hooks.SessionStart.length, 3);
   for (const group of settings.hooks.SessionStart) {
-    assert.equal(group.hooks.length, 1);
-    assert.match(group.hooks[0].command, /session-start-orchestrator\.js/);
-    assert.equal(group.hooks[0].timeout, 20000);
+    const coreHooks = group.hooks.filter(h => h.command?.includes('session-start-orchestrator.js'));
+    assert.deepEqual(coreHooks.map(h => extractShardArg(h.command)), CORE_SHARD_SEQUENCE);
+    for (const hook of coreHooks) {
+      assert.equal(hook.timeout, 20000);
+    }
   }
 }
 
@@ -662,14 +676,16 @@ describe('hookScriptKey', () => {
 });
 
 describe('core hook registry', () => {
-  it('includes every desired command hook', () => {
+  it('includes every desired command hook by base script key', () => {
     const templateKeys = new Set();
 
     for (const groups of Object.values(desiredClaudeHooks())) {
       if (!Array.isArray(groups)) continue;
       for (const group of groups) {
         for (const hook of getCommandHooks(group)) {
-          templateKeys.add(hookScriptKey(hook.command));
+          // Base key: CORE_MANAGED_HOOKS lists bare script paths; every
+          // --shard variant of a core script must map onto one of them.
+          templateKeys.add(hookScriptBaseKey(hook.command));
         }
       }
     }
@@ -710,7 +726,9 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
 
     const result = syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
 
-    assert.deepEqual(result, { added: 10, updated: 0, removed: 12 });
+    // 7 shard/side-effect commands x 3 SessionStart matchers + 7 other-event
+    // hooks added; 4 retired per-step hooks x 3 matchers removed.
+    assert.deepEqual(result, { added: 28, updated: 0, removed: 12 });
     assertSessionStartUsesOrchestrator(installed);
   });
 

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -855,6 +855,128 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
   });
 });
 
+describe('component shard claim boundary (opt-in contract)', () => {
+  const noopLog = () => {};
+
+  function makeDeclaredZylosDir() {
+    const zylosDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shard-claim-test-'));
+    const emitterDir = path.join(zylosDir, '.claude', 'skills', 'role-manager');
+    fs.mkdirSync(emitterDir, { recursive: true });
+    fs.writeFileSync(path.join(emitterDir, 'emit-role.js'), 'export function emit() { return "ROLE"; }\n');
+    const shardsDir = path.join(zylosDir, '.zylos', 'shards.d');
+    fs.mkdirSync(shardsDir, { recursive: true });
+    fs.writeFileSync(path.join(shardsDir, 'role-inject.json'), JSON.stringify({
+      name: 'role-inject',
+      order: 10,
+      emitter: 'skills/role-manager/emit-role.js',
+      claimHooks: ['skills/role-manager/role-inject-hook.sh'],
+    }));
+    return zylosDir;
+  }
+
+  it('claims a declared legacy hook: old entry removed, --shard command generated, chain covers it', async () => {
+    const zylosDir = makeDeclaredZylosDir();
+    const { desiredClaudeHooks: desired, claimedHookBaseKeys } = await import('../sync-settings-hooks.js');
+    const { buildChain } = await import('../../../skills/activity-monitor/scripts/shard-registry.js');
+
+    const installed = {
+      hooks: {
+        SessionStart: [
+          {
+            matcher: 'startup',
+            hooks: [
+              // The component's declared legacy hook (claimed → removed).
+              makeHook(zylosHookPath('skills/role-manager/role-inject-hook.sh'), 10000),
+              // A user hook (never claimed → preserved).
+              makeHook('/custom/my-session-start.js', 5000),
+              // An UNDECLARED component-style hook (not claimed → preserved,
+              // keeps running outside the chain exactly as before).
+              makeHook(zylosHookPath('skills/other-component/scripts/other-hook.js'), 5000),
+            ],
+          },
+        ],
+      },
+    };
+
+    const result = syncHooks(installed, {}, {
+      log: noopLog,
+      desiredHooks: desired({ zylosDir }),
+      claimedKeys: claimedHookBaseKeys({ zylosDir }),
+    });
+
+    const startup = installed.hooks.SessionStart.find(g => g.matcher === 'startup');
+    // Old declared hook is gone.
+    assert.equal(startup.hooks.some(h => h.command?.includes('role-inject-hook.sh')), false);
+    assert.equal(result.removed, 1);
+    // The shard command replaced it, positioned after the core shards.
+    const shardArgs = startup.hooks
+      .filter(h => h.command?.includes('session-start-orchestrator.js'))
+      .map(h => extractShardArg(h.command));
+    assert.deepEqual(shardArgs, [
+      'identity', 'references', 'state', 'c4-checkpoint', 'c4-conversations', 'role-inject', 'fg', 'start-prompt',
+    ]);
+    // User and undeclared hooks are untouched.
+    assert.ok(startup.hooks.some(h => h.command?.includes('/custom/my-session-start.js')));
+    assert.ok(startup.hooks.some(h => h.command?.includes('other-component/scripts/other-hook.js')));
+    // The chain-tail wait covers the component shard (it is the last chain member).
+    const { chain } = buildChain({ zylosDir });
+    assert.equal(chain.at(-1).name, 'role-inject');
+
+    fs.rmSync(zylosDir, { recursive: true, force: true });
+  });
+
+  it('claims nothing when no declarations exist, even for shard-suffixed user paths', async () => {
+    const zylosDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shard-claim-empty-'));
+    const { desiredClaudeHooks: desired, claimedHookBaseKeys } = await import('../sync-settings-hooks.js');
+
+    const installed = {
+      hooks: {
+        SessionStart: [
+          {
+            matcher: 'startup',
+            hooks: [
+              makeHook(zylosHookPath('skills/role-manager/role-inject-hook.sh'), 10000),
+              makeHook('/custom/my-session-start.js --shard mine', 5000),
+            ],
+          },
+        ],
+      },
+    };
+
+    const result = syncHooks(installed, {}, {
+      log: noopLog,
+      desiredHooks: desired({ zylosDir }),
+      claimedKeys: claimedHookBaseKeys({ zylosDir }),
+    });
+
+    assert.equal(result.removed, 0);
+    const startup = installed.hooks.SessionStart.find(g => g.matcher === 'startup');
+    assert.ok(startup.hooks.some(h => h.command?.includes('role-inject-hook.sh')));
+    assert.ok(startup.hooks.some(h => h.command?.includes('/custom/my-session-start.js')));
+
+    fs.rmSync(zylosDir, { recursive: true, force: true });
+  });
+
+  it('rejects absolute claim paths at declaration time so user hooks can never be claimed', async () => {
+    const zylosDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shard-claim-abs-'));
+    const shardsDir = path.join(zylosDir, '.zylos', 'shards.d');
+    fs.mkdirSync(shardsDir, { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(shardsDir, 'grabby.json'), JSON.stringify({
+      name: 'grabby',
+      order: 10,
+      emitter: 'skills/grabby/emit.js',
+      claimHooks: ['/custom/my-session-start.js'],
+    }));
+
+    const { claimedHookBaseKeys } = await import('../sync-settings-hooks.js');
+    const claimed = claimedHookBaseKeys({ zylosDir });
+    assert.equal(claimed.size, 0);
+
+    fs.rmSync(zylosDir, { recursive: true, force: true });
+  });
+});
+
 // --- syncHooks (forward + reverse pass) tests ---
 describe('syncHooks forward pass', () => {
   const noopLog = () => {};

--- a/cli/lib/codex-hooks.js
+++ b/cli/lib/codex-hooks.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { parse, stringify } from 'smol-toml';
+import { SIDE_EFFECT_NAMES, buildChain } from '../../skills/activity-monitor/scripts/shard-registry.js';
 
 const SESSION_START = 'SessionStart';
 const CODEX_EVENT_KEYS = {
@@ -84,6 +85,24 @@ export function coreSessionStartCommand(zylosDir) {
   return `node ${script}`;
 }
 
+/**
+ * One command per injection shard plus the two side-effect steps, in chain
+ * order. Codex injects hook output in CONFIG order (measured — the opposite
+ * of Claude Code's completion order), so the array order here IS the
+ * injection order there; the flag chain still runs as a second, redundant
+ * guarantee with identical semantics on both runtimes.
+ */
+export function coreSessionStartCommands(zylosDir) {
+  const base = coreSessionStartCommand(zylosDir);
+  const { chain } = buildChain({ zylosDir });
+  const names = [
+    ...chain.map(shard => shard.name),
+    SIDE_EFFECT_NAMES.foreground,
+    SIDE_EFFECT_NAMES.startPrompt,
+  ];
+  return names.map(name => `${base} --shard ${name}`);
+}
+
 export function isCoreCodexHook(command, zylosDir) {
   if (!command) return false;
   const script = path.join(
@@ -126,41 +145,37 @@ export function installCoreCodexHook({ zylosDir }) {
   const filePath = codexHooksPath(zylosDir);
   const config = readCodexHooksConfig(filePath);
   config.hooks = isSection(config.hooks) ? config.hooks : {};
-  config.hooks[SESSION_START] = Array.isArray(config.hooks[SESSION_START])
-    ? config.hooks[SESSION_START]
-    : [];
+  const before = stableJson(config);
 
-  const command = coreSessionStartCommand(zylosDir);
-  const desiredHook = {
+  const commands = coreSessionStartCommands(zylosDir);
+  const desiredHooks = commands.map(command => ({
     type: 'command',
     command,
     timeout: DEFAULT_HOOK_TIMEOUT_SECONDS,
-  };
+  }));
 
-  let changed = false;
-  const existingGroup = config.hooks[SESSION_START].find(group =>
-    Array.isArray(group?.hooks) && group.hooks.some(h => isCoreCodexHook(h?.command, zylosDir))
-  );
+  // Reconcile: strip every core-managed hook (including the retired no-arg
+  // orchestrator command and stale shard sets), keep non-core groups intact,
+  // then install the full desired shard command set as one group. Config
+  // order is injection order on Codex, so the group must stay contiguous
+  // and chain-ordered.
+  const existing = Array.isArray(config.hooks[SESSION_START]) ? config.hooks[SESSION_START] : [];
+  const preserved = existing
+    .map((group) => {
+      if (!Array.isArray(group?.hooks)) return group;
+      return { ...group, hooks: group.hooks.filter(h => !isCoreCodexHook(h?.command, zylosDir)) };
+    })
+    .filter(group => !Array.isArray(group?.hooks) || group.hooks.length > 0);
 
-  if (existingGroup) {
-    existingGroup.hooks = existingGroup.hooks.map((hook) => {
-      if (!isCoreCodexHook(hook?.command, zylosDir)) return hook;
-      const next = { ...hook, ...desiredHook };
-      delete next.async;
-      if (stableJson(next) !== stableJson(hook)) changed = true;
-      return next;
-    });
-  } else {
-    config.hooks[SESSION_START].push({ hooks: [desiredHook] });
-    changed = true;
-  }
+  config.hooks[SESSION_START] = [...preserved, { hooks: desiredHooks }];
 
+  const changed = stableJson(config) !== before;
   if (changed) {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + '\n');
   }
 
-  return { path: filePath, changed, command };
+  return { path: filePath, changed, commands };
 }
 
 export function uninstallCoreCodexHook({ zylosDir }) {

--- a/cli/lib/hook-utils.js
+++ b/cli/lib/hook-utils.js
@@ -156,11 +156,28 @@ function normalizedAbsolutePath(scriptPath) {
 }
 
 /**
- * Return the canonical key used to compare hook script identity. Only hooks
- * under the zylos-owned .claude directory are reduced to registry suffixes;
- * other paths keep their full normalized path to avoid user hook collisions.
+ * Extract the value of a `--shard <name>` argument from a hook command, or
+ * null when the command has none.
  */
-export function hookScriptKey(command) {
+export function extractShardArg(command) {
+  if (typeof command !== 'string') return null;
+  const lastSegment = commandSegments(command).at(-1) || command;
+  const tokens = shellTokens(lastSegment);
+  const index = tokens.indexOf('--shard');
+  if (index === -1) return null;
+  const value = tokens[index + 1];
+  return value && !value.startsWith('-') ? value : null;
+}
+
+/**
+ * Script-identity key without shard discrimination. This is the key used for
+ * "is this a zylos-core-managed script" checks (CORE_MANAGED_HOOKS lists bare
+ * script paths, and every `--shard` variant of a core script is core-managed).
+ * Only hooks under the zylos-owned .claude directory are reduced to registry
+ * suffixes; other paths keep their full normalized path to avoid user hook
+ * collisions.
+ */
+export function hookScriptBaseKey(command) {
   const scriptPath = normalizedAbsolutePath(
     extractScriptPath(command).replaceAll('\\', '/').split(path.sep).join('/')
   );
@@ -168,6 +185,18 @@ export function hookScriptKey(command) {
   if (scriptPath.startsWith(root)) return scriptPath.slice(root.length);
 
   return scriptPath;
+}
+
+/**
+ * Return the canonical key used to compare hook command identity. Shard-mode
+ * commands (`--shard <name>`) get a `#shard=<name>` suffix so the N shard
+ * commands of the same orchestrator script sync independently instead of
+ * colliding on one script-path key.
+ */
+export function hookScriptKey(command) {
+  const base = hookScriptBaseKey(command);
+  const shard = extractShardArg(command);
+  return shard ? `${base}#shard=${shard}` : base;
 }
 
 /**

--- a/cli/lib/sync-settings-hooks.js
+++ b/cli/lib/sync-settings-hooks.js
@@ -21,9 +21,14 @@ import path from 'path';
 import os from 'os';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { hookScriptKey, getCommandHooks } from './hook-utils.js';
+import { hookScriptKey, hookScriptBaseKey, getCommandHooks } from './hook-utils.js';
 import { getZylosConfig, updateZylosConfig } from './config.js';
 import { renderCodexProjectConfig, renderCodexGlobalConfig, writeCodexConfig } from './runtime-setup.js';
+import {
+  SIDE_EFFECT_NAMES,
+  buildChain,
+  loadComponentShardDeclarations,
+} from '../../skills/activity-monitor/scripts/shard-registry.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ZYLOS_DIR = path.resolve(process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
@@ -46,8 +51,11 @@ export const CORE_MANAGED_HOOKS = new Set([
 ]);
 
 export function isCoreManaged(hook) {
+  // Base key (shard-arg stripped): every --shard variant of a core-managed
+  // script is core-managed, and the retired no-arg orchestrator command keys
+  // to the same path so upgrades sweep it out.
   if (!hook || hook.type !== 'command') return false;
-  return CORE_MANAGED_HOOKS.has(hookScriptKey(hook.command));
+  return CORE_MANAGED_HOOKS.has(hookScriptBaseKey(hook.command));
 }
 
 function zylosClaudeScript(relativePath) {
@@ -63,11 +71,30 @@ function commandHook(relativePath, options = {}) {
   };
 }
 
-export function desiredClaudeHooks() {
-  const sessionStartHook = commandHook(
-    'skills/activity-monitor/scripts/session-start-orchestrator.js',
-    { timeout: 20000 }
-  );
+/**
+ * One SessionStart hook command per injection shard (plus the two
+ * side-effect steps), all running the orchestrator script with distinct
+ * `--shard` args. Chain membership and order come from the shard registry:
+ * 5 core shards followed by any component shards declared under
+ * ~/zylos/.zylos/shards.d/.
+ */
+export function desiredSessionStartHooks({ zylosDir = ZYLOS_DIR } = {}) {
+  const { chain } = buildChain({ zylosDir });
+  const names = [
+    ...chain.map(shard => shard.name),
+    SIDE_EFFECT_NAMES.foreground,
+    SIDE_EFFECT_NAMES.startPrompt,
+  ];
+  const orchestrator = zylosClaudeScript('skills/activity-monitor/scripts/session-start-orchestrator.js');
+  return names.map(name => ({
+    type: 'command',
+    command: `${orchestrator} --shard ${name}`,
+    timeout: 20000,
+  }));
+}
+
+export function desiredClaudeHooks({ zylosDir = ZYLOS_DIR } = {}) {
+  const sessionStartHooks = desiredSessionStartHooks({ zylosDir });
   const activityHook = commandHook(
     'skills/activity-monitor/scripts/hook-activity.js',
     { async: true, timeout: 5 }
@@ -76,7 +103,7 @@ export function desiredClaudeHooks() {
   return {
     SessionStart: ['startup', 'clear', 'compact'].map(matcher => ({
       matcher,
-      hooks: [{ ...sessionStartHook }],
+      hooks: sessionStartHooks.map(hook => ({ ...hook })),
     })),
     UserPromptSubmit: [
       {
@@ -341,12 +368,30 @@ export function syncCodexConfig({
 }
 
 /**
+ * Legacy SessionStart hook paths that component shard declarations claim for
+ * removal (shard-registry.js documents the declaration contract). This is the
+ * ONLY channel through which sync removes hooks it does not own: a component
+ * may claim its own old hook paths (relative to ~/zylos/.claude, enforced at
+ * declaration validation), and everything unclaimed — user hooks, undeclared
+ * component hooks, anything outside the zylos .claude root — is preserved.
+ */
+export function claimedHookBaseKeys({ zylosDir = ZYLOS_DIR } = {}) {
+  const { declarations } = loadComponentShardDeclarations({ zylosDir });
+  return new Set(declarations.flatMap(declaration => declaration.claimHooks));
+}
+
+/**
  * Sync hooks between template and installed settings (in-memory).
  * Exported for unit testing. Called by main() after loading files.
  *
  * @returns {{ added: number, updated: number, removed: number }}
  */
-export function syncHooks(installedSettings, _templateSettings, { dryRun = false, log = console.log, desiredHooks = desiredClaudeHooks() } = {}) {
+export function syncHooks(installedSettings, _templateSettings, {
+  dryRun = false,
+  log = console.log,
+  desiredHooks = desiredClaudeHooks(),
+  claimedKeys = claimedHookBaseKeys(),
+} = {}) {
   const desiredHookGroups = desiredHooks || {};
 
   let added = 0;
@@ -438,7 +483,13 @@ export function syncHooks(installedSettings, _templateSettings, { dryRun = false
         const h = group.hooks[hi];
         if (h.type !== 'command') continue;
 
-        if (!isCoreManaged(h)) continue;
+        // Claims only ever apply to SessionStart (the shard chain's event)
+        // and only via relative-to-.claude keys, so hooks outside the zylos
+        // root can never match a claim.
+        const claimed = event === 'SessionStart'
+          && claimedKeys.size > 0
+          && claimedKeys.has(hookScriptBaseKey(h.command));
+        if (!isCoreManaged(h) && !claimed) continue;
 
         const installedKey = hookScriptKey(h.command);
         // Check only the corresponding template group, not all groups
@@ -451,7 +502,7 @@ export function syncHooks(installedSettings, _templateSettings, { dryRun = false
             group.hooks.splice(hi, 1);
           }
           removed++;
-          log(`  - ${event}[${groupMatcher}]: ${h.command}`);
+          log(`  - ${event}[${groupMatcher}]: ${h.command}${claimed && !isCoreManaged(h) ? ' (claimed by component shard declaration)' : ''}`);
         }
       }
 

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -496,6 +496,9 @@ describe('authoritative injection order (shard chain)', () => {
           tmpdir: tmpDir,
           linkMs: 5000,
           resolveShardImpl,
+          // In-process stand-in for the per-process exit hook: these shards
+          // share one process, so "exit" is the moment the shard's run ends.
+          registerExitFlagImpl: fn => fn(),
         })));
 
       const expected = chain.map((shard, index) =>

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -3,7 +3,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -83,6 +83,17 @@ async function runWithActions(source, overrides = {}, options = {}) {
 }
 
 describe('session-start-orchestrator', () => {
+  // The orchestrator unrefs its budget timers on purpose (a hook process
+  // must never be kept alive by its own watchdogs). Tests that feed it
+  // never-settling promises therefore need SOMETHING ref'd on the event
+  // loop, or the loop drains before the unref'd timeout can fire and the
+  // runner cancels the remaining tests. A ref'd keep-alive interval
+  // restores deterministic timer delivery without touching production
+  // semantics.
+  let keepAlive;
+  before(() => { keepAlive = setInterval(() => {}, 1000); });
+  after(() => clearInterval(keepAlive));
+
   it('runs startup source with all four steps', async () => {
     const result = await runWithActions('startup');
     assert.deepEqual(result.calls, [

--- a/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
+++ b/skills/activity-monitor/scripts/__tests__/session-start-orchestrator.test.js
@@ -10,9 +10,12 @@ import {
   installProcessBackstop,
   readStdinPayload,
   runSessionStartOrchestrator,
+  runSessionStartShard,
   runStep,
+  shardHeader,
   writeAllSync,
 } from '../session-start-orchestrator.js';
+import { CORE_SHARDS } from '../shard-registry.js';
 import { enqueueStartupPrompt, isOnboardingPending } from '../session-start-prompt.js';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -116,7 +119,11 @@ describe('session-start-orchestrator', () => {
     assert.equal(result.stdout, 'MEM\nC4\n');
   });
 
-  it('preserves stdout byte order as memory then C4', async () => {
+  // Compatibility only: the legacy no-arg path keeps its pre-shard byte
+  // order (memory before C4) for installs that still run the un-sharded
+  // command. The authoritative injection-order contract is the shard chain —
+  // see the "authoritative injection order (shard chain)" suite below.
+  it('legacy path preserves the pre-shard stdout byte order (memory then C4)', async () => {
     const result = await runWithActions('startup', {
       memoryInject: async () => 'A',
       c4SessionInit: async () => 'B',
@@ -443,6 +450,61 @@ describe('session-start-orchestrator', () => {
       assert.equal(exitCode, 0);
     } finally {
       clearTimeout(timer);
+    }
+  });
+});
+
+// The injection-order contract used to be the legacy assertions above
+// ("memory then C4" inside one process). With the shard split, the single
+// authoritative order is the registry chain
+// identity→references→state→c4-checkpoint→c4-conversations: shards run as
+// independent hook processes and the flag chain — not process scheduling —
+// decides what lands in context first. These tests pin that contract at the
+// whole-chain level (shard-mode.test.js covers the per-link mechanics).
+describe('authoritative injection order (shard chain)', () => {
+  it('subsumes the legacy contract: every memory shard precedes every C4 shard in the chain', () => {
+    const names = CORE_SHARDS.map(shard => shard.name);
+    const lastMemory = Math.max(
+      ...['identity', 'references', 'state'].map(name => names.indexOf(name)));
+    const firstC4 = Math.min(
+      ...['c4-checkpoint', 'c4-conversations'].map(name => names.indexOf(name)));
+    assert.ok(lastMemory >= 0 && firstC4 > lastMemory,
+      `chain ${names.join('→')} must keep memory shards ahead of C4 shards`);
+  });
+
+  it('five core shards launched concurrently in reverse order inject in chain order', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shard-chain-order-'));
+    const outPath = path.join(tmpDir, 'stdout.txt');
+    const fd = fs.openSync(outPath, 'w+');
+    const chain = CORE_SHARDS.map((core, index) => ({
+      name: core.name,
+      chainIndex: index,
+      budget: { maxChars: 10_000, maxTokens: 2_200 },
+      emit: async () => `${core.name.toUpperCase()} BODY`,
+    }));
+    const resolveShardImpl = (name) => {
+      const shard = chain.find(entry => entry.name === name);
+      return shard ? { kind: 'content', shard, chain, warnings: [] } : null;
+    };
+
+    try {
+      // Worst-case scheduling: the tail of the chain gets a head start. The
+      // flag chain alone must restore chain order on the shared stdout.
+      await Promise.all([...chain].reverse().map(shard =>
+        runSessionStartShard(shard.name, { session_id: 'sess-chain-order', source: 'startup' }, {
+          stdout: { fd },
+          tmpdir: tmpDir,
+          linkMs: 5000,
+          resolveShardImpl,
+        })));
+
+      const expected = chain.map((shard, index) =>
+        `${shardHeader({ position: index + 1, total: chain.length, name: shard.name })}\n${shard.name.toUpperCase()} BODY\n`
+      ).join('');
+      assert.equal(fs.readFileSync(outPath, 'utf8'), expected);
+    } finally {
+      try { fs.closeSync(fd); } catch {}
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 });

--- a/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
@@ -197,10 +197,11 @@ describe('shard budget (dual limit)', () => {
 describe('runSessionStartShard (content shards)', () => {
   const basePayload = { session_id: 'sess-1', source: 'startup' };
 
-  it('emits the numbered header and body, then writes its completion flag', async () => {
+  it('emits the numbered header and body, then registers its completion flag for exit time', async () => {
     const tmpdir = makeTmpdir();
     const out = tempStdout();
     const flags = [];
+    const exitHooks = [];
     const chain = fakeChain([
       { name: 'identity', emit: async () => 'IDENTITY BODY' },
       { name: 'references', emit: async () => 'REFS BODY' },
@@ -211,9 +212,16 @@ describe('runSessionStartShard (content shards)', () => {
       tmpdir,
       resolveShardImpl: fakeResolver(chain),
       writeFlagImpl: (sessionId, name) => flags.push([sessionId, name]),
+      registerExitFlagImpl: fn => exitHooks.push(fn),
     });
 
     assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [1/2] identity ===\nIDENTITY BODY\n');
+    // The flag is DEFERRED to process exit — the runtime attaches hook output
+    // in process-exit order, so flagging at stdout time lets a fast successor
+    // exit inside the predecessor's tail and invert the injected order.
+    assert.deepEqual(flags, [], 'flag must not be written before process exit');
+    assert.equal(exitHooks.length, 1);
+    exitHooks[0]();
     assert.deepEqual(flags, [['sess-1', 'identity']]);
   });
 
@@ -272,6 +280,7 @@ describe('runSessionStartShard (content shards)', () => {
       tmpdir,
       resolveShardImpl: fakeResolver(chain),
       writeFlagImpl: (sessionId, name) => flags.push(name),
+      registerExitFlagImpl: fn => fn(),
     });
 
     const text = out.read();
@@ -349,6 +358,7 @@ describe('runSessionStartShard (content shards)', () => {
       stdout: out.stdout,
       tmpdir,
       zylosDir,
+      registerExitFlagImpl: fn => fn(),
     });
 
     assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [6/6] role-inject ===\nROLE CONTEXT\n');

--- a/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
@@ -152,9 +152,11 @@ describe('shard-registry chain', () => {
 });
 
 describe('shard budget (dual limit)', () => {
-  it('estimates ASCII at ~4 chars/token and non-ASCII at ~1.6 chars/token', () => {
+  it('estimates ASCII at ~4 chars/token and non-ASCII at ~1.3 chars/token', () => {
     assert.equal(estimateTokens('a'.repeat(4000)), 1000);
-    assert.equal(estimateTokens('中'.repeat(1600)), 1000);
+    // Codex measures common CJK at ~1.34 chars/token; 1.3 keeps the
+    // estimate erring high so a budget-fitted shard never gets elided.
+    assert.equal(estimateTokens('中'.repeat(1300)), 1000);
   });
 
   it('fits CJK-heavy text by the token limit even when well under the char limit', () => {

--- a/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
@@ -299,7 +299,8 @@ describe('runSessionStartShard (content shards)', () => {
     const spillPath = text.match(/full section saved to: (\S+)\]/)?.[1];
     assert.ok(spillPath, 'truncation notice must name the spill file');
     assert.equal(fs.readFileSync(spillPath, 'utf8'), 'y'.repeat(15000));
-    assert.ok(spillPath.startsWith(path.join(tmpdir, 'zylos-shard-spill')));
+    // Spill root is per-user for the same multi-user /tmp reason as flags.
+    assert.match(spillPath, new RegExp(`^${tmpdir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/zylos-shard-spill-[^/]+/`));
   });
 
   it('emits without serialization and without flags when the payload has no session_id', async () => {

--- a/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
@@ -1,0 +1,445 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+  CORE_SHARDS,
+  DEFAULT_SHARD_BUDGET,
+  buildChain,
+  estimateTokens,
+  fitToBudget,
+  loadComponentShardDeclarations,
+  resolveShard,
+} from '../shard-registry.js';
+import {
+  composeShardOutput,
+  parseShardArg,
+  runSessionStartShard,
+  shardHeader,
+} from '../session-start-orchestrator.js';
+import { writeFlag } from '../shard-sequencer.js';
+
+const tmpDirs = [];
+
+function makeTmpdir(prefix = 'shard-mode-test-') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+});
+
+function tempStdout() {
+  const tmpDir = makeTmpdir('shard-stdout-');
+  const filePath = path.join(tmpDir, 'stdout.txt');
+  const fd = fs.openSync(filePath, 'w+');
+  return {
+    stdout: { fd },
+    read() {
+      return fs.readFileSync(filePath, 'utf8');
+    },
+  };
+}
+
+function writeDeclaration(zylosDir, fileName, declaration) {
+  const dir = path.join(zylosDir, '.zylos', 'shards.d');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, fileName), JSON.stringify(declaration, null, 2));
+}
+
+function makeComponentZylosDir() {
+  const zylosDir = makeTmpdir('shard-zylos-');
+  const emitterDir = path.join(zylosDir, '.claude', 'skills', 'role-manager');
+  fs.mkdirSync(emitterDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(emitterDir, 'emit-role.js'),
+    'export function emit() { return "ROLE CONTEXT"; }\n'
+  );
+  writeDeclaration(zylosDir, 'role-inject.json', {
+    name: 'role-inject',
+    order: 10,
+    emitter: 'skills/role-manager/emit-role.js',
+    claimHooks: ['skills/role-manager/role-inject-hook.sh'],
+  });
+  return zylosDir;
+}
+
+function fakeChain(entries) {
+  return entries.map((entry, index) => ({
+    budget: { ...DEFAULT_SHARD_BUDGET },
+    chainIndex: index,
+    ...entry,
+  }));
+}
+
+function fakeResolver(chain) {
+  return (name) => {
+    if (name === 'fg' || name === 'start-prompt') {
+      return { kind: 'side-effect', name, chain, warnings: [] };
+    }
+    const shard = chain.find(s => s.name === name);
+    return shard ? { kind: 'content', shard, chain, warnings: [] } : null;
+  };
+}
+
+describe('shard-registry chain', () => {
+  it('builds the 5 core shards in the agreed order', () => {
+    const { chain } = buildChain({ zylosDir: makeTmpdir() });
+    assert.deepEqual(
+      chain.map(s => [s.name, s.chainIndex]),
+      [
+        ['identity', 0],
+        ['references', 1],
+        ['state', 2],
+        ['c4-checkpoint', 3],
+        ['c4-conversations', 4],
+      ]
+    );
+    assert.ok(chain.every(s => s.budget.maxChars === DEFAULT_SHARD_BUDGET.maxChars));
+  });
+
+  it('appends declared component shards after the core shards', () => {
+    const zylosDir = makeComponentZylosDir();
+    const { chain, warnings } = buildChain({ zylosDir });
+    assert.deepEqual(warnings, []);
+    assert.equal(chain.length, CORE_SHARDS.length + 1);
+    assert.equal(chain.at(-1).name, 'role-inject');
+    assert.equal(chain.at(-1).chainIndex, 5);
+  });
+
+  it('rejects invalid declarations without breaking the chain', () => {
+    const zylosDir = makeTmpdir();
+    writeDeclaration(zylosDir, 'reserved.json', { name: 'identity', order: 10, emitter: 'skills/x/e.js' });
+    writeDeclaration(zylosDir, 'low-order.json', { name: 'too-early', order: 2, emitter: 'skills/x/e.js' });
+    writeDeclaration(zylosDir, 'escape.json', { name: 'escape', order: 11, emitter: '/etc/evil.js' });
+    writeDeclaration(zylosDir, 'bad-claim.json', {
+      name: 'bad-claim', order: 12, emitter: 'skills/x/e.js', claimHooks: ['/custom/user-hook.js'],
+    });
+    fs.writeFileSync(path.join(zylosDir, '.zylos', 'shards.d', 'garbage.json'), '{nope');
+
+    const { declarations, warnings } = loadComponentShardDeclarations({ zylosDir });
+
+    assert.deepEqual(declarations, []);
+    assert.equal(warnings.length, 5);
+    const { chain } = buildChain({ zylosDir });
+    assert.equal(chain.length, CORE_SHARDS.length);
+  });
+
+  it('rejects duplicate component shard names (first declaration wins)', () => {
+    const zylosDir = makeTmpdir();
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+    writeDeclaration(zylosDir, 'a.json', { name: 'dup', order: 10, emitter: 'skills/a/e.js' });
+    writeDeclaration(zylosDir, 'b.json', { name: 'dup', order: 11, emitter: 'skills/b/e.js' });
+
+    const { declarations, warnings } = loadComponentShardDeclarations({ zylosDir });
+    assert.equal(declarations.length, 1);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /duplicate/);
+  });
+
+  it('clamps component budgets to the dual-limit ceiling', () => {
+    const zylosDir = makeTmpdir();
+    writeDeclaration(zylosDir, 'big.json', {
+      name: 'big', order: 10, emitter: 'skills/x/e.js', budget: { maxChars: 99999, maxTokens: 99999 },
+    });
+    const { declarations } = loadComponentShardDeclarations({ zylosDir });
+    assert.deepEqual(declarations[0].budget, { ...DEFAULT_SHARD_BUDGET });
+  });
+});
+
+describe('shard budget (dual limit)', () => {
+  it('estimates ASCII at ~4 chars/token and non-ASCII at ~1.6 chars/token', () => {
+    assert.equal(estimateTokens('a'.repeat(4000)), 1000);
+    assert.equal(estimateTokens('中'.repeat(1600)), 1000);
+  });
+
+  it('fits CJK-heavy text by the token limit even when well under the char limit', () => {
+    // 8,000 CJK chars is under 10,000 chars but ~5,000 estimated tokens —
+    // the token limit must bind (this is the Codex-measured failure mode).
+    const text = '中'.repeat(8000);
+    const fit = fitToBudget(text, DEFAULT_SHARD_BUDGET);
+    assert.equal(fit.truncated, true);
+    assert.ok(estimateTokens(fit.text) <= DEFAULT_SHARD_BUDGET.maxTokens);
+  });
+
+  it('fits ASCII text by whichever limit binds first (tokens at 8,800 chars)', () => {
+    const text = 'a'.repeat(12000);
+    const fit = fitToBudget(text, DEFAULT_SHARD_BUDGET);
+    assert.equal(fit.truncated, true);
+    // 10,000 ASCII chars would be 2,500 estimated tokens, so the token limit
+    // binds below the char limit: 2,200 tokens x 4 chars/token = 8,800.
+    assert.equal(fit.text.length, 8800);
+    assert.equal(estimateTokens(fit.text), DEFAULT_SHARD_BUDGET.maxTokens);
+  });
+
+  it('composeShardOutput keeps header + trims body + appends the spill pointer', () => {
+    const header = shardHeader({ position: 3, total: 5, name: 'state' });
+    const { output, truncated } = composeShardOutput({
+      header,
+      body: 'x'.repeat(20000),
+      budget: DEFAULT_SHARD_BUDGET,
+      spillPath: '/tmp/spill/state.txt',
+    });
+    assert.equal(truncated, true);
+    assert.ok(output.startsWith(`${header}\n`));
+    assert.match(output, /\[shard output truncated: first \d+ of 20000 chars inline; full section saved to: \/tmp\/spill\/state\.txt\]/);
+    assert.ok(output.length <= DEFAULT_SHARD_BUDGET.maxChars);
+    assert.ok(estimateTokens(output) <= DEFAULT_SHARD_BUDGET.maxTokens);
+  });
+});
+
+describe('runSessionStartShard (content shards)', () => {
+  const basePayload = { session_id: 'sess-1', source: 'startup' };
+
+  it('emits the numbered header and body, then writes its completion flag', async () => {
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    const flags = [];
+    const chain = fakeChain([
+      { name: 'identity', emit: async () => 'IDENTITY BODY' },
+      { name: 'references', emit: async () => 'REFS BODY' },
+    ]);
+
+    await runSessionStartShard('identity', basePayload, {
+      stdout: out.stdout,
+      tmpdir,
+      resolveShardImpl: fakeResolver(chain),
+      writeFlagImpl: (sessionId, name) => flags.push([sessionId, name]),
+    });
+
+    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [1/2] identity ===\nIDENTITY BODY\n');
+    assert.deepEqual(flags, [['sess-1', 'identity']]);
+  });
+
+  it('waits for the predecessor flag before emitting', async () => {
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    const chain = fakeChain([
+      { name: 'identity', emit: async () => 'A' },
+      { name: 'references', emit: async () => 'B' },
+    ]);
+    setTimeout(() => writeFlag('sess-1', 'identity', { tmpdir }), 50);
+    const startMs = Date.now();
+
+    await runSessionStartShard('references', basePayload, {
+      stdout: out.stdout,
+      tmpdir,
+      linkMs: 2000,
+      resolveShardImpl: fakeResolver(chain),
+    });
+
+    assert.ok(Date.now() - startMs >= 40, 'must have actually waited for the predecessor');
+    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [2/2] references ===\nB\n');
+  });
+
+  it('fails open at the ladder deadline when the predecessor crashed, and says so in the header', async () => {
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    const chain = fakeChain([
+      { name: 'identity', emit: async () => 'A' },
+      { name: 'references', emit: async () => 'B' },
+    ]);
+
+    await runSessionStartShard('references', basePayload, {
+      stdout: out.stdout,
+      tmpdir,
+      linkMs: 80,
+      resolveShardImpl: fakeResolver(chain),
+    });
+
+    const text = out.read();
+    assert.match(text, /^=== ZYLOS STARTUP CONTEXT \[2\/2\] references \(predecessor "identity" not ready after \d+ms, continued\) ===\n/);
+    assert.match(text, /\nB\n$/);
+  });
+
+  it('emits a visible failure notice (numbering intact) and still flags when the emitter throws', async () => {
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    const flags = [];
+    const chain = fakeChain([
+      { name: 'identity', emit: async () => { throw new Error('boom'); } },
+      { name: 'references', emit: async () => 'B' },
+    ]);
+
+    await runSessionStartShard('identity', basePayload, {
+      stdout: out.stdout,
+      tmpdir,
+      resolveShardImpl: fakeResolver(chain),
+      writeFlagImpl: (sessionId, name) => flags.push(name),
+    });
+
+    const text = out.read();
+    assert.ok(text.startsWith('=== ZYLOS STARTUP CONTEXT [1/2] identity ===\n'));
+    assert.match(text, /=== IDENTITY UNAVAILABLE ===/);
+    assert.match(text, /failed: boom/);
+    assert.deepEqual(flags, ['identity']);
+  });
+
+  it('spills the full body and inlines a trimmed copy when over budget', async () => {
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    const chain = fakeChain([
+      { name: 'identity', emit: async () => 'y'.repeat(15000) },
+    ]);
+
+    await runSessionStartShard('identity', basePayload, {
+      stdout: out.stdout,
+      tmpdir,
+      resolveShardImpl: fakeResolver(chain),
+    });
+
+    const text = out.read();
+    assert.ok(text.length <= DEFAULT_SHARD_BUDGET.maxChars);
+    const spillPath = text.match(/full section saved to: (\S+)\]/)?.[1];
+    assert.ok(spillPath, 'truncation notice must name the spill file');
+    assert.equal(fs.readFileSync(spillPath, 'utf8'), 'y'.repeat(15000));
+    assert.ok(spillPath.startsWith(path.join(tmpdir, 'zylos-shard-spill')));
+  });
+
+  it('emits without serialization and without flags when the payload has no session_id', async () => {
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    const flags = [];
+    const chain = fakeChain([
+      { name: 'identity', emit: async () => 'A' },
+      { name: 'references', emit: async () => 'B' },
+    ]);
+    const startMs = Date.now();
+
+    await runSessionStartShard('references', { source: 'startup' }, {
+      stdout: out.stdout,
+      tmpdir,
+      linkMs: 5000,
+      resolveShardImpl: fakeResolver(chain),
+      writeFlagImpl: (...args) => flags.push(args),
+    });
+
+    assert.ok(Date.now() - startMs < 1000, 'no session id must mean no ladder wait');
+    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [2/2] references ===\nB\n');
+    assert.deepEqual(flags, []);
+  });
+
+  it('produces no stdout for an unknown shard name (fail-open)', async () => {
+    const out = tempStdout();
+    await runSessionStartShard('bogus', basePayload, {
+      stdout: out.stdout,
+      tmpdir: makeTmpdir(),
+      resolveShardImpl: () => null,
+    });
+    assert.equal(out.read(), '');
+  });
+
+  it('runs a declared component shard end-to-end through the real registry', async () => {
+    const zylosDir = makeComponentZylosDir();
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+
+    // Pre-flag the whole core chain so the component shard (position 6)
+    // does not sit through its ladder deadline.
+    for (const shard of CORE_SHARDS) writeFlag('sess-1', shard.name, { tmpdir });
+
+    await runSessionStartShard('role-inject', basePayload, {
+      stdout: out.stdout,
+      tmpdir,
+      zylosDir,
+    });
+
+    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [6/6] role-inject ===\nROLE CONTEXT\n');
+  });
+});
+
+describe('runSessionStartShard (side effects)', () => {
+  const chain = fakeChain([
+    { name: 'identity', emit: async () => 'A' },
+    { name: 'references', emit: async () => 'B' },
+  ]);
+
+  it('fg runs the foreground action without stdout or flags', async () => {
+    const out = tempStdout();
+    const calls = [];
+    await runSessionStartShard('fg', { session_id: 'sess-1', source: 'startup' }, {
+      stdout: out.stdout,
+      tmpdir: makeTmpdir(),
+      resolveShardImpl: fakeResolver(chain),
+      actions: {
+        foreground: async () => calls.push('foreground'),
+        startupPrompt: async () => calls.push('prompt'),
+      },
+    });
+    assert.deepEqual(calls, ['foreground']);
+    assert.equal(out.read(), '');
+  });
+
+  it('start-prompt waits for the chain tail flag before enqueueing', async () => {
+    const tmpdir = makeTmpdir();
+    const calls = [];
+    setTimeout(() => writeFlag('sess-1', 'references', { tmpdir }), 50);
+    const startMs = Date.now();
+
+    await runSessionStartShard('start-prompt', { session_id: 'sess-1', source: 'startup' }, {
+      stdout: tempStdout().stdout,
+      tmpdir,
+      linkMs: 2000,
+      resolveShardImpl: fakeResolver(chain),
+      actions: {
+        foreground: async () => calls.push('foreground'),
+        startupPrompt: async () => calls.push(['prompt', Date.now() - startMs]),
+      },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], 'prompt');
+    assert.ok(calls[0][1] >= 40, 'prompt must not fire before the chain tail flag');
+  });
+
+  it('start-prompt fails open past the chain-tail deadline (prompt never permanently withheld)', async () => {
+    const calls = [];
+    await runSessionStartShard('start-prompt', { session_id: 'sess-1', source: 'startup' }, {
+      stdout: tempStdout().stdout,
+      tmpdir: makeTmpdir(),
+      linkMs: 40,
+      resolveShardImpl: fakeResolver(chain),
+      actions: {
+        foreground: async () => {},
+        startupPrompt: async () => calls.push('prompt'),
+      },
+    });
+    assert.deepEqual(calls, ['prompt']);
+  });
+
+  it('start-prompt is skipped on compact', async () => {
+    const calls = [];
+    await runSessionStartShard('start-prompt', { session_id: 'sess-1', source: 'compact' }, {
+      stdout: tempStdout().stdout,
+      tmpdir: makeTmpdir(),
+      resolveShardImpl: fakeResolver(chain),
+      actions: {
+        foreground: async () => calls.push('foreground'),
+        startupPrompt: async () => calls.push('prompt'),
+      },
+    });
+    assert.deepEqual(calls, []);
+  });
+});
+
+describe('resolveShard / parseShardArg', () => {
+  it('resolves side-effect names with the full chain attached', () => {
+    const resolved = resolveShard('start-prompt', { zylosDir: makeTmpdir() });
+    assert.equal(resolved.kind, 'side-effect');
+    assert.equal(resolved.chain.length, CORE_SHARDS.length);
+  });
+
+  it('returns null for unknown names', () => {
+    assert.equal(resolveShard('nope', { zylosDir: makeTmpdir() }), null);
+  });
+
+  it('parses --shard from argv', () => {
+    assert.equal(parseShardArg(['--shard', 'identity']), 'identity');
+    assert.equal(parseShardArg([]), null);
+    assert.equal(parseShardArg(['--shard']), null);
+  });
+});

--- a/skills/activity-monitor/scripts/__tests__/shard-sequencer.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-sequencer.test.js
@@ -5,7 +5,10 @@ import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 
 import {
+  DEFAULT_FLAG_FRESH_TOLERANCE_MS,
   DEFAULT_T_LINK_MS,
+  defaultFreshAfterMs,
+  flagFreshToleranceMs,
   flagPath,
   flagRoot,
   ladderDeadlineMs,
@@ -122,6 +125,69 @@ describe('shard-sequencer session isolation (failure-mode case C/C\')', () => {
       flagPath('sess-a', 'identity', { tmpdir }),
       flagPath('sess-b', 'identity', { tmpdir })
     );
+  });
+});
+
+describe('shard-sequencer same-session re-trigger (compact keeps session_id)', () => {
+  // Compact fires SessionStart with the SAME session_id as startup (verified
+  // on a live Claude Code session, 2026-07-10), so per-session isolation does
+  // not protect a second trigger: the startup round's flags would satisfy
+  // every compact-round wait instantly and the chain would degrade to
+  // completion order. Freshness is what closes that hole.
+
+  function backdateFlag(sessionId, name, tmpdir, ageMs = 60 * 60 * 1000) {
+    const past = new Date(Date.now() - ageMs);
+    fs.utimesSync(flagPath(sessionId, name, { tmpdir }), past, past);
+  }
+
+  it('a previous round\'s full flag set in the SAME session does not satisfy waits', async () => {
+    const tmpdir = makeTmpdir();
+    // Round 1 (startup) completed: full flag set exists, aged past tolerance.
+    for (const name of ['identity', 'references', 'state', 'c4-checkpoint', 'c4-conversations']) {
+      writeFlag('sess-a', name, { tmpdir });
+      backdateFlag('sess-a', name, tmpdir);
+    }
+
+    // Round 2 (compact, same session id): old flags must read as absent.
+    const wait = await waitForFlag('sess-a', 'identity', { deadlineMs: 100, pollMs: 10, tmpdir });
+    assert.equal(wait.ok, false, 'stale same-session flags must not satisfy a re-trigger wait');
+  });
+
+  it('the predecessor\'s rewrite this round bumps mtime and unblocks the wait', async () => {
+    const tmpdir = makeTmpdir();
+    writeFlag('sess-a', 'identity', { tmpdir });
+    backdateFlag('sess-a', 'identity', tmpdir);
+
+    const pending = waitForFlag('sess-a', 'identity', { deadlineMs: 2000, pollMs: 10, tmpdir });
+    setTimeout(() => writeFlag('sess-a', 'identity', { tmpdir }), 60);
+    const result = await pending;
+    assert.equal(result.ok, true);
+    assert.ok(result.waitedMs >= 40, `waited ${result.waitedMs}ms, expected a real wait until the rewrite`);
+  });
+
+  it('an explicit freshAfterMs cutoff overrides the process-start default', async () => {
+    const tmpdir = makeTmpdir();
+    writeFlag('sess-a', 'identity', { tmpdir });
+    const future = Date.now() + 60_000;
+    const rejected = await waitForFlag('sess-a', 'identity', {
+      deadlineMs: 80, pollMs: 10, tmpdir, freshAfterMs: future,
+    });
+    assert.equal(rejected.ok, false, 'a flag older than the cutoff must not count');
+
+    const accepted = await waitForFlag('sess-a', 'identity', {
+      deadlineMs: 80, pollMs: 10, tmpdir, freshAfterMs: 0,
+    });
+    assert.equal(accepted.ok, true);
+  });
+
+  it('reads the freshness tolerance from the environment with a sane default', () => {
+    assert.equal(flagFreshToleranceMs({}), DEFAULT_FLAG_FRESH_TOLERANCE_MS);
+    assert.equal(flagFreshToleranceMs({ ZYLOS_SHARD_FLAG_FRESH_TOLERANCE_MS: '250' }), 250);
+    assert.equal(flagFreshToleranceMs({ ZYLOS_SHARD_FLAG_FRESH_TOLERANCE_MS: '0' }), 0);
+    assert.equal(flagFreshToleranceMs({ ZYLOS_SHARD_FLAG_FRESH_TOLERANCE_MS: 'nonsense' }), DEFAULT_FLAG_FRESH_TOLERANCE_MS);
+    assert.equal(flagFreshToleranceMs({ ZYLOS_SHARD_FLAG_FRESH_TOLERANCE_MS: '-5' }), DEFAULT_FLAG_FRESH_TOLERANCE_MS);
+    // The default cutoff sits at or before "now": process start minus tolerance.
+    assert.ok(defaultFreshAfterMs() <= Date.now());
   });
 });
 

--- a/skills/activity-monitor/scripts/__tests__/shard-sequencer.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-sequencer.test.js
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+  DEFAULT_T_LINK_MS,
+  flagPath,
+  ladderDeadlineMs,
+  sessionFlagDir,
+  sweepStaleFlags,
+  tLinkMs,
+  waitForFlag,
+  writeFlag,
+} from '../shard-sequencer.js';
+
+const tmpDirs = [];
+
+function makeTmpdir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shard-seq-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+});
+
+describe('shard-sequencer ladder deadlines', () => {
+  it('gives shard k (1-based) a (k-1) x T_LINK wait budget', () => {
+    assert.equal(ladderDeadlineMs(0, 1000), 0);
+    assert.equal(ladderDeadlineMs(1, 1000), 1000);
+    assert.equal(ladderDeadlineMs(4, 1000), 4000);
+    assert.equal(ladderDeadlineMs(4, 250), 1000);
+  });
+
+  it('reads T_LINK from the environment with a 1s default', () => {
+    assert.equal(tLinkMs({}), DEFAULT_T_LINK_MS);
+    assert.equal(tLinkMs({ ZYLOS_SHARD_T_LINK_MS: '250' }), 250);
+    assert.equal(tLinkMs({ ZYLOS_SHARD_T_LINK_MS: 'nonsense' }), DEFAULT_T_LINK_MS);
+    assert.equal(tLinkMs({ ZYLOS_SHARD_T_LINK_MS: '-5' }), DEFAULT_T_LINK_MS);
+  });
+});
+
+describe('shard-sequencer flag chain', () => {
+  it('wait resolves once the predecessor flag lands', async () => {
+    const tmpdir = makeTmpdir();
+    const pending = waitForFlag('sess-a', 'identity', { deadlineMs: 2000, pollMs: 10, tmpdir });
+    setTimeout(() => writeFlag('sess-a', 'identity', { tmpdir }), 60);
+    const result = await pending;
+    assert.equal(result.ok, true);
+    assert.ok(result.waitedMs >= 40, `waited ${result.waitedMs}ms, expected a real wait`);
+  });
+
+  it('wait fails open at the deadline when the predecessor never flags (crash mode)', async () => {
+    const tmpdir = makeTmpdir();
+    const result = await waitForFlag('sess-a', 'identity', { deadlineMs: 120, pollMs: 10, tmpdir });
+    assert.equal(result.ok, false);
+    assert.ok(result.waitedMs >= 120);
+  });
+
+  it('sanitizes hostile session ids to a single segment under the flag root', () => {
+    const tmpdir = makeTmpdir();
+    const dir = sessionFlagDir('../../etc/passwd', { tmpdir });
+    // Path separators are flattened, so the id cannot traverse out of the
+    // flag root — it must resolve to a direct child directory.
+    assert.equal(path.dirname(dir), path.join(tmpdir, 'zylos-shard-flags'));
+  });
+});
+
+describe('shard-sequencer session isolation (failure-mode case C/C\')', () => {
+  // Isolation is a correctness requirement: the design experiments showed a
+  // shared flag directory pre-planted with stale flags reverses the whole
+  // chain (every wait returns instantly, order degrades to completion order,
+  // memory shards land last). These tests pin the isolation behavior.
+
+  it('a full stale flag set from another session is invisible: the real chain still waits', async () => {
+    const tmpdir = makeTmpdir();
+    // Pre-plant a complete flag set under a stale session directory.
+    for (const name of ['identity', 'references', 'state', 'c4-checkpoint', 'c4-conversations']) {
+      writeFlag('stale-session', name, { tmpdir });
+    }
+
+    // The real session must NOT see them: its wait times out (fail-open)
+    // instead of returning instantly off the stale flags.
+    const poisonedWait = await waitForFlag('real-session', 'identity', { deadlineMs: 100, pollMs: 10, tmpdir });
+    assert.equal(poisonedWait.ok, false, 'stale flags from another session must not satisfy a wait');
+
+    // And a real flag in the real session satisfies it normally.
+    writeFlag('real-session', 'identity', { tmpdir });
+    const realWait = await waitForFlag('real-session', 'identity', { deadlineMs: 100, pollMs: 10, tmpdir });
+    assert.equal(realWait.ok, true);
+  });
+
+  it('documents the broken-isolation fingerprint: same-directory stale flags short-circuit to WAIT=ok:0', async () => {
+    const tmpdir = makeTmpdir();
+    // This is case C' — what happens WHEN isolation is broken (both runs
+    // keyed to the same directory). Every wait returns instantly; the
+    // all-zero waitedMs pattern is the diagnostic fingerprint.
+    writeFlag('shared', 'identity', { tmpdir });
+    const result = await waitForFlag('shared', 'identity', { deadlineMs: 1000, pollMs: 10, tmpdir });
+    assert.equal(result.ok, true);
+    assert.ok(result.waitedMs <= 20, `expected instant (poisoned) wait, got ${result.waitedMs}ms`);
+  });
+
+  it('flags for the same shard name are distinct files per session', () => {
+    const tmpdir = makeTmpdir();
+    assert.notEqual(
+      flagPath('sess-a', 'identity', { tmpdir }),
+      flagPath('sess-b', 'identity', { tmpdir })
+    );
+  });
+});
+
+describe('shard-sequencer TTL sweep', () => {
+  it('removes expired session directories and keeps fresh ones', () => {
+    const tmpdir = makeTmpdir();
+    writeFlag('old-session', 'identity', { tmpdir });
+    writeFlag('fresh-session', 'identity', { tmpdir });
+    const oldDir = sessionFlagDir('old-session', { tmpdir });
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    fs.utimesSync(oldDir, past, past);
+
+    const removed = sweepStaleFlags({ ttlMs: 60 * 60 * 1000, tmpdir });
+
+    assert.equal(removed, 1);
+    assert.equal(fs.existsSync(oldDir), false);
+    assert.equal(fs.existsSync(sessionFlagDir('fresh-session', { tmpdir })), true);
+  });
+
+  it('is a no-op when the flag root does not exist', () => {
+    const tmpdir = makeTmpdir();
+    assert.equal(sweepStaleFlags({ tmpdir }), 0);
+  });
+});

--- a/skills/activity-monitor/scripts/__tests__/shard-sequencer.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-sequencer.test.js
@@ -7,7 +7,9 @@ import { afterEach, describe, it } from 'node:test';
 import {
   DEFAULT_T_LINK_MS,
   flagPath,
+  flagRoot,
   ladderDeadlineMs,
+  perUserSuffix,
   sessionFlagDir,
   sweepStaleFlags,
   tLinkMs,
@@ -65,7 +67,17 @@ describe('shard-sequencer flag chain', () => {
     const dir = sessionFlagDir('../../etc/passwd', { tmpdir });
     // Path separators are flattened, so the id cannot traverse out of the
     // flag root — it must resolve to a direct child directory.
-    assert.equal(path.dirname(dir), path.join(tmpdir, 'zylos-shard-flags'));
+    assert.equal(path.dirname(dir), flagRoot({ tmpdir }));
+  });
+
+  it('keys the flag root per user so multi-user hosts cannot collide on a shared /tmp root', () => {
+    // A fixed root name is created 0755 by the first user and is then
+    // unwritable for every other user — flag writes fail silently and the
+    // chain degrades to completion order. The suffix pins per-user roots.
+    const tmpdir = makeTmpdir();
+    const suffix = perUserSuffix();
+    assert.ok(suffix.length > 0 && !/[/\\]/.test(suffix));
+    assert.equal(flagRoot({ tmpdir }), path.join(tmpdir, `zylos-shard-flags-${suffix}`));
   });
 });
 

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -2,13 +2,37 @@
 /**
  * SessionStart orchestrator.
  *
- * Runs context-producing startup steps first, then side-effect-only steps.
- * Stdout is reserved for context injection payloads.
+ * Two modes:
+ * - `--shard <name>`: emit a single injection shard (or run a single
+ *   side-effect step). Hook sync installs one command per shard so each
+ *   shard gets its own hook stdout budget; the shard sequencer pins the
+ *   injection order to chain order (see shard-sequencer.js).
+ * - no arguments (legacy): run every startup step in-process with a single
+ *   combined stdout. Kept for installs whose settings.json still points at
+ *   the un-sharded command.
+ *
+ * Stdout is reserved for context injection payloads in both modes.
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { formatSection } from '../../comm-bridge/scripts/session-format.js';
+import {
+  SIDE_EFFECT_NAMES,
+  estimateTokens,
+  fitToBudget,
+  resolveShard,
+  withinBudget,
+} from './shard-registry.js';
+import {
+  ladderDeadlineMs,
+  sweepStaleFlags,
+  tLinkMs,
+  waitForFlag,
+  writeFlag,
+} from './shard-sequencer.js';
 
 export const DEFAULT_TOTAL_BUDGET_MS = 17_000;
 export const STEP_BUDGETS_MS = {
@@ -17,6 +41,8 @@ export const STEP_BUDGETS_MS = {
   foreground: 3_000,
   startupPrompt: 3_000,
 };
+export const SHARD_EMIT_BUDGET_MS = 5_500;
+const SPILL_ROOT_NAME = 'zylos-shard-spill';
 
 export function installProcessBackstop({
   totalBudgetMs = DEFAULT_TOTAL_BUDGET_MS,
@@ -83,7 +109,7 @@ export function readStdinPayload({
   });
 }
 
-async function logStep({ name, source, status, durationMs, stdoutBytes = 0, error }) {
+async function logStep({ name, source, status, durationMs, stdoutBytes = 0, extra, error }) {
   try {
     const { logHookTiming } = await import('../../comm-bridge/scripts/c4-diagnostic.js');
     const detail = [
@@ -91,6 +117,7 @@ async function logStep({ name, source, status, durationMs, stdoutBytes = 0, erro
       source ? `[${source}]` : '',
       `status=${status}`,
       `stdout=${stdoutBytes}`,
+      extra || '',
       error ? `error=${String(error.message || error).replace(/\s+/g, '_').slice(0, 120)}` : '',
     ].filter(Boolean).join(':');
     logHookTiming(detail, durationMs);
@@ -114,6 +141,7 @@ export async function runStep({
   budgetMs,
   action,
   writeStdout = false,
+  extra,
   stdout = process.stdout,
   writeSync = fs.writeSync,
 }) {
@@ -130,6 +158,7 @@ export async function runStep({
       status: 'ok',
       durationMs: Date.now() - startMs,
       stdoutBytes: writeStdout ? Buffer.byteLength(text) : 0,
+      extra,
     });
     return { ok: true, output: text };
   } catch (error) {
@@ -150,6 +179,7 @@ export async function runStep({
       source,
       status: timedOut ? 'timeout' : 'failed',
       durationMs: Date.now() - startMs,
+      extra,
       error,
     });
     return { ok: false, error };
@@ -241,13 +271,243 @@ export async function runSessionStartOrchestrator(payload = {}, {
   }
 }
 
+/**
+ * Numbered self-describing shard header. This is the fail-safe half of the
+ * ordering design: a crashed shard leaves no trace in context at all (only a
+ * transcript-level hook error), so a missing [k/N] number is the ONLY
+ * in-context signal that a shard was lost. The header sits within the first
+ * 2KB, so it survives the persisted-output preview if a budget is ever blown.
+ */
+export function shardHeader({ position, total, name, waitNote = '' }) {
+  return `=== ZYLOS STARTUP CONTEXT [${position}/${total}] ${name}${waitNote ? ` (${waitNote})` : ''} ===`;
+}
+
+export function shardSpillPath(sessionId, shardName, { tmpdir = os.tmpdir() } = {}) {
+  const cleaned = String(sessionId || 'nosession').replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 128);
+  return path.join(tmpdir, SPILL_ROOT_NAME, cleaned, `${shardName}.txt`);
+}
+
+/**
+ * Compose a shard's stdout under its dual budget (chars for Claude's 10K
+ * persist threshold, estimated tokens for Codex's elision threshold). Over
+ * budget → keep the header, trim the body tail, and point at the spilled
+ * full copy so nothing is lost.
+ */
+export function composeShardOutput({ header, body, budget, spillPath }) {
+  const trimmedBody = (body == null ? '' : String(body)).trim();
+  const full = trimmedBody ? `${header}\n${trimmedBody}\n` : `${header}\n`;
+  if (withinBudget(full, budget)) {
+    return { output: full, truncated: false };
+  }
+
+  const notice = keptChars =>
+    `\n[shard output truncated: first ${keptChars} of ${trimmedBody.length} chars inline; full section saved to: ${spillPath}]`;
+  const worstOverhead = `${header}${notice(trimmedBody.length)}\n`;
+  const fit = fitToBudget(trimmedBody, {
+    maxChars: Math.max(0, budget.maxChars - (worstOverhead.length + 1)),
+    maxTokens: Math.max(0, budget.maxTokens - estimateTokens(worstOverhead)),
+  });
+  return {
+    output: `${header}\n${fit.text}${notice(fit.text.length)}\n`,
+    truncated: true,
+    fullBody: trimmedBody,
+  };
+}
+
+async function runShardSideEffect(name, payload, {
+  source,
+  budgets,
+  actions,
+  chain,
+  sessionId,
+  linkMs,
+  waitForFlagImpl,
+}) {
+  if (name === SIDE_EFFECT_NAMES.foreground) {
+    await runStep({
+      name: 'session-foreground',
+      source,
+      budgetMs: budgets.foreground,
+      action: () => actions.foreground(payload),
+    });
+    return;
+  }
+
+  // start-prompt: the startup prompt must be enqueued only after the
+  // injection chain has finished, or the agent starts acting with no memory
+  // in context. Wait on the last in-chain shard's flag; fail open past the
+  // chain-tail deadline so the prompt is never permanently withheld.
+  if (source === 'compact') {
+    await logStep({ name: 'session-start-prompt', source, status: 'skipped', durationMs: 0 });
+    return;
+  }
+
+  let waitExtra = '';
+  const tail = chain.at(-1);
+  if (tail && sessionId) {
+    const wait = await waitForFlagImpl(sessionId, tail.name, {
+      deadlineMs: ladderDeadlineMs(chain.length, linkMs),
+    });
+    waitExtra = `wait=${wait.ok ? 'ok' : 'timeout'}:${wait.waitedMs}`;
+  }
+  await runStep({
+    name: 'session-start-prompt',
+    source,
+    budgetMs: budgets.startupPrompt,
+    extra: waitExtra,
+    action: () => actions.startupPrompt(payload),
+  });
+}
+
+/**
+ * `--shard <name>` entry point: emit one content shard (predecessor wait →
+ * emit → budgeted stdout → completion flag) or run one side-effect step.
+ * Every failure path is fail-open — a shard-mode process must never block
+ * session start or exit non-zero.
+ */
+export async function runSessionStartShard(name, payload = {}, {
+  budgets = STEP_BUDGETS_MS,
+  emitBudgetMs = SHARD_EMIT_BUDGET_MS,
+  stdout = process.stdout,
+  zylosDir,
+  tmpdir,
+  linkMs = tLinkMs(),
+  resolveShardImpl = resolveShard,
+  waitForFlagImpl = waitForFlag,
+  writeFlagImpl = writeFlag,
+  actions = {
+    foreground: runForeground,
+    startupPrompt: runStartupPrompt,
+  },
+} = {}) {
+  const source = payload?.source || null;
+  const sessionId = typeof payload?.session_id === 'string' && payload.session_id ? payload.session_id : null;
+  const sequencerOptions = tmpdir ? { tmpdir } : {};
+
+  try {
+    sweepStaleFlags(sequencerOptions);
+  } catch { /* best-effort janitor */ }
+
+  const resolved = resolveShardImpl(name, zylosDir ? { zylosDir } : {});
+  if (!resolved) {
+    console.error(`[session-start-orchestrator] unknown shard "${name}"; emitting nothing (fail-open)`);
+    await logStep({ name: `shard-${name}`, source, status: 'unknown-shard', durationMs: 0 });
+    return;
+  }
+  for (const warning of resolved.warnings || []) {
+    console.error(`[session-start-orchestrator] shard declaration warning: ${warning}`);
+  }
+
+  if (resolved.kind === 'side-effect') {
+    await runShardSideEffect(name, payload, {
+      source,
+      budgets,
+      actions,
+      chain: resolved.chain,
+      sessionId,
+      linkMs,
+      waitForFlagImpl,
+    });
+    return;
+  }
+
+  const { shard, chain } = resolved;
+  const startMs = Date.now();
+
+  // Serialize: wait for the predecessor's flag with this shard's ladder
+  // deadline. No session id means no isolation key, so skip serialization
+  // entirely rather than risk cross-session flag poisoning.
+  let waitNote = '';
+  let waitExtra = 'wait=none';
+  const predecessor = shard.chainIndex > 0 ? chain[shard.chainIndex - 1] : null;
+  if (predecessor && sessionId) {
+    const wait = await waitForFlagImpl(sessionId, predecessor.name, {
+      deadlineMs: ladderDeadlineMs(shard.chainIndex, linkMs),
+      ...sequencerOptions,
+    });
+    waitExtra = `wait=${wait.ok ? 'ok' : 'timeout'}:${wait.waitedMs}`;
+    if (!wait.ok) waitNote = `predecessor "${predecessor.name}" not ready after ${wait.waitedMs}ms, continued`;
+  } else if (!sessionId) {
+    console.error(`[session-start-orchestrator] shard "${name}": no session_id in hook payload; emitting without serialization`);
+  }
+
+  let body = '';
+  let status = 'ok';
+  let error = null;
+  try {
+    const output = await withTimeout(Promise.resolve().then(() => shard.emit(payload)), emitBudgetMs, name);
+    body = output == null ? '' : String(output);
+  } catch (err) {
+    // Keep the failure visible in the injected stream (and keep the [k/N]
+    // numbering intact) instead of silently dropping the section.
+    error = err;
+    status = /timed out/.test(String(err?.message || err)) ? 'timeout' : 'failed';
+    body = formatSection(
+      `${name.toUpperCase()} UNAVAILABLE`,
+      `session-start shard "${name}" ${status === 'timeout' ? 'timed out' : 'failed'}: ${err?.message || err}`,
+    );
+  }
+
+  const header = shardHeader({
+    position: shard.chainIndex + 1,
+    total: chain.length,
+    name: shard.name,
+    waitNote,
+  });
+  const spillPath = shardSpillPath(sessionId, shard.name, sequencerOptions);
+  const composed = composeShardOutput({ header, body, budget: shard.budget, spillPath });
+  if (composed.truncated) {
+    try {
+      fs.mkdirSync(path.dirname(spillPath), { recursive: true });
+      fs.writeFileSync(spillPath, composed.fullBody);
+    } catch (spillError) {
+      console.error(`[session-start-orchestrator] shard "${name}": failed to spill full output: ${spillError.message}`);
+    }
+  }
+
+  writeAllSync(stdout.fd ?? 1, composed.output);
+
+  // Flag goes down only after our bytes are out — it is the "injected"
+  // signal successors serialize on. An emitter failure still flags: the
+  // failure notice was emitted in this shard's slot, so successors must not
+  // burn their ladder deadline waiting for a shard that already spoke.
+  if (sessionId) {
+    writeFlagImpl(sessionId, shard.name, sequencerOptions);
+  }
+
+  await logStep({
+    name: `shard-${shard.name}`,
+    source,
+    status,
+    durationMs: Date.now() - startMs,
+    stdoutBytes: Buffer.byteLength(composed.output),
+    extra: [waitExtra, composed.truncated ? 'truncated=1' : ''].filter(Boolean).join(':'),
+    error,
+  });
+}
+
+export function parseShardArg(argv) {
+  const index = argv.indexOf('--shard');
+  if (index === -1) return null;
+  return argv[index + 1] || null;
+}
+
 async function main() {
   const hardBackstopTimer = installProcessBackstop();
+  const shardName = parseShardArg(process.argv.slice(2));
   const payload = await readStdinPayload();
-  await runSessionStartOrchestrator(payload, {
-    totalBudgetMs: DEFAULT_TOTAL_BUDGET_MS,
-    hardBackstopTimer,
-  });
+  try {
+    if (shardName) {
+      await runSessionStartShard(shardName, payload);
+    } else {
+      await runSessionStartOrchestrator(payload, {
+        totalBudgetMs: DEFAULT_TOTAL_BUDGET_MS,
+        hardBackstopTimer,
+      });
+    }
+  } finally {
+    clearTimeout(hardBackstopTimer);
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -322,6 +322,7 @@ async function runShardSideEffect(name, payload, {
   sessionId,
   linkMs,
   waitForFlagImpl,
+  sequencerOptions = {},
 }) {
   if (name === SIDE_EFFECT_NAMES.foreground) {
     await runStep({
@@ -347,6 +348,7 @@ async function runShardSideEffect(name, payload, {
   if (tail && sessionId) {
     const wait = await waitForFlagImpl(sessionId, tail.name, {
       deadlineMs: ladderDeadlineMs(chain.length, linkMs),
+      ...sequencerOptions,
     });
     waitExtra = `wait=${wait.ok ? 'ok' : 'timeout'}:${wait.waitedMs}`;
   }
@@ -407,6 +409,7 @@ export async function runSessionStartShard(name, payload = {}, {
       sessionId,
       linkMs,
       waitForFlagImpl,
+      sequencerOptions,
     });
     return;
   }

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -28,6 +28,7 @@ import {
 } from './shard-registry.js';
 import {
   ladderDeadlineMs,
+  perUserSuffix,
   sweepStaleFlags,
   tLinkMs,
   waitForFlag,
@@ -42,7 +43,10 @@ export const STEP_BUDGETS_MS = {
   startupPrompt: 3_000,
 };
 export const SHARD_EMIT_BUDGET_MS = 5_500;
-const SPILL_ROOT_NAME = 'zylos-shard-spill';
+// Per-user root for the same reason as the flag root (see perUserSuffix in
+// shard-sequencer.js): a fixed name under shared /tmp is unwritable for the
+// second zylos user on a multi-user host.
+const SPILL_ROOT_NAME = `zylos-shard-spill-${perUserSuffix()}`;
 
 export function installProcessBackstop({
   totalBudgetMs = DEFAULT_TOTAL_BUDGET_MS,

--- a/skills/activity-monitor/scripts/session-start-orchestrator.js
+++ b/skills/activity-monitor/scripts/session-start-orchestrator.js
@@ -381,6 +381,7 @@ export async function runSessionStartShard(name, payload = {}, {
   resolveShardImpl = resolveShard,
   waitForFlagImpl = waitForFlag,
   writeFlagImpl = writeFlag,
+  registerExitFlagImpl = fn => process.once('exit', fn),
   actions = {
     foreground: runForeground,
     startupPrompt: runStartupPrompt,
@@ -474,12 +475,21 @@ export async function runSessionStartShard(name, payload = {}, {
 
   writeAllSync(stdout.fd ?? 1, composed.output);
 
-  // Flag goes down only after our bytes are out — it is the "injected"
-  // signal successors serialize on. An emitter failure still flags: the
-  // failure notice was emitted in this shard's slot, so successors must not
-  // burn their ladder deadline waiting for a shard that already spoke.
+  // The flag is the "injected" signal successors serialize on, and it must
+  // mark this PROCESS's completion, not its stdout write: the runtime
+  // attaches hook output in process-exit order, and after stdout there is
+  // still a tail (diagnostics below, event-loop drain of whatever the
+  // emitter imported). An ultra-cheap successor can detect an early flag,
+  // emit, and exit inside that tail, deterministically inverting the link
+  // (observed: the 3-line custom emitter overtaking identity in every
+  // sandbox run). Deferring the flag to the exit hook shrinks the
+  // predecessor's post-flag tail to ~0ms, while a successor's post-detect
+  // path always includes at least its emitter import + emit + diagnostics.
+  // An emitter failure still flags: the failure notice was emitted in this
+  // shard's slot, so successors must not burn their ladder deadline waiting
+  // for a shard that already spoke.
   if (sessionId) {
-    writeFlagImpl(sessionId, shard.name, sequencerOptions);
+    registerExitFlagImpl(() => writeFlagImpl(sessionId, shard.name, sequencerOptions));
   }
 
   await logStep({

--- a/skills/activity-monitor/scripts/shard-registry.js
+++ b/skills/activity-monitor/scripts/shard-registry.js
@@ -1,0 +1,291 @@
+/**
+ * Session-start shard registry.
+ *
+ * Single source of truth for the session-start injection chain: which shards
+ * exist, their chain order, their emitters, and their per-shard output
+ * budgets. Consumed by:
+ * - session-start-orchestrator.js --shard <name> (runtime emission)
+ * - cli/lib/sync-settings-hooks.js (Claude settings hook generation)
+ * - cli/lib/codex-hooks.js (Codex hooks.json generation)
+ *
+ * Core shards occupy chain orders 1-5. Components join the chain via opt-in
+ * declaration files in ~/zylos/.zylos/shards.d/<name>.json:
+ *
+ *   {
+ *     "name": "role-inject",            // unique shard name, [a-z0-9_-]
+ *     "order": 10,                      // chain slot, components use 10+
+ *     "emitter": "skills/role-manager/emit-role.js",  // under ~/zylos/.claude
+ *     "budget": { "maxChars": 10000, "maxTokens": 2200 },  // optional
+ *     "claimHooks": ["skills/role-manager/role-inject-hook.sh"]  // optional
+ *   }
+ *
+ * `claimHooks` lists the component's OWN legacy SessionStart hook paths
+ * (relative to ~/zylos/.claude) that hook sync may remove once the shard
+ * command replaces them. Sync only ever consumes these declarations — it
+ * never guesses paths and never claims hooks that no declaration names, so
+ * user hooks and undeclared component hooks are untouched. Undeclared
+ * component hooks keep running outside the chain, unordered, exactly as
+ * before the shard split.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Per-shard output budget. Dual limit:
+ * - maxChars: Claude Code persists hook stdout above 10,000 characters,
+ *   leaving only a ~2KB preview in context.
+ * - maxTokens: Codex elides hook output above ~2,500 tokens (measured), so
+ *   the cap is token-denominated there; 2,200 leaves headroom. Estimated
+ *   with the ascii/4 + non-ascii/1.6 heuristic calibrated in the Codex
+ *   ordering experiment.
+ */
+export const DEFAULT_SHARD_BUDGET = Object.freeze({ maxChars: 10_000, maxTokens: 2_200 });
+export const COMPONENT_ORDER_MIN = 10;
+
+const SHARD_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+export const SIDE_EFFECT_NAMES = Object.freeze({
+  foreground: 'fg',
+  startPrompt: 'start-prompt',
+});
+
+export const CORE_SHARDS = Object.freeze([
+  {
+    name: 'identity',
+    order: 1,
+    emit: async payload =>
+      (await import('../../zylos-memory/scripts/session-start-inject.js')).emitMemoryPart('identity', payload),
+  },
+  {
+    name: 'references',
+    order: 2,
+    emit: async payload =>
+      (await import('../../zylos-memory/scripts/session-start-inject.js')).emitMemoryPart('references', payload),
+  },
+  {
+    name: 'state',
+    order: 3,
+    emit: async payload =>
+      (await import('../../zylos-memory/scripts/session-start-inject.js')).emitMemoryPart('state', payload),
+  },
+  {
+    name: 'c4-checkpoint',
+    order: 4,
+    emit: async payload =>
+      (await import('../../comm-bridge/scripts/c4-session-init.js')).emitC4Checkpoint(payload),
+  },
+  {
+    name: 'c4-conversations',
+    order: 5,
+    emit: async payload =>
+      (await import('../../comm-bridge/scripts/c4-session-init.js')).emitC4Conversations(payload),
+  },
+].map(Object.freeze));
+
+const RESERVED_NAMES = new Set([
+  ...CORE_SHARDS.map(shard => shard.name),
+  SIDE_EFFECT_NAMES.foreground,
+  SIDE_EFFECT_NAMES.startPrompt,
+]);
+
+export function defaultZylosDir(env = process.env) {
+  return path.resolve(env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
+}
+
+export function shardsDeclarationDir(zylosDir = defaultZylosDir()) {
+  return path.join(zylosDir, '.zylos', 'shards.d');
+}
+
+function normalizedClaudeRoot(zylosDir) {
+  return `${path.resolve(zylosDir, '.claude').replaceAll('\\', '/').replace(/\/+$/, '')}/`;
+}
+
+function isRelativeClaimPath(claim) {
+  if (typeof claim !== 'string' || !claim.trim()) return false;
+  if (claim.startsWith('/') || claim.startsWith('~') || /^[A-Za-z]:/.test(claim)) return false;
+  return !claim.split('/').includes('..');
+}
+
+function validateBudget(budget) {
+  if (budget == null) return { ...DEFAULT_SHARD_BUDGET };
+  if (typeof budget !== 'object') return null;
+  const maxChars = budget.maxChars == null ? DEFAULT_SHARD_BUDGET.maxChars : Number(budget.maxChars);
+  const maxTokens = budget.maxTokens == null ? DEFAULT_SHARD_BUDGET.maxTokens : Number(budget.maxTokens);
+  if (!Number.isFinite(maxChars) || !Number.isFinite(maxTokens) || maxChars <= 0 || maxTokens <= 0) {
+    return null;
+  }
+  return {
+    maxChars: Math.min(Math.floor(maxChars), DEFAULT_SHARD_BUDGET.maxChars),
+    maxTokens: Math.min(Math.floor(maxTokens), DEFAULT_SHARD_BUDGET.maxTokens),
+  };
+}
+
+function validateDeclaration(raw, { zylosDir, takenNames }) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { error: 'declaration must be a JSON object' };
+  }
+  const name = raw.name;
+  if (typeof name !== 'string' || !SHARD_NAME_RE.test(name)) {
+    return { error: `invalid shard name ${JSON.stringify(raw.name)}` };
+  }
+  if (RESERVED_NAMES.has(name)) {
+    return { error: `shard name "${name}" is reserved for core shards` };
+  }
+  if (takenNames.has(name)) {
+    return { error: `duplicate shard name "${name}"` };
+  }
+  if (!Number.isInteger(raw.order) || raw.order < COMPONENT_ORDER_MIN) {
+    return { error: `shard "${name}" order must be an integer >= ${COMPONENT_ORDER_MIN}` };
+  }
+  if (typeof raw.emitter !== 'string' || !raw.emitter.trim()) {
+    return { error: `shard "${name}" is missing an emitter path` };
+  }
+
+  const claudeRoot = normalizedClaudeRoot(zylosDir);
+  const emitterPath = path.isAbsolute(raw.emitter)
+    ? path.resolve(raw.emitter)
+    : path.resolve(zylosDir, '.claude', raw.emitter);
+  if (!`${emitterPath.replaceAll('\\', '/')}`.startsWith(claudeRoot)) {
+    return { error: `shard "${name}" emitter must live under ${claudeRoot}` };
+  }
+
+  const budget = validateBudget(raw.budget);
+  if (!budget) {
+    return { error: `shard "${name}" has an invalid budget` };
+  }
+
+  const claimHooks = [];
+  for (const claim of Array.isArray(raw.claimHooks) ? raw.claimHooks : []) {
+    if (!isRelativeClaimPath(claim)) {
+      return { error: `shard "${name}" claimHooks entries must be paths relative to ${claudeRoot} (got ${JSON.stringify(claim)})` };
+    }
+    claimHooks.push(claim.replace(/^\.\//, ''));
+  }
+
+  return {
+    declaration: { name, order: raw.order, emitterPath, budget, claimHooks },
+  };
+}
+
+/**
+ * Load component shard declarations from <zylosDir>/.zylos/shards.d/*.json.
+ * Invalid declarations are skipped (collected in `warnings`), never fatal —
+ * a malformed component file must not break session start or hook sync.
+ */
+export function loadComponentShardDeclarations({ zylosDir = defaultZylosDir() } = {}) {
+  const dir = shardsDeclarationDir(zylosDir);
+  const declarations = [];
+  const warnings = [];
+  let files = [];
+  try {
+    files = fs.readdirSync(dir).filter(name => name.endsWith('.json')).sort();
+  } catch {
+    return { declarations, warnings };
+  }
+
+  const takenNames = new Set();
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    let raw;
+    try {
+      raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch (error) {
+      warnings.push(`${file}: unreadable declaration (${error.message})`);
+      continue;
+    }
+    const result = validateDeclaration(raw, { zylosDir, takenNames });
+    if (result.error) {
+      warnings.push(`${file}: ${result.error}`);
+      continue;
+    }
+    takenNames.add(result.declaration.name);
+    declarations.push(result.declaration);
+  }
+
+  declarations.sort((a, b) => a.order - b.order || a.name.localeCompare(b.name));
+  return { declarations, warnings };
+}
+
+async function emitComponentShard(declaration, payload) {
+  const module = await import(pathToFileURL(declaration.emitterPath).href);
+  const emit = module.emit ?? module.default;
+  if (typeof emit !== 'function') {
+    throw new Error(`emitter ${declaration.emitterPath} exports no emit() function`);
+  }
+  return emit(payload);
+}
+
+/**
+ * Build the injection chain: core shards followed by registered component
+ * shards, each annotated with its 0-based chainIndex. The chain length N is
+ * decided at runtime from this result — headers ([k/N]) and the start-prompt
+ * chain-tail wait both derive from it, never from a hardcoded count.
+ */
+export function buildChain({ zylosDir = defaultZylosDir() } = {}) {
+  const { declarations, warnings } = loadComponentShardDeclarations({ zylosDir });
+  const chain = [
+    ...CORE_SHARDS.map(shard => ({ ...shard, budget: { ...DEFAULT_SHARD_BUDGET }, source: 'core' })),
+    ...declarations.map(declaration => ({
+      name: declaration.name,
+      order: declaration.order,
+      budget: declaration.budget,
+      source: 'component',
+      emit: payload => emitComponentShard(declaration, payload),
+    })),
+  ].map((shard, index) => ({ ...shard, chainIndex: index }));
+  return { chain, warnings };
+}
+
+/**
+ * Resolve a --shard argument to either a content shard (with chain position)
+ * or a side-effect step. Returns null for unknown names.
+ */
+export function resolveShard(name, { zylosDir = defaultZylosDir() } = {}) {
+  const { chain, warnings } = buildChain({ zylosDir });
+  if (name === SIDE_EFFECT_NAMES.foreground || name === SIDE_EFFECT_NAMES.startPrompt) {
+    return { kind: 'side-effect', name, chain, warnings };
+  }
+  const shard = chain.find(entry => entry.name === name);
+  if (!shard) return null;
+  return { kind: 'content', shard, chain, warnings };
+}
+
+/**
+ * Token estimate for budget enforcement, calibrated against Codex's
+ * per-hook cap: ~4 chars/token for ASCII, ~1.6 chars/token otherwise
+ * (8,000 CJK chars measured as 3,556 tokens).
+ */
+export function estimateTokens(text) {
+  let ascii = 0;
+  let other = 0;
+  for (const ch of String(text)) {
+    if (ch.codePointAt(0) <= 0x7f) ascii += 1;
+    else other += 1;
+  }
+  return Math.ceil(ascii / 4 + other / 1.6);
+}
+
+export function withinBudget(text, budget = DEFAULT_SHARD_BUDGET) {
+  return text.length <= budget.maxChars && estimateTokens(text) <= budget.maxTokens;
+}
+
+/**
+ * Trim `text` from the tail until it satisfies both budget limits.
+ */
+export function fitToBudget(text, budget = DEFAULT_SHARD_BUDGET) {
+  const original = String(text);
+  if (withinBudget(original, budget)) {
+    return { text: original, truncated: false, originalChars: original.length };
+  }
+  let keep = Math.min(original.length, Math.max(0, budget.maxChars));
+  let slice = original.slice(0, keep);
+  while (keep > 0 && estimateTokens(slice) > budget.maxTokens) {
+    const ratio = budget.maxTokens / estimateTokens(slice);
+    keep = Math.min(keep - 1, Math.floor(keep * ratio));
+    slice = original.slice(0, Math.max(0, keep));
+  }
+  return { text: slice, truncated: true, originalChars: original.length };
+}

--- a/skills/activity-monitor/scripts/shard-registry.js
+++ b/skills/activity-monitor/scripts/shard-registry.js
@@ -81,10 +81,13 @@ export const CORE_SHARDS = Object.freeze([
       (await import('../../comm-bridge/scripts/c4-session-init.js')).emitC4Checkpoint(payload),
   },
   {
+    // Passes the shard budget so the emitter packs whole messages
+    // newest-first instead of ever falling back to the generic tail-trim +
+    // spill (which would cut the newest messages of the chronological text).
     name: 'c4-conversations',
     order: 5,
     emit: async payload =>
-      (await import('../../comm-bridge/scripts/c4-session-init.js')).emitC4Conversations(payload),
+      (await import('../../comm-bridge/scripts/c4-session-init.js')).emitC4Conversations(payload, DEFAULT_SHARD_BUDGET),
   },
 ].map(Object.freeze));
 

--- a/skills/activity-monitor/scripts/shard-registry.js
+++ b/skills/activity-monitor/scripts/shard-registry.js
@@ -37,10 +37,13 @@ import { pathToFileURL } from 'node:url';
  * Per-shard output budget. Dual limit:
  * - maxChars: Claude Code persists hook stdout above 10,000 characters,
  *   leaving only a ~2KB preview in context.
- * - maxTokens: Codex elides hook output above ~2,500 tokens (measured), so
- *   the cap is token-denominated there; 2,200 leaves headroom. Estimated
- *   with the ascii/4 + non-ascii/1.6 heuristic calibrated in the Codex
- *   ordering experiment.
+ * - maxTokens: Codex elides hook output above its per-hook token cap
+ *   (keeps exactly 2,469 tokens on codex-cli 0.142.0, measured across
+ *   ASCII/CJK/mixed inputs); 2,200 leaves headroom. Estimated with the
+ *   ascii/4 + non-ascii/1.3 heuristic: 11,000 lorem chars measured as
+ *   2,750 tokens (4.0 chars/token) and 8,000 CJK chars as 5,970 tokens
+ *   (~1.34 chars/token), so 1.3 keeps the estimate on the safe side of
+ *   common CJK. Re-verify against the cap when codex-cli upgrades.
  */
 export const DEFAULT_SHARD_BUDGET = Object.freeze({ maxChars: 10_000, maxTokens: 2_200 });
 export const COMPONENT_ORDER_MIN = 10;
@@ -255,8 +258,10 @@ export function resolveShard(name, { zylosDir = defaultZylosDir() } = {}) {
 
 /**
  * Token estimate for budget enforcement, calibrated against Codex's
- * per-hook cap: ~4 chars/token for ASCII, ~1.6 chars/token otherwise
- * (8,000 CJK chars measured as 3,556 tokens).
+ * per-hook cap: ~4 chars/token for ASCII (11,000 chars measured as 2,750
+ * tokens) and ~1.34 chars/token for common CJK (8,000 chars measured as
+ * 5,970 tokens); 1.3 is used so the estimate errs high, never low —
+ * an underestimate here means Codex elides the shard mid-body.
  */
 export function estimateTokens(text) {
   let ascii = 0;
@@ -265,7 +270,7 @@ export function estimateTokens(text) {
     if (ch.codePointAt(0) <= 0x7f) ascii += 1;
     else other += 1;
   }
-  return Math.ceil(ascii / 4 + other / 1.6);
+  return Math.ceil(ascii / 4 + other / 1.3);
 }
 
 export function withinBudget(text, budget = DEFAULT_SHARD_BUDGET) {

--- a/skills/activity-monitor/scripts/shard-sequencer.js
+++ b/skills/activity-monitor/scripts/shard-sequencer.js
@@ -26,7 +26,26 @@ import path from 'node:path';
 export const DEFAULT_T_LINK_MS = 1_000;
 export const DEFAULT_POLL_INTERVAL_MS = 25;
 export const DEFAULT_FLAG_TTL_MS = 6 * 60 * 60 * 1000;
-const FLAG_ROOT_NAME = 'zylos-shard-flags';
+
+/**
+ * Per-user suffix for working-dir roots under the shared temp dir. A fixed
+ * root name breaks multi-user hosts: the first zylos user creates it 0755,
+ * every other user then gets EACCES on writes inside it — and because flag
+ * writes are best-effort, sequencing silently degrades to completion order
+ * (each shard burning its full ladder deadline) and spills become
+ * unwritable. uid keeps the name stable per user; username is the Windows
+ * fallback where getuid is unavailable.
+ */
+export function perUserSuffix() {
+  if (typeof process.getuid === 'function') return String(process.getuid());
+  try {
+    return String(os.userInfo().username).replace(/[^A-Za-z0-9._-]/g, '_') || 'nouser';
+  } catch {
+    return 'nouser';
+  }
+}
+
+const FLAG_ROOT_NAME = `zylos-shard-flags-${perUserSuffix()}`;
 
 export function tLinkMs(env = process.env) {
   const raw = Number(env.ZYLOS_SHARD_T_LINK_MS);

--- a/skills/activity-monitor/scripts/shard-sequencer.js
+++ b/skills/activity-monitor/scripts/shard-sequencer.js
@@ -1,0 +1,130 @@
+/**
+ * Session-start shard sequencer.
+ *
+ * Multiple SessionStart hooks run in parallel and their stdout is injected in
+ * completion order, not config order (undocumented runtime behavior, verified
+ * experimentally for both Claude Code and Codex). This module pins completion
+ * order to chain order with flag files:
+ *
+ * - Each shard waits for its predecessor's flag before writing stdout, then
+ *   writes its own flag.
+ * - Flag directories are isolated per session_id. Isolation is a correctness
+ *   requirement, not hygiene: a shared flag directory poisoned by stale flags
+ *   reverses the whole chain (all waits return instantly, output degrades to
+ *   raw completion order).
+ * - Waits use a ladder deadline — shard k (1-based chain position) waits at
+ *   most (k-1) x T_LINK. A flat deadline makes every shard downstream of a
+ *   mid-chain failure expire simultaneously and race; the ladder keeps
+ *   survivors strictly ordered.
+ * - All waits fail open: a missing predecessor delays a shard, never drops it.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const DEFAULT_T_LINK_MS = 1_000;
+export const DEFAULT_POLL_INTERVAL_MS = 25;
+export const DEFAULT_FLAG_TTL_MS = 6 * 60 * 60 * 1000;
+const FLAG_ROOT_NAME = 'zylos-shard-flags';
+
+export function tLinkMs(env = process.env) {
+  const raw = Number(env.ZYLOS_SHARD_T_LINK_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_T_LINK_MS;
+}
+
+/**
+ * Ladder deadline for a shard's predecessor wait. `chainIndex` is 0-based, so
+ * the first shard waits 0ms and shard k (1-based) waits (k-1) x T_LINK.
+ */
+export function ladderDeadlineMs(chainIndex, linkMs = tLinkMs()) {
+  return Math.max(0, chainIndex) * linkMs;
+}
+
+function sanitizeSessionId(sessionId) {
+  const cleaned = String(sessionId || '').replace(/[^A-Za-z0-9._-]/g, '_');
+  return cleaned.slice(0, 128);
+}
+
+export function flagRoot({ tmpdir = os.tmpdir() } = {}) {
+  return path.join(tmpdir, FLAG_ROOT_NAME);
+}
+
+export function sessionFlagDir(sessionId, options = {}) {
+  return path.join(flagRoot(options), sanitizeSessionId(sessionId));
+}
+
+export function flagPath(sessionId, shardName, options = {}) {
+  return path.join(sessionFlagDir(sessionId, options), `${shardName}.flag`);
+}
+
+/**
+ * Write this shard's completion flag. Must be called AFTER the shard's stdout
+ * write — the flag is the "my bytes are out" signal successors wait on.
+ * Best effort: a failed flag write only costs successors their ladder wait.
+ */
+export function writeFlag(sessionId, shardName, options = {}) {
+  try {
+    fs.mkdirSync(sessionFlagDir(sessionId, options), { recursive: true });
+    fs.writeFileSync(flagPath(sessionId, shardName, options), '1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll for a predecessor's flag until it appears or `deadlineMs` elapses.
+ * Resolves { ok, waitedMs }. `waitedMs` is kept for diagnostics: an abnormal
+ * all-zeros pattern across shards is the fingerprint of broken session
+ * isolation, and ok=false with the predecessor's content present is the
+ * fingerprint of a flag-write bug.
+ */
+export async function waitForFlag(sessionId, shardName, {
+  deadlineMs,
+  pollMs = DEFAULT_POLL_INTERVAL_MS,
+  tmpdir,
+} = {}) {
+  const target = flagPath(sessionId, shardName, tmpdir ? { tmpdir } : {});
+  const startMs = Date.now();
+  for (;;) {
+    if (fs.existsSync(target)) {
+      return { ok: true, waitedMs: Date.now() - startMs };
+    }
+    const elapsed = Date.now() - startMs;
+    if (elapsed >= deadlineMs) {
+      return { ok: false, waitedMs: elapsed };
+    }
+    await new Promise(resolve => setTimeout(resolve, Math.min(pollMs, deadlineMs - elapsed)));
+  }
+}
+
+/**
+ * Best-effort removal of flag directories left behind by crashed or aborted
+ * sessions. Stale directories are harmless while isolation holds (each run
+ * uses its own session_id), so this is a bounded janitor, not a correctness
+ * mechanism.
+ */
+export function sweepStaleFlags({ ttlMs = DEFAULT_FLAG_TTL_MS, tmpdir } = {}) {
+  const root = flagRoot(tmpdir ? { tmpdir } : {});
+  let removed = 0;
+  let entries;
+  try {
+    entries = fs.readdirSync(root);
+  } catch {
+    return removed;
+  }
+  const cutoff = Date.now() - ttlMs;
+  for (const entry of entries) {
+    const dir = path.join(root, entry);
+    try {
+      if (fs.statSync(dir).mtimeMs < cutoff) {
+        fs.rmSync(dir, { recursive: true, force: true });
+        removed += 1;
+      }
+    } catch {
+      // Another process may have swept it first.
+    }
+  }
+  return removed;
+}

--- a/skills/activity-monitor/scripts/shard-sequencer.js
+++ b/skills/activity-monitor/scripts/shard-sequencer.js
@@ -12,6 +12,13 @@
  *   requirement, not hygiene: a shared flag directory poisoned by stale flags
  *   reverses the whole chain (all waits return instantly, output degrades to
  *   raw completion order).
+ * - Session isolation alone does not cover re-triggers WITHIN a session:
+ *   compact fires SessionStart with the SAME session_id as startup (verified
+ *   experimentally on Claude Code, 2026-07-10), so the startup round's flags
+ *   would satisfy every compact-round wait instantly. Waits therefore also
+ *   require the flag to be FRESH — written no earlier than this process's
+ *   start minus a skew tolerance. Old-round flags count as absent; the
+ *   predecessor's rewrite this round bumps the mtime and unblocks normally.
  * - Waits use a ladder deadline — shard k (1-based chain position) waits at
  *   most (k-1) x T_LINK. A flat deadline makes every shard downstream of a
  *   mid-chain failure expire simultaneously and race; the ladder keeps
@@ -26,6 +33,11 @@ import path from 'node:path';
 export const DEFAULT_T_LINK_MS = 1_000;
 export const DEFAULT_POLL_INTERVAL_MS = 25;
 export const DEFAULT_FLAG_TTL_MS = 6 * 60 * 60 * 1000;
+export const DEFAULT_FLAG_FRESH_TOLERANCE_MS = 5_000;
+
+// True process start, not module-load time: shard processes call waitForFlag
+// almost immediately, but a slow require chain must not shift the cutoff.
+const PROCESS_START_MS = Date.now() - Math.round(process.uptime() * 1000);
 
 /**
  * Per-user suffix for working-dir roots under the shared temp dir. A fixed
@@ -50,6 +62,24 @@ const FLAG_ROOT_NAME = `zylos-shard-flags-${perUserSuffix()}`;
 export function tLinkMs(env = process.env) {
   const raw = Number(env.ZYLOS_SHARD_T_LINK_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_T_LINK_MS;
+}
+
+export function flagFreshToleranceMs(env = process.env) {
+  const raw = Number(env.ZYLOS_SHARD_FLAG_FRESH_TOLERANCE_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_FLAG_FRESH_TOLERANCE_MS;
+}
+
+/**
+ * Freshness cutoff for flag acceptance: flags written before this instant are
+ * treated as leftovers from an earlier trigger of the same session (compact
+ * reuses the session_id) and ignored. The tolerance absorbs sibling spawn
+ * skew and coarse filesystem mtime granularity; its failure directions are
+ * asymmetric — too tight only costs a ladder wait (fail-open), too loose only
+ * risks old-round flags being honored when a re-trigger lands within the
+ * tolerance of the previous round, which a context-full compact cannot do.
+ */
+export function defaultFreshAfterMs() {
+  return PROCESS_START_MS - flagFreshToleranceMs();
 }
 
 /**
@@ -94,20 +124,29 @@ export function writeFlag(sessionId, shardName, options = {}) {
 
 /**
  * Poll for a predecessor's flag until it appears or `deadlineMs` elapses.
- * Resolves { ok, waitedMs }. `waitedMs` is kept for diagnostics: an abnormal
- * all-zeros pattern across shards is the fingerprint of broken session
- * isolation, and ok=false with the predecessor's content present is the
- * fingerprint of a flag-write bug.
+ * A flag only counts if its mtime is at or after `freshAfterMs` — flags left
+ * by an earlier trigger of the same session (compact keeps the session_id)
+ * are treated as absent. Resolves { ok, waitedMs }. `waitedMs` is kept for
+ * diagnostics: an abnormal all-zeros pattern across shards is the fingerprint
+ * of broken session isolation, and ok=false with the predecessor's content
+ * present is the fingerprint of a flag-write bug.
  */
 export async function waitForFlag(sessionId, shardName, {
   deadlineMs,
   pollMs = DEFAULT_POLL_INTERVAL_MS,
   tmpdir,
+  freshAfterMs = defaultFreshAfterMs(),
 } = {}) {
   const target = flagPath(sessionId, shardName, tmpdir ? { tmpdir } : {});
   const startMs = Date.now();
   for (;;) {
-    if (fs.existsSync(target)) {
+    let mtimeMs = null;
+    try {
+      mtimeMs = fs.statSync(target).mtimeMs;
+    } catch {
+      // Absent (or swept mid-poll) — keep waiting.
+    }
+    if (mtimeMs != null && mtimeMs >= freshAfterMs) {
       return { ok: true, waitedMs: Date.now() - startMs };
     }
     const elapsed = Date.now() - startMs;

--- a/skills/activity-monitor/scripts/shard-sequencer.js
+++ b/skills/activity-monitor/scripts/shard-sequencer.js
@@ -33,7 +33,7 @@ import path from 'node:path';
 export const DEFAULT_T_LINK_MS = 1_000;
 export const DEFAULT_POLL_INTERVAL_MS = 25;
 export const DEFAULT_FLAG_TTL_MS = 6 * 60 * 60 * 1000;
-export const DEFAULT_FLAG_FRESH_TOLERANCE_MS = 5_000;
+export const DEFAULT_FLAG_FRESH_TOLERANCE_MS = 10_000;
 
 // True process start, not module-load time: shard processes call waitForFlag
 // almost immediately, but a slow require chain must not shift the cutoff.

--- a/skills/comm-bridge/scripts/__tests__/c4-conversations-budget.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-conversations-budget.test.js
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { DEFAULT_SHARD_BUDGET, withinBudget } from '../../../activity-monitor/scripts/shard-registry.js';
+
+const RECEIVE_PATH = fileURLToPath(new URL('../c4-receive.js', import.meta.url));
+const SESSION_INIT_URL = pathToFileURL(fileURLToPath(new URL('../c4-session-init.js', import.meta.url))).href;
+const REGISTRY_URL = pathToFileURL(
+  fileURLToPath(new URL('../../../activity-monitor/scripts/shard-registry.js', import.meta.url)),
+).href;
+
+// c4-config resolves ZYLOS_DIR at module load, so every emitter call runs in
+// a fresh child process with the tmp dir in its environment.
+function emitConversations(env, budget = null) {
+  const script = `
+    const mod = await import(${JSON.stringify(SESSION_INIT_URL)});
+    const budget = process.env.TEST_BUDGET ? JSON.parse(process.env.TEST_BUDGET) : null;
+    process.stdout.write(await mod.emitC4Conversations({}, budget));
+  `;
+  const result = spawnSync('node', ['--input-type=module', '-e', script], {
+    env: { ...process.env, ...env, TEST_BUDGET: budget ? JSON.stringify(budget) : '' },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}
+
+function emitViaRegistry(env) {
+  const script = `
+    const { CORE_SHARDS } = await import(${JSON.stringify(REGISTRY_URL)});
+    const shard = CORE_SHARDS.find(s => s.name === 'c4-conversations');
+    process.stdout.write(await shard.emit({}));
+  `;
+  const result = spawnSync('node', ['--input-type=module', '-e', script], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}
+
+function receive(content, env) {
+  const result = spawnSync('node', [RECEIVE_PATH, '--channel', 'system', '--no-reply', '--content', content], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function withTmpDir(fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'c4-conv-budget-'));
+  const env = { ZYLOS_DIR: tmpDir };
+  try {
+    return fn({ tmpDir, env });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// Messages must stay under the 2,048-byte per-message delivery threshold so
+// the DB stores them verbatim (no attachment preview) and sizes stay exact.
+const marker = i => `UNIQ_MARK_${i}`;
+
+describe('emitC4Conversations budget packing (message-boundary, newest-first)', () => {
+  it('drops the oldest whole messages when the char budget overflows', () => {
+    withTmpDir(({ env }) => {
+      for (let i = 1; i <= 6; i++) receive(`${marker(i)} ${'x'.repeat(1800)}`, env);
+
+      // ~11K chars total against a 5K char budget (room for two whole
+      // messages, not three); token limit kept out of the way so the char
+      // dimension drives the packing.
+      const out = emitConversations(env, { maxChars: 5000, maxTokens: 100000 });
+
+      assert.ok(out.includes(marker(6)), 'newest message must survive');
+      assert.ok(!out.includes(marker(1)), 'oldest message must be dropped whole');
+      assert.match(out, /showing the newest \d+ of 6 unsummarized messages/);
+      assert.ok(out.length <= 5000, `packed output must fit the char budget (got ${out.length})`);
+      // Every kept message is complete: its marker implies its full body.
+      for (let i = 1; i <= 6; i++) {
+        if (out.includes(marker(i))) {
+          assert.ok(out.includes(`${marker(i)} ${'x'.repeat(1800)}`), `message ${i} must be intact, not cut mid-message`);
+        }
+      }
+      // Packing selects newest-first but must EMIT in chronological order —
+      // the last message in the section must remain the newest one.
+      const positions = [];
+      for (let i = 1; i <= 6; i++) {
+        const at = out.indexOf(marker(i));
+        if (at !== -1) positions.push({ i, at });
+      }
+      assert.ok(positions.length >= 2, 'expected more than one surviving message');
+      for (let k = 1; k < positions.length; k++) {
+        assert.ok(
+          positions[k].i > positions[k - 1].i && positions[k].at > positions[k - 1].at,
+          'kept messages must appear oldest → newest',
+        );
+      }
+    });
+  });
+
+  it('drops the oldest whole messages when the token budget overflows (CJK)', () => {
+    withTmpDir(({ env }) => {
+      // 650 CJK chars ≈ 500 estimated tokens per message, 1,950 bytes < the
+      // per-message threshold. Six messages ≈ 3,000 tokens against a 1,500
+      // token budget, while chars stay far under their limit — the token
+      // dimension alone must drive the packing.
+      for (let i = 1; i <= 6; i++) receive(`${marker(i)} ${'的'.repeat(650)}`, env);
+
+      const out = emitConversations(env, { maxChars: 100000, maxTokens: 1500 });
+
+      assert.ok(out.includes(marker(6)), 'newest message must survive');
+      assert.ok(!out.includes(marker(1)), 'oldest message must be dropped whole');
+      assert.match(out, /showing the newest \d+ of 6 unsummarized messages/);
+    });
+  });
+
+  it('is byte-identical to the legacy path when everything fits', () => {
+    withTmpDir(({ env }) => {
+      for (let i = 1; i <= 3; i++) receive(`${marker(i)} short`, env);
+
+      const legacy = emitConversations(env, null);
+      const shard = emitConversations(env, DEFAULT_SHARD_BUDGET);
+
+      assert.equal(shard, legacy);
+      assert.ok(!shard.includes('showing the newest'), 'no omission note when nothing was dropped');
+      for (let i = 1; i <= 3; i++) assert.ok(shard.includes(marker(i)));
+    });
+  });
+
+  it('never drops below one message — the newest stays even if it alone overflows', () => {
+    withTmpDir(({ env }) => {
+      receive(`${marker(1)} ${'x'.repeat(1800)}`, env);
+      receive(`${marker(2)} ${'x'.repeat(1800)}`, env);
+
+      // Budget smaller than a single message: packing keeps the newest one
+      // and leaves the last-resort generic trim+spill to the orchestrator.
+      const out = emitConversations(env, { maxChars: 300, maxTokens: 50 });
+
+      assert.ok(out.includes(marker(2)), 'the newest message is always kept');
+      assert.ok(!out.includes(marker(1)));
+    });
+  });
+
+  it('keeps the ACTION REQUIRED sync instruction while packing above the threshold', () => {
+    withTmpDir(({ env }) => {
+      // 17 messages > CHECKPOINT_THRESHOLD (15); session-init then considers
+      // only the newest 6, and the budget squeezes those further.
+      for (let i = 1; i <= 17; i++) receive(`${marker(i)} ${'x'.repeat(1200)}`, env);
+
+      const out = emitConversations(env, { maxChars: 3000, maxTokens: 100000 });
+
+      assert.ok(out.includes('=== ACTION REQUIRED ==='), 'sync instruction must survive packing');
+      assert.ok(out.includes('There are 17 unsummarized conversations'));
+      assert.ok(out.includes(marker(17)), 'newest message must survive');
+      assert.match(out, /showing the newest \d+ of 17 unsummarized messages/);
+      assert.ok(out.length <= 3000);
+    });
+  });
+
+  it('registry closure passes the shard budget: shard-mode output always fits inline', () => {
+    withTmpDir(({ env }) => {
+      // 650 CJK chars ≈ 500 estimated tokens per message while staying under
+      // the 2,048-byte per-message delivery threshold (bigger messages become
+      // 100-char previews + attachment pointers and would never overflow).
+      // Six of them ≈ 3,000 tokens blow the default 2,200-token shard budget.
+      for (let i = 1; i <= 6; i++) receive(`${marker(i)} ${'守'.repeat(650)}`, env);
+
+      const out = emitViaRegistry(env);
+
+      assert.ok(
+        withinBudget(out, DEFAULT_SHARD_BUDGET),
+        'registry-driven emit must come back within the shard budget so composeShardOutput never truncates it',
+      );
+      assert.ok(out.includes(marker(6)), 'newest message must survive');
+      assert.match(out, /showing the newest \d+ of 6 unsummarized messages/);
+    });
+  });
+});

--- a/skills/comm-bridge/scripts/c4-session-init.js
+++ b/skills/comm-bridge/scripts/c4-session-init.js
@@ -15,6 +15,7 @@
 
 import { logHookTiming } from './c4-diagnostic.js';
 import { formatSection } from './session-format.js';
+import { withinBudget } from '../../activity-monitor/scripts/shard-registry.js';
 import { fileURLToPath } from 'node:url';
 
 async function withC4Db(label, action) {
@@ -57,8 +58,17 @@ export async function emitC4Checkpoint() {
 /**
  * Emit the unsummarized-conversations section (including the "no new
  * conversations" fallback and, above threshold, the Memory Sync instruction).
+ *
+ * In shard mode the orchestrator passes the shard's budget, and over-budget
+ * output is packed at MESSAGE granularity: whole oldest messages are dropped
+ * until the newest ones fit inline. This shard must never rely on the generic
+ * tail-trim + spill fallback — that would cut the NEWEST messages (the text
+ * is chronological) and depend on the agent following a read-this-file
+ * pointer. Dropped messages are not lost: Memory Sync reads c4.db directly,
+ * so they are covered by the next checkpoint summary. Without a budget
+ * (legacy single-stdout path) the output is byte-identical to before.
  */
-export async function emitC4Conversations() {
+export async function emitC4Conversations(_payload, budget = null) {
   return withC4Db('c4 conversations init', async ({
     getUnsummarizedRange,
     getUnsummarizedConversations,
@@ -78,17 +88,39 @@ export async function emitC4Conversations() {
       ? getUnsummarizedConversations(SESSION_INIT_RECENT_COUNT)
       : getUnsummarizedConversations();
 
-    const sections = [formatSection('RECENT CONVERSATIONS', formatConversationsForAgent(conversations))];
+    const assemble = kept => {
+      // Informational only — no file to read. Kept within the section so it
+      // survives exactly as long as the section does.
+      const note = kept.length < conversations.length
+        ? `(showing the newest ${kept.length} of ${range.count} unsummarized messages inline; older ones are covered by the next Memory Sync checkpoint)\n\n`
+        : '';
+      const sections = [formatSection('RECENT CONVERSATIONS', note + formatConversationsForAgent(kept))];
 
-    // If over threshold, append Memory Sync instruction
-    if (needsSync) {
-      sections.push(formatSection(
-        'ACTION REQUIRED',
-        `There are ${range.count} unsummarized conversations (conversation id ${range.begin_id} ~ ${range.end_id}). Please use zylos-memory skill to process them.`,
-      ));
+      // If over threshold, append Memory Sync instruction
+      if (needsSync) {
+        sections.push(formatSection(
+          'ACTION REQUIRED',
+          `There are ${range.count} unsummarized conversations (conversation id ${range.begin_id} ~ ${range.end_id}). Please use zylos-memory skill to process them.`,
+        ));
+      }
+
+      return sections.join('\n\n');
+    };
+
+    let kept = conversations;
+    let body = assemble(kept);
+    if (!budget) return body;
+
+    // Reserve room for the [k/N] shard header the orchestrator prepends.
+    const packBudget = {
+      maxChars: Math.max(0, budget.maxChars - 200),
+      maxTokens: Math.max(0, budget.maxTokens - 60),
+    };
+    while (kept.length > 1 && !withinBudget(body, packBudget)) {
+      kept = kept.slice(1); // drop the oldest whole message
+      body = assemble(kept);
     }
-
-    return sections.join('\n\n');
+    return body;
   });
 }
 

--- a/skills/comm-bridge/scripts/c4-session-init.js
+++ b/skills/comm-bridge/scripts/c4-session-init.js
@@ -17,39 +17,58 @@ import { logHookTiming } from './c4-diagnostic.js';
 import { formatSection } from './session-format.js';
 import { fileURLToPath } from 'node:url';
 
-export async function initC4Session() {
+async function withC4Db(label, action) {
   let close = () => {};
   try {
-    const {
-      getLastCheckpoint,
-      getUnsummarizedRange,
-      getUnsummarizedConversations,
-      formatConversationsForAgent,
-      close: closeDb,
-    } = await import('./c4-db.js');
-    close = closeDb;
-    const { CHECKPOINT_THRESHOLD, SESSION_INIT_RECENT_COUNT } = await import('./c4-config.js');
+    const db = await import('./c4-db.js');
+    close = db.close;
+    return await action(db);
+  } catch (err) {
+    const wrapped = new Error(`Error in ${label}: ${err.message}`);
+    wrapped.cause = err;
+    throw wrapped;
+  } finally {
+    close();
+  }
+}
 
+/**
+ * Emit the last-checkpoint section, or '' when no checkpoint exists yet.
+ * Standalone emitter for the session-start shard orchestrator; also composed
+ * into initC4Session() for the legacy single-stdout path.
+ */
+export async function emitC4Checkpoint() {
+  return withC4Db('c4 checkpoint init', ({ getLastCheckpoint }) => {
     const checkpoint = getLastCheckpoint();
-    const range = getUnsummarizedRange();
-    const sections = [];
 
     // Always surface the last checkpoint. Summary present → show it; summary
     // null → emit a fallback so the block never silently disappears.
-    if (checkpoint) {
-      if (checkpoint.summary) {
-        sections.push(formatSection('LAST CHECKPOINT SUMMARY', checkpoint.summary));
-      } else {
-        sections.push(formatSection(
-          'LAST CHECKPOINT',
-          `(no summary — checkpoint #${checkpoint.id}, ${checkpoint.timestamp})`,
-        ));
-      }
+    if (!checkpoint) return '';
+    if (checkpoint.summary) {
+      return formatSection('LAST CHECKPOINT SUMMARY', checkpoint.summary);
     }
+    return formatSection(
+      'LAST CHECKPOINT',
+      `(no summary — checkpoint #${checkpoint.id}, ${checkpoint.timestamp})`,
+    );
+  });
+}
 
+/**
+ * Emit the unsummarized-conversations section (including the "no new
+ * conversations" fallback and, above threshold, the Memory Sync instruction).
+ */
+export async function emitC4Conversations() {
+  return withC4Db('c4 conversations init', async ({
+    getUnsummarizedRange,
+    getUnsummarizedConversations,
+    formatConversationsForAgent,
+  }) => {
+    const { CHECKPOINT_THRESHOLD, SESSION_INIT_RECENT_COUNT } = await import('./c4-config.js');
+
+    const range = getUnsummarizedRange();
     if (range.count === 0) {
-      sections.push(formatSection('RECENT CONVERSATIONS', 'No new conversations since last checkpoint.'));
-      return `${sections.join('\n\n')}\n`;
+      return formatSection('RECENT CONVERSATIONS', 'No new conversations since last checkpoint.');
     }
 
     const needsSync = range.count > CHECKPOINT_THRESHOLD;
@@ -59,7 +78,7 @@ export async function initC4Session() {
       ? getUnsummarizedConversations(SESSION_INIT_RECENT_COUNT)
       : getUnsummarizedConversations();
 
-    sections.push(formatSection('RECENT CONVERSATIONS', formatConversationsForAgent(conversations)));
+    const sections = [formatSection('RECENT CONVERSATIONS', formatConversationsForAgent(conversations))];
 
     // If over threshold, append Memory Sync instruction
     if (needsSync) {
@@ -69,13 +88,19 @@ export async function initC4Session() {
       ));
     }
 
+    return sections.join('\n\n');
+  });
+}
+
+export async function initC4Session() {
+  try {
+    const sections = [await emitC4Checkpoint(), await emitC4Conversations()].filter(Boolean);
     return `${sections.join('\n\n')}\n`;
   } catch (err) {
+    if (err.cause) throw err;
     const wrapped = new Error(`Error in session init: ${err.message}`);
     wrapped.cause = err;
     throw wrapped;
-  } finally {
-    close();
   }
 }
 

--- a/skills/zylos-memory/scripts/session-start-inject.js
+++ b/skills/zylos-memory/scripts/session-start-inject.js
@@ -51,11 +51,27 @@ function section(label, filePath) {
   return formatSection(label, content);
 }
 
+export const MEMORY_PARTS = Object.freeze({
+  identity: Object.freeze({ label: 'BOT IDENTITY', file: 'identity.md' }),
+  state: Object.freeze({ label: 'ACTIVE STATE', file: 'state.md' }),
+  references: Object.freeze({ label: 'REFERENCES', file: 'references.md' }),
+});
+
+/**
+ * Emit a single memory section. Used by the session-start shard orchestrator
+ * so each memory file gets its own hook stdout budget instead of sharing one.
+ */
+export function emitMemoryPart(part) {
+  const spec = MEMORY_PARTS[part];
+  if (!spec) throw new Error(`unknown memory part "${part}"`);
+  return section(spec.label, path.join(MEMORY_DIR, spec.file));
+}
+
 export function injectMemory() {
   const parts = [
-    section('BOT IDENTITY', path.join(MEMORY_DIR, 'identity.md')),
-    section('ACTIVE STATE', path.join(MEMORY_DIR, 'state.md')),
-    section('REFERENCES', path.join(MEMORY_DIR, 'references.md'))
+    emitMemoryPart('identity'),
+    emitMemoryPart('state'),
+    emitMemoryPart('references')
   ];
 
   return `${parts.join('\n\n')}\n`;

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -109,7 +109,7 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
 
 ### Memory Update Practices
 
-1. **At session start:** identity + state + references are auto-injected.
+1. **At session start:** identity + state + references are auto-injected, arriving as numbered blocks headed `=== ZYLOS STARTUP CONTEXT [k/N] <name> ===` (memory first, then C4 checkpoint and recent conversations). If a number in 1..N is missing, that block was lost at startup — read its source directly (memory files under `~/zylos/memory/`, conversations via c4-db.js). A block noting truncation points to the file holding its full content.
 2. **During work:** Update appropriate memory files immediately when you learn something important.
 3. **Memory Sync:** When triggered, launch a background subagent using the current runtime's supported subagent/task mechanism. The subagent's prompt must instruct it to follow the full sync flow in `~/zylos/.claude/skills/zylos-memory/SKILL.md`. This also applies in Codex and in `new-session` handoff flows: do not run Memory Sync inline in the main loop.
 4. **references.md is a pointer file with strict content rules.**


### PR DESCRIPTION
Splits the single session-start injection stdout into per-section SessionStart hook shards with a flag-file serialization chain, so every section gets its own hook-output budget and a pinned, runtime-enforced injection order.

Fixes #686

## What this does

- **`shard-sequencer.js`** (new): per-session flag chain — each shard waits for its predecessor's flag before writing stdout, ladder deadline `(k-1)×T_LINK` (default 1s, `ZYLOS_SHARD_T_LINK_MS`), fail-open everywhere, session-isolated flag dirs (correctness requirement: shared dirs poisoned by stale flags reverse the chain), 6h TTL sweep.
- **`shard-registry.js`** (new): single source of truth for the chain — 5 core shards `identity → references → state → c4-checkpoint → c4-conversations` + component opt-in declarations (`~/zylos/.zylos/shards.d/<name>.json`, order 10+, invalid declarations warn-and-skip, `claimHooks` restricted to relative `.claude` paths so user hooks are structurally unclaimable). Dual per-shard budget: ≤10,000 chars (Claude persist threshold) AND ≤2,200 estimated tokens (Codex elision cap, measured kept=2,469 on codex-cli 0.142.0).
- **orchestrator `--shard <name>`**: wait → emit → budget-fit (tail-trim + full-body spill with pointer) → numbered header `=== ZYLOS STARTUP CONTEXT [k/N] <name> ===` → completion flag. A crashed shard is traceless in context, so a missing [k/N] number is the designed loss signal; emitter failures still emit the header + UNAVAILABLE notice + flag (successors don't burn their ladder). `fg` runs chain-free; `start-prompt` waits on the chain tail. **Legacy no-arg path preserved byte-compatible** for un-upgraded installs.
- **Hook generation both sides**: `sync-settings-hooks.js` emits 7 commands per SessionStart matcher (5 shards + fg + start-prompt) + declared component shards; old orchestrator commands auto-removed on upgrade (`hookScriptBaseKey` strips the `#shard=` key suffix). `codex-hooks.js` generates the same registry as one contiguous config-order group (Codex injects in config order — config order = chain order). claimHooks consumption is a hard boundary: only declared, only SessionStart, only relative paths.
- **templates/ZYLOS.md**: [k/N] header reading convention (missing number = lost shard; truncated shard → read the spill path).
- **Tests**: shard-sequencer/shard-mode suites; session isolation regression (§4.2 C/C′); claim boundary (§3.6.4); order-authority migration — legacy "memory then C4" retitled as compatibility coverage, new suite pins the chain contract incl. 5 shards launched concurrently in reverse order restoring exact chain order on shared stdout.

Design source: workspace KB `/projects/zylos-core/research/` — *Session-start 注入拆分方案* rev4 (reviewed by @jinglever, accepted by Howard) + *Codex 运行时 SessionStart 注入顺序与截断语义实验报告* v2.

## #686 AC disposition (explicit, per review condition)

| AC | Status | Where / evidence |
|----|--------|------------------|
| Output ordered `identity → references → state → c4-checkpoint → c4-conversations` | ✅ **this PR** | registry chain + sequencer; sandbox acceptance: order exact in all runs with settings config order deliberately reversed; crash/hang/stale cases keep survivors ordered |
| identity.md restructured (first ~1.5KB self-sufficient) | ⏳ **not this PR** | motivation was the 2KB single-stdout preview; under sharding, identity (5.4KB) fits whole in its own budget and injects first. Remains a per-instance content edit — owner to decide whether to keep as a separate content task or drop as superseded |
| state.md <10KB consolidation | ⏳ **not this PR** | instance content hygiene, tracked via zylos-memory sync-audit practice; sharding independently guarantees state gets its own budget (over-budget → trim + spill, exercised in acceptance runs) |
| references.md <12KB via on-demand files | ✅ **covered by #696 / PR #697** (merged, `f94f149`) | content rules + sync-time audit + 8KB warn threshold; reference instance cleaned 14.0→6.1KB during dogfood |
| Truncation guidance verified/adjusted | ✅ **this PR** | per-shard truncation notice names the spill path inline; ZYLOS.md documents the [k/N] convention and spill-read instruction |
| Bootstrap works truncated + untruncated | ✅ **this PR** (premise transformed) | within-budget shards inject inline (now the normal path); over-budget shard trims + spills with pointer (verified end-to-end); legacy no-arg path byte-compatible for un-upgraded installs |

## Acceptance evidence

Sandbox rerun of the v1/v2 methodology against the REAL implementation (fake `ZYLOS_DIR`, real `claude -p`, transcript JSONL extraction), claude-cli 2.1.201 / node v22.22.2 / T_link 1000ms:

- baseline ×3: order exact, headers [1/5]…[5/5], CJK state trimmed to budget + byte-complete spill
- crash: [2/5] absent (designed loss signal), successor header carries fail-open note, survivors strictly ordered
- hang (12s): downstream unblocked at ladder, hung shard lands last with numbering intact
- stale flags: full dead-session flag set invisible — real waits, exact order
- claim boundary: real-instance dry-run +21/−3, undeclared user hook untouched

**Codex budget smoke (review condition 2, codex-cli 0.142.0)**: cap re-measured — keeps exactly 2,469 tokens (ASCII 11,000c→2,750t warn; CJK 8,000c→5,970t ⇒ ~1.34 chars/token). The smoke **caught a real miscalibration**: the estimator's 1.6 CJK divisor under-counted, a budget-fitted CJK shard measured 2,619 actual tokens and got elided. Fixed in `1e15af7` (divisor →1.3, budget now ~11-13% under cap); re-run lands the trimmed state shard in Codex context verbatim, no elision.

Repo tests: node 638/639 (sole failure = pre-existing environmental "Codex launch — new session", identical on clean main), jest 112/112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
