### PR TITLE
fix: prefer authenticated GitHub API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Flags can also be set via environment variables during `zylos init`. Resolution 
 | `ZYLOS_PROTOCOL` (`https` or `http`) | `--https` / `--no-https` |
 | `ZYLOS_WEB_PASSWORD` | `--web-password` |
 
+CI, Kubernetes, and shared E2E environments should also provide `GITHUB_TOKEN`
+so `zylos add` and `zylos upgrade` use GitHub's authenticated API quota instead
+of the shared unauthenticated quota. See the
+[GitHub authentication operations guide](docs/github-authentication.md) for
+configuration examples and fallback behavior.
+
 **Exit codes:** `0` = success, `1` = fatal error (e.g. invalid token), `2` = partial success (e.g. Caddy download failed but everything else succeeded).
 
 </details>

--- a/cli/lib/__tests__/github-rate-limit.test.js
+++ b/cli/lib/__tests__/github-rate-limit.test.js
@@ -197,21 +197,40 @@ echo "file-content"
 });
 
 describe('GitHub API authentication order (fake curl on PATH)', () => {
-  function installRecordingCommands({ failAuthenticated = false } = {}) {
+  function installRecordingCommands({
+    failAuthenticated = false,
+    authenticatedStatus = '403',
+    publicFailuresBeforeSuccess = 0,
+    publicStatus = '500',
+  } = {}) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-github-order-'));
     tmpDirs.push(dir);
     const callsFile = path.join(dir, 'curl-calls');
+    const publicCallsFile = path.join(dir, 'public-calls');
     const curlScript = `#!/bin/sh
-printf '%s\\n' "$*" >> "${callsFile}"
-case "$*" in
+args="$*"
+input=""
+case "$args" in
+  *"-H @-"*) input=$(cat) ;;
+esac
+flat_input=$(printf '%s' "$input" | tr '\\n' '|')
+printf '%s\\t%s\\n' "$args" "$flat_input" >> "${callsFile}"
+case "$input" in
   *"Authorization: Bearer"*)
     if [ "${failAuthenticated ? 'yes' : 'no'}" = "yes" ]; then
-      echo "curl: (22) The requested URL returned error: 403" >&2
+      echo "curl: (22) The requested URL returned error: ${authenticatedStatus}" >&2
       exit 22
     fi
     ;;
 esac
-case "$*" in
+public_calls=$(cat "${publicCallsFile}" 2>/dev/null || echo 0)
+public_calls=$((public_calls+1))
+echo "$public_calls" > "${publicCallsFile}"
+if [ "$public_calls" -le "${publicFailuresBeforeSuccess}" ]; then
+  echo "curl: (22) The requested URL returned error: ${publicStatus}" >&2
+  exit 22
+fi
+case "$args" in
   *"/tags?per_page=100"*) printf '%s\\n' '[{"name":"v1.2.3"}]' ;;
   *) printf '%s\\n' 'file-content' ;;
 esac
@@ -222,7 +241,14 @@ esac
     return {
       calls() {
         if (!fs.existsSync(callsFile)) return [];
-        return fs.readFileSync(callsFile, 'utf8').trim().split('\n');
+        return fs.readFileSync(callsFile, 'utf8').trim().split('\n').map(line => {
+          const [args, input = ''] = line.split('\t');
+          return { args, input };
+        });
+      },
+      publicCalls() {
+        if (!fs.existsSync(publicCallsFile)) return 0;
+        return Number(fs.readFileSync(publicCallsFile, 'utf8').trim());
       },
     };
   }
@@ -238,8 +264,10 @@ esac
     const calls = fake.calls();
     assert.equal(calls.length, 2);
     for (const call of calls) {
-      assert.match(call, /Authorization: Bearer test-token/);
-      assert.match(call, /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+      assert.doesNotMatch(call.args, /test-token/);
+      assert.match(call.args, /-H @-/);
+      assert.match(call.input, /Authorization: Bearer test-token/);
+      assert.match(call.args, /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
     }
   });
 
@@ -251,9 +279,10 @@ esac
     assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
 
     const [call] = fake.calls();
-    assert.match(call, /Authorization: Bearer test-token/);
-    assert.match(call, /Accept: application\/vnd\.github\.raw\+json/);
-    assert.match(call, /api\.github\.com\/repos\/org\/repo\/contents\/SKILL\.md\?ref=main/);
+    assert.doesNotMatch(call.args, /test-token/);
+    assert.match(call.input, /Authorization: Bearer test-token/);
+    assert.match(call.input, /Accept: application\/vnd\.github\.raw\+json/);
+    assert.match(call.args, /api\.github\.com\/repos\/org\/repo\/contents\/SKILL\.md\?ref=main/);
   });
 
   it('falls back to public endpoints when an authenticated request fails', async () => {
@@ -268,15 +297,15 @@ esac
 
     const calls = fake.calls();
     assert.equal(calls.length, 6);
-    assert.match(calls[0], /Authorization: Bearer test-token/);
-    assert.doesNotMatch(calls[1], /Authorization:/);
-    assert.match(calls[1], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
-    assert.match(calls[2], /Authorization: Bearer test-token/);
-    assert.doesNotMatch(calls[3], /Authorization:/);
-    assert.match(calls[3], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
-    assert.match(calls[4], /Authorization: Bearer test-token/);
-    assert.doesNotMatch(calls[5], /Authorization:/);
-    assert.match(calls[5], /raw\.githubusercontent\.com\/org\/repo\/main\/SKILL\.md/);
+    assert.match(calls[0].input, /Authorization: Bearer test-token/);
+    assert.equal(calls[1].input, '');
+    assert.match(calls[1].args, /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.match(calls[2].input, /Authorization: Bearer test-token/);
+    assert.equal(calls[3].input, '');
+    assert.match(calls[3].args, /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.match(calls[4].input, /Authorization: Bearer test-token/);
+    assert.equal(calls[5].input, '');
+    assert.match(calls[5].args, /raw\.githubusercontent\.com\/org\/repo\/main\/SKILL\.md/);
   });
 
   it('uses public endpoints directly when no token is available', async () => {
@@ -292,11 +321,130 @@ esac
 
     const calls = fake.calls();
     assert.equal(calls.length, 3);
-    assert.doesNotMatch(calls[0], /Authorization:/);
-    assert.match(calls[0], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
-    assert.doesNotMatch(calls[1], /Authorization:/);
-    assert.match(calls[1], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
-    assert.doesNotMatch(calls[2], /Authorization:/);
-    assert.match(calls[2], /raw\.githubusercontent\.com\/org\/repo\/main\/SKILL\.md/);
+    assert.equal(calls[0].input, '');
+    assert.match(calls[0].args, /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.equal(calls[1].input, '');
+    assert.match(calls[1].args, /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.equal(calls[2].input, '');
+    assert.match(calls[2].args, /raw\.githubusercontent\.com\/org\/repo\/main\/SKILL\.md/);
+  });
+
+  it('keeps the legacy immediate public retry without a token', async () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '';
+
+    for (const operation of ['sync tags', 'async tags', 'raw file']) {
+      const fake = installRecordingCommands({
+        publicFailuresBeforeSuccess: 1,
+        publicStatus: '500',
+      });
+      const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
+        await importFreshGitHub();
+
+      if (operation === 'sync tags') {
+        assert.equal(fetchLatestTag('org/repo'), '1.2.3');
+      } else if (operation === 'async tags') {
+        assert.equal(await fetchLatestTagAsync('org/repo'), '1.2.3');
+      } else {
+        assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
+      }
+      assert.equal(fake.publicCalls(), 2, operation);
+    }
+  });
+
+  it('makes exactly two public calls per failed no-token attempt', async () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '';
+
+    for (const operation of ['sync tags', 'async tags', 'raw file']) {
+      const fake = installRecordingCommands({
+        publicFailuresBeforeSuccess: 99,
+        publicStatus: '500',
+      });
+      const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
+        await importFreshGitHub();
+
+      if (operation === 'sync tags') {
+        assert.throws(() => fetchLatestTag('org/repo'));
+      } else if (operation === 'async tags') {
+        await assert.rejects(fetchLatestTagAsync('org/repo'));
+      } else {
+        assert.throws(() => fetchRawFileFresh('org/repo', 'SKILL.md'));
+      }
+      assert.equal(fake.publicCalls(), 2, operation);
+    }
+  });
+
+  it('makes six public calls when all three no-token rate-limit attempts fail', async () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '0,0';
+
+    for (const operation of ['sync tags', 'async tags', 'raw file']) {
+      const fake = installRecordingCommands({
+        publicFailuresBeforeSuccess: 99,
+        publicStatus: '403',
+      });
+      const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
+        await importFreshGitHub();
+
+      if (operation === 'sync tags') {
+        assert.throws(() => fetchLatestTag('org/repo'));
+      } else if (operation === 'async tags') {
+        await assert.rejects(fetchLatestTagAsync('org/repo'));
+      } else {
+        assert.throws(() => fetchRawFileFresh('org/repo', 'SKILL.md'));
+      }
+      assert.equal(fake.publicCalls(), 6, operation);
+    }
+  });
+
+  async function assertPublicRateLimitWins({ operation, authenticatedStatus, publicStatus }) {
+    process.env.GITHUB_TOKEN = 'test-token';
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '0';
+    const fake = installRecordingCommands({
+      failAuthenticated: true,
+      authenticatedStatus,
+      publicFailuresBeforeSuccess: 1,
+      publicStatus,
+    });
+    const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
+      await importFreshGitHub();
+
+    if (operation === 'sync tags') {
+      assert.equal(fetchLatestTag('org/repo'), '1.2.3');
+    } else if (operation === 'async tags') {
+      assert.equal(await fetchLatestTagAsync('org/repo'), '1.2.3');
+    } else {
+      assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
+    }
+
+    assert.equal(fake.publicCalls(), 2);
+    const calls = fake.calls();
+    assert.equal(calls.length, 4);
+    assert.match(calls[0].input, /Authorization: Bearer test-token/);
+    assert.equal(calls[1].input, '');
+    assert.match(calls[2].input, /Authorization: Bearer test-token/);
+    assert.equal(calls[3].input, '');
+  }
+
+  it('retries sync tags when auth 401 is followed by public 403', async () => {
+    await assertPublicRateLimitWins({
+      operation: 'sync tags', authenticatedStatus: '401', publicStatus: '403',
+    });
+  });
+
+  it('retries async tags when auth 404 is followed by public 429', async () => {
+    await assertPublicRateLimitWins({
+      operation: 'async tags', authenticatedStatus: '404', publicStatus: '429',
+    });
+  });
+
+  it('retries raw files when auth 404 is followed by public 403', async () => {
+    await assertPublicRateLimitWins({
+      operation: 'raw file', authenticatedStatus: '404', publicStatus: '403',
+    });
   });
 });

--- a/cli/lib/__tests__/github-rate-limit.test.js
+++ b/cli/lib/__tests__/github-rate-limit.test.js
@@ -9,9 +9,15 @@ for (const key of ['ZYLOS_GH_RETRY_DELAY_MS', 'GITHUB_TOKEN', 'GH_TOKEN', 'PATH'
   origEnv[key] = process.env[key];
 }
 const tmpDirs = [];
+let freshImportId = 0;
 
 const { isRateLimitError, withRateLimitRetrySync, withRateLimitRetryAsync, fetchRawFile } =
   await import('../github.js');
+
+function importFreshGitHub() {
+  freshImportId += 1;
+  return import(`../github.js?token-order-test=${freshImportId}`);
+}
 
 beforeEach(() => {
   // Fast retries so tests don't sleep for real
@@ -171,8 +177,8 @@ echo "file-content"
   }
 
   it('recovers when rate limiting clears within the retry budget', () => {
-    // Token present: each operation attempt = public + authenticated call.
-    // Attempt 1 (calls 1-2) is fully rate limited; the retry's public
+    // Token present: each operation attempt = authenticated + public call.
+    // Attempt 1 (calls 1-2) is fully rate limited; the retry's authenticated
     // call (call 3) succeeds.
     process.env.GITHUB_TOKEN = 'test-token';
     const fake = installFakeCurl({ failuresBeforeSuccess: 2, status: '403' });
@@ -185,7 +191,112 @@ echo "file-content"
     process.env.GITHUB_TOKEN = 'test-token';
     const fake = installFakeCurl({ failuresBeforeSuccess: 99, status: '404' });
     assert.throws(() => fetchRawFile('org/repo', 'SKILL.md'));
-    // public + authenticated within the single attempt, no retries
+    // authenticated + public within the single attempt, no retries
     assert.equal(fake.calls(), 2);
+  });
+});
+
+describe('GitHub API authentication order (fake curl on PATH)', () => {
+  function installRecordingCommands({ failAuthenticated = false } = {}) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-github-order-'));
+    tmpDirs.push(dir);
+    const callsFile = path.join(dir, 'curl-calls');
+    const curlScript = `#!/bin/sh
+printf '%s\\n' "$*" >> "${callsFile}"
+case "$*" in
+  *"Authorization: Bearer"*)
+    if [ "${failAuthenticated ? 'yes' : 'no'}" = "yes" ]; then
+      echo "curl: (22) The requested URL returned error: 403" >&2
+      exit 22
+    fi
+    ;;
+esac
+case "$*" in
+  *"/tags?per_page=100"*) printf '%s\\n' '[{"name":"v1.2.3"}]' ;;
+  *) printf '%s\\n' 'file-content' ;;
+esac
+`;
+    fs.writeFileSync(path.join(dir, 'curl'), curlScript, { mode: 0o755 });
+    fs.writeFileSync(path.join(dir, 'gh'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    process.env.PATH = `${dir}${path.delimiter}${process.env.PATH}`;
+    return {
+      calls() {
+        if (!fs.existsSync(callsFile)) return [];
+        return fs.readFileSync(callsFile, 'utf8').trim().split('\n');
+      },
+    };
+  }
+
+  it('uses authenticated API calls first for sync and async tag queries', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    const fake = installRecordingCommands();
+    const { fetchLatestTag, fetchLatestTagAsync } = await importFreshGitHub();
+
+    assert.equal(fetchLatestTag('org/repo'), '1.2.3');
+    assert.equal(await fetchLatestTagAsync('org/repo'), '1.2.3');
+
+    const calls = fake.calls();
+    assert.equal(calls.length, 2);
+    for (const call of calls) {
+      assert.match(call, /Authorization: Bearer test-token/);
+      assert.match(call, /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    }
+  });
+
+  it('uses the authenticated contents API first for raw files', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    const fake = installRecordingCommands();
+    const { fetchRawFile: fetchRawFileFresh } = await importFreshGitHub();
+
+    assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
+
+    const [call] = fake.calls();
+    assert.match(call, /Authorization: Bearer test-token/);
+    assert.match(call, /Accept: application\/vnd\.github\.raw\+json/);
+    assert.match(call, /api\.github\.com\/repos\/org\/repo\/contents\/SKILL\.md\?ref=main/);
+  });
+
+  it('falls back to public endpoints when an authenticated request fails', async () => {
+    process.env.GITHUB_TOKEN = 'test-token';
+    const fake = installRecordingCommands({ failAuthenticated: true });
+    const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
+      await importFreshGitHub();
+
+    assert.equal(fetchLatestTag('org/repo'), '1.2.3');
+    assert.equal(await fetchLatestTagAsync('org/repo'), '1.2.3');
+    assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
+
+    const calls = fake.calls();
+    assert.equal(calls.length, 6);
+    assert.match(calls[0], /Authorization: Bearer test-token/);
+    assert.doesNotMatch(calls[1], /Authorization:/);
+    assert.match(calls[1], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.match(calls[2], /Authorization: Bearer test-token/);
+    assert.doesNotMatch(calls[3], /Authorization:/);
+    assert.match(calls[3], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.match(calls[4], /Authorization: Bearer test-token/);
+    assert.doesNotMatch(calls[5], /Authorization:/);
+    assert.match(calls[5], /raw\.githubusercontent\.com\/org\/repo\/main\/SKILL\.md/);
+  });
+
+  it('uses public endpoints directly when no token is available', async () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    const fake = installRecordingCommands();
+    const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
+      await importFreshGitHub();
+
+    assert.equal(fetchLatestTag('org/repo'), '1.2.3');
+    assert.equal(await fetchLatestTagAsync('org/repo'), '1.2.3');
+    assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
+
+    const calls = fake.calls();
+    assert.equal(calls.length, 3);
+    assert.doesNotMatch(calls[0], /Authorization:/);
+    assert.match(calls[0], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.doesNotMatch(calls[1], /Authorization:/);
+    assert.match(calls[1], /api\.github\.com\/repos\/org\/repo\/tags\?per_page=100/);
+    assert.doesNotMatch(calls[2], /Authorization:/);
+    assert.match(calls[2], /raw\.githubusercontent\.com\/org\/repo\/main\/SKILL\.md/);
   });
 });

--- a/cli/lib/github.js
+++ b/cli/lib/github.js
@@ -9,6 +9,31 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFileCb);
 let _cachedToken = undefined;
 
+function authenticationHeaders(token, additionalHeaders = []) {
+  return [`Authorization: Bearer ${token}`, ...additionalHeaders].join('\n') + '\n';
+}
+
+function execFileWithInput(file, args, options, input) {
+  return new Promise((resolve, reject) => {
+    const child = execFileCb(file, args, options, (err, stdout, stderr) => {
+      if (err) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        reject(err);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+    child.stdin.end(input);
+  });
+}
+
+function preferredFallbackError(authenticatedError, publicError) {
+  // Public rate limiting is actionable by the outer retry loop. Otherwise the
+  // authenticated error is more useful for private-repository diagnostics.
+  return isRateLimitError(publicError) ? publicError : authenticatedError || publicError;
+}
+
 /**
  * Detect a GitHub token from the environment or gh CLI.
  * Result is cached for the process lifetime.
@@ -165,9 +190,13 @@ function fetchRawFileOnce(repo, filePath, branch) {
     const apiUrl = `https://api.github.com/repos/${repo}/contents/${filePath}?ref=${branch}`;
     try {
       return execFileSync('curl', [
-        '-fsSL', '-H', `Authorization: Bearer ${token}`,
-        '-H', 'Accept: application/vnd.github.raw+json', apiUrl,
-      ], { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] });
+        '-fsSL', '-H', '@-', apiUrl,
+      ], {
+        encoding: 'utf8',
+        timeout: 10000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        input: authenticationHeaders(token, ['Accept: application/vnd.github.raw+json']),
+      });
     } catch (err) {
       // A token without access must not block public repositories.
       authenticatedError = err;
@@ -181,8 +210,18 @@ function fetchRawFileOnce(repo, filePath, branch) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
   } catch (publicError) {
-    // Preserve the authenticated failure for private repos and rate-limit retry.
-    throw authenticatedError || publicError;
+    if (!token) {
+      // Preserve the pre-auth-first behavior: without credentials, a failed
+      // public request gets one immediate re-attempt in the same retry cycle.
+      return execFileSync('curl', ['-fsSL', publicUrl], {
+        encoding: 'utf8',
+        timeout: 10000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    }
+    // A rate-limited public fallback must reach the outer retry loop even when
+    // the authenticated request failed first with a non-rate-limit status.
+    throw preferredFallbackError(authenticatedError, publicError);
   }
 }
 
@@ -241,8 +280,9 @@ function fetchTagsJsonSync(repo) {
   let authenticatedError;
   if (token) {
     try {
-      return execFileSync('curl', ['-fsSL', '-H', `Authorization: Bearer ${token}`, url], {
+      return execFileSync('curl', ['-fsSL', '-H', '@-', url], {
         encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
+        input: authenticationHeaders(token),
       });
     } catch (err) {
       // Preserve public-repository access when the token has insufficient scope.
@@ -254,8 +294,12 @@ function fetchTagsJsonSync(repo) {
       encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
     });
   } catch (publicError) {
-    // Preserve the authenticated failure for private repos and rate-limit retry.
-    throw authenticatedError || publicError;
+    if (!token) {
+      return execFileSync('curl', ['-fsSL', url], {
+        encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    }
+    throw preferredFallbackError(authenticatedError, publicError);
   }
 }
 
@@ -265,11 +309,12 @@ async function fetchTagsJsonAsync(repo) {
   let authenticatedError;
   if (token) {
     try {
-      const { stdout } = await execFileAsync('curl', [
-        '-fsSL', '-H', `Authorization: Bearer ${token}`, url,
-      ], {
-        encoding: 'utf8', timeout: 10000,
-      });
+      const { stdout } = await execFileWithInput(
+        'curl',
+        ['-fsSL', '-H', '@-', url],
+        { encoding: 'utf8', timeout: 10000 },
+        authenticationHeaders(token)
+      );
       return stdout;
     } catch (err) {
       // Preserve public-repository access when the token has insufficient scope.
@@ -282,8 +327,13 @@ async function fetchTagsJsonAsync(repo) {
     });
     return stdout;
   } catch (publicError) {
-    // Preserve the authenticated failure for private repos and rate-limit retry.
-    throw authenticatedError || publicError;
+    if (!token) {
+      const { stdout } = await execFileAsync('curl', ['-fsSL', url], {
+        encoding: 'utf8', timeout: 10000,
+      });
+      return stdout;
+    }
+    throw preferredFallbackError(authenticatedError, publicError);
   }
 }
 

--- a/cli/lib/github.js
+++ b/cli/lib/github.js
@@ -97,9 +97,8 @@ function sleepSync(ms) {
 
 /**
  * Run an operation, retrying when it fails with a GitHub rate-limit
- * signature. The operation should contain its full fallback chain
- * (public endpoint → authenticated API), so a rate-limited public call
- * still falls through to the authenticated endpoint before any sleep.
+ * signature. The operation should contain its full endpoint fallback chain,
+ * so retries only start after all usable endpoints have failed.
  * Non-rate-limit failures are rethrown immediately.
  *
  * @param {Function} fn - Operation to run
@@ -141,8 +140,9 @@ export async function withRateLimitRetryAsync(fn, label) {
 
 /**
  * Fetch raw file content from a GitHub repo.
- * Tries public endpoint first, falls back to authenticated GitHub API
- * for private repos. Retries with backoff on GitHub rate limiting.
+ * Uses the authenticated GitHub API first when a token is available, then
+ * falls back to the public raw endpoint. Without a token, uses only the
+ * public endpoint. Retries with backoff on GitHub rate limiting.
  *
  * @param {string} repo - GitHub repo in "org/name" format
  * @param {string} filePath - Path to file in the repo (e.g. "SKILL.md")
@@ -158,34 +158,32 @@ export function fetchRawFile(repo, filePath, branch = 'main') {
 }
 
 function fetchRawFileOnce(repo, filePath, branch) {
-  // 1. Try public endpoint first
   const publicUrl = `https://raw.githubusercontent.com/${repo}/${branch}/${filePath}`;
+  const token = getGitHubToken();
+  let authenticatedError;
+  if (token) {
+    const apiUrl = `https://api.github.com/repos/${repo}/contents/${filePath}?ref=${branch}`;
+    try {
+      return execFileSync('curl', [
+        '-fsSL', '-H', `Authorization: Bearer ${token}`,
+        '-H', 'Accept: application/vnd.github.raw+json', apiUrl,
+      ], { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] });
+    } catch (err) {
+      // A token without access must not block public repositories.
+      authenticatedError = err;
+    }
+  }
+
   try {
     return execFileSync('curl', ['-fsSL', publicUrl], {
       encoding: 'utf8',
       timeout: 10000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-  } catch {
-    // Public fetch failed — repo may be private
+  } catch (publicError) {
+    // Preserve the authenticated failure for private repos and rate-limit retry.
+    throw authenticatedError || publicError;
   }
-
-  // 2. Fall back to authenticated GitHub API
-  const token = getGitHubToken();
-  if (!token) {
-    // No token — re-attempt public to get the original error
-    return execFileSync('curl', ['-fsSL', publicUrl], {
-      encoding: 'utf8',
-      timeout: 10000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-  }
-
-  const apiUrl = `https://api.github.com/repos/${repo}/contents/${filePath}?ref=${branch}`;
-  return execFileSync('curl', [
-    '-fsSL', '-H', `Authorization: Bearer ${token}`,
-    '-H', 'Accept: application/vnd.github.raw+json', apiUrl,
-  ], { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] });
 }
 
 // ── Shared tag parsing ───────────────────────────────────────────
@@ -239,42 +237,53 @@ function parseTagsResponse(jsonStr, { includePrerelease = false } = {}) {
 
 function fetchTagsJsonSync(repo) {
   const url = `https://api.github.com/repos/${repo}/tags?per_page=100`;
+  const token = getGitHubToken();
+  let authenticatedError;
+  if (token) {
+    try {
+      return execFileSync('curl', ['-fsSL', '-H', `Authorization: Bearer ${token}`, url], {
+        encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      // Preserve public-repository access when the token has insufficient scope.
+      authenticatedError = err;
+    }
+  }
   try {
     return execFileSync('curl', ['-fsSL', url], {
       encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
     });
-  } catch {
-    const token = getGitHubToken();
-    if (!token) {
-      return execFileSync('curl', ['-fsSL', url], {
-        encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
-      });
-    }
-    return execFileSync('curl', ['-fsSL', '-H', `Authorization: Bearer ${token}`, url], {
-      encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
-    });
+  } catch (publicError) {
+    // Preserve the authenticated failure for private repos and rate-limit retry.
+    throw authenticatedError || publicError;
   }
 }
 
 async function fetchTagsJsonAsync(repo) {
   const url = `https://api.github.com/repos/${repo}/tags?per_page=100`;
+  const token = getGitHubToken();
+  let authenticatedError;
+  if (token) {
+    try {
+      const { stdout } = await execFileAsync('curl', [
+        '-fsSL', '-H', `Authorization: Bearer ${token}`, url,
+      ], {
+        encoding: 'utf8', timeout: 10000,
+      });
+      return stdout;
+    } catch (err) {
+      // Preserve public-repository access when the token has insufficient scope.
+      authenticatedError = err;
+    }
+  }
   try {
     const { stdout } = await execFileAsync('curl', ['-fsSL', url], {
       encoding: 'utf8', timeout: 10000,
     });
     return stdout;
-  } catch {
-    const token = getGitHubToken();
-    if (!token) {
-      const { stdout } = await execFileAsync('curl', ['-fsSL', url], {
-        encoding: 'utf8', timeout: 10000,
-      });
-      return stdout;
-    }
-    const { stdout } = await execFileAsync('curl', ['-fsSL', '-H', `Authorization: Bearer ${token}`, url], {
-      encoding: 'utf8', timeout: 10000,
-    });
-    return stdout;
+  } catch (publicError) {
+    // Preserve the authenticated failure for private repos and rate-limit retry.
+    throw authenticatedError || publicError;
   }
 }
 

--- a/docs/github-authentication.md
+++ b/docs/github-authentication.md
@@ -1,0 +1,87 @@
+# GitHub Authentication for Component Operations
+
+`zylos add`, `zylos upgrade`, and upgrade checks read release tags and component
+metadata from GitHub. Public API requests are limited per source IP, so CI,
+Kubernetes, and shared E2E runners should provide a token:
+
+```bash
+export GITHUB_TOKEN="<read-only-token>"
+zylos upgrade --all --check
+```
+
+Use a read-only fine-grained token with access only to the repositories that
+Zylos must read. Store it in the platform's secret manager; do not commit it to
+the repository or print it in job logs.
+
+## Resolution and fallback behavior
+
+Credentials are resolved in this order:
+
+1. `GITHUB_TOKEN`
+2. `GH_TOKEN`
+3. `gh auth token`
+
+When a token is available, GitHub API tag and raw-file requests authenticate on
+the first attempt. If GitHub rejects that request (for example, because the
+token cannot access a public organization), Zylos retries the public endpoint.
+Without a token, it uses the public endpoint directly.
+
+GitHub archive downloads remain public-first because codeload traffic does not
+consume the REST API quota. Private-repository downloads still fall back to the
+authenticated tarball API.
+
+## CI and E2E
+
+GitHub Actions can use its short-lived job token:
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test # Replace with the project's E2E command when different.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+```
+
+For other CI systems, create a masked secret named `GITHUB_TOKEN` and expose it
+only to the install, upgrade, or E2E step. Avoid placing the token directly in a
+shell command, where tracing can reveal it.
+
+## Kubernetes
+
+Create a Secret through your normal secret-management workflow, then reference
+it from the Zylos container:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zylos-github
+type: Opaque
+stringData:
+  token: <read-only-token>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zylos
+spec:
+  template:
+    spec:
+      containers:
+        - name: zylos
+          env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: zylos-github
+                  key: token
+```
+
+For production, prefer an external secret controller or an encrypted manifest
+over committing the `Secret` example with a real value.

--- a/docs/github-authentication.md
+++ b/docs/github-authentication.md
@@ -48,6 +48,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 ```
 
+The job token is limited to 1,000 requests per hour per repository. That is
+lower than a normal authenticated user's quota and also applies when the job
+reads component repositories other than the workflow repository, so
+cross-repository component tests may still need a dedicated read-only token.
+
 For other CI systems, create a masked secret named `GITHUB_TOKEN` and expose it
 only to the install, upgrade, or E2E step. Avoid placing the token directly in a
 shell command, where tracing can reveal it.


### PR DESCRIPTION
## Summary
- prefer authenticated `api.github.com` requests for sync/async tag lookup and raw component metadata when a token is available
- fall back to public endpoints when authentication fails, while keeping no-token behavior public-only
- leave public-first GitHub archive/codeload downloads unchanged
- document `GITHUB_TOKEN` setup for CI, Kubernetes, and shared E2E runners

## Validation
- `node --test cli/lib/__tests__/github-rate-limit.test.js`: 20/20 passed
- Jest: 112/112 passed
- full Node suite: 603/604 passed; the sole failure is the pre-existing `runtime-launch.test.js` assertion that expects no Codex bootstrap argument while `origin/main` still sets `kickPrompt = "hello"`
- `git diff --check`: passed

Refs #695. This PR covers Task A only; local-source installation remains in a separate PR.