### PR TITLE
feat(cli): install components from local sources

### DIFF
--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -20,9 +20,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { SKILLS_DIR, COMPONENTS_DIR, BIN_DIR } from '../lib/config.js';
-import { loadRegistry } from '../lib/registry.js';
-import { loadComponents, saveComponents, resolveTarget, outputTask } from '../lib/components.js';
-import { downloadArchive, downloadBranch } from '../lib/download.js';
+import { loadComponents, saveComponents, resolveTarget, loadTargetRegistryInfo, outputTask } from '../lib/components.js';
+import { acquireSource } from '../lib/download.js';
 import { generateManifest, saveManifest } from '../lib/manifest.js';
 import { parseSkillMd, detectComponentType } from '../lib/skill.js';
 import { linkBins } from '../lib/bin.js';
@@ -85,7 +84,7 @@ export async function addComponent(args) {
   }
 
   // 1. Resolve target
-  const resolved = await resolveTarget(target);
+  const resolved = await resolveTarget(target, { branch });
 
   // Validate: --branch conflicts with explicit @version in target
   // (resolved.version may be auto-populated by fetchLatestTag for registry components)
@@ -103,16 +102,32 @@ export async function addComponent(args) {
     process.exit(1);
   }
 
-  if (!resolved.repo) {
+  if (branch && resolved.source?.type !== 'github-release') {
+    if (jsonOutput) {
+      console.log(JSON.stringify({
+        action: 'add', component: target, success: false,
+        error: 'conflict', message: '--branch can only be used with a GitHub source',
+        reply: 'Error: --branch can only be used with a GitHub source.',
+      }, null, 2));
+    } else {
+      console.error(error('--branch can only be used with a GitHub source.'));
+    }
+    process.exit(1);
+  }
+
+  if (!resolved.repo && !resolved.source) {
+    const message = resolved.resolutionError || `Unknown component: ${target}`;
     if (jsonOutput) {
       console.log(JSON.stringify({
         action: 'add_check', component: target, success: false,
-        error: 'not_found', message: `Unknown component: ${target}`,
-        reply: `Component "${target}" not found. Use "search <keyword>" to find available components.`,
+        error: resolved.resolutionError ? 'invalid_local_source' : 'not_found', message,
+        reply: resolved.resolutionError
+          ? message
+          : `Component "${target}" not found. Use "search <keyword>" to find available components.`,
       }, null, 2));
     } else {
-      console.error(error(`Unknown component: ${bold(target)}`));
-      console.log(dim('Use "zylos search <keyword>" to find available components.'));
+      console.error(error(message));
+      if (!resolved.resolutionError) console.log(dim('Use "zylos search <keyword>" to find available components.'));
     }
     process.exit(1);
   }
@@ -134,13 +149,12 @@ export async function addComponent(args) {
   }
 
   // 3. Gather component info from registry
-  const registry = await loadRegistry();
-  const regInfo = registry[resolved.name] || {};
+  const regInfo = await loadTargetRegistryInfo(resolved);
 
   // 4. Check-only mode: show component info without installing
   if (checkOnly) {
-    const noRelease = !branch && !resolved.version;
-    const fetchFailed = !branch && !resolved.version && resolved.fetchError;
+    const noRelease = !resolved.source;
+    const fetchFailed = noRelease && resolved.fetchError;
     if (jsonOutput) {
       const output = {
         action: 'add_check', component: resolved.name, success: !noRelease,
@@ -150,6 +164,7 @@ export async function addComponent(args) {
         description: regInfo.description || null,
         type: regInfo.type || null,
         repo: resolved.repo,
+        source: resolved.source,
         isThirdParty: resolved.isThirdParty || false,
       };
       let reply = `${resolved.name}`;
@@ -157,7 +172,7 @@ export async function addComponent(args) {
       else if (resolved.version) reply += ` (v${resolved.version})`;
       if (regInfo.description) reply += `\n${regInfo.description}`;
       reply += `\nType: ${regInfo.type || 'unknown'}`;
-      reply += `\nRepo: ${resolved.repo}`;
+      reply += `\n${resolved.sourceReplyLabel}: ${resolved.sourceLabel}`;
       if (resolved.isThirdParty) reply += '\nWarning: Third-party component';
       if (fetchFailed) {
         output.error = 'fetch_failed';
@@ -168,7 +183,9 @@ export async function addComponent(args) {
         output.message = `No release found for ${resolved.name}`;
         reply += `\n\nNo release found. Use "add ${resolved.name} --branch main" to install from branch.`;
       } else {
-        let confirmTarget = (!branch && resolved.version) ? `${resolved.name}@${resolved.version}` : resolved.name;
+        let confirmTarget = resolved.repo && !branch && resolved.version
+          ? `${resolved.name}@${resolved.version}`
+          : resolved.installTarget;
         if (branch) confirmTarget += ` --branch ${branch}`;
         reply += `\n\nReply "add ${confirmTarget} confirm" to install.`;
       }
@@ -177,7 +194,7 @@ export async function addComponent(args) {
     } else {
       const versionInfo = branch ? ` (branch: ${bold(branch)})` : (resolved.version ? `@${bold(resolved.version)}` : '');
       console.log(`\n${heading('Component:')} ${bold(resolved.name)}${versionInfo}`);
-      console.log(`${heading('Repository:')} ${dim('https://github.com/' + resolved.repo)}`);
+      console.log(`${heading(resolved.sourceHeading)} ${dim(resolved.sourceLabel)}`);
       if (resolved.isThirdParty) {
         console.log(warn('Third-party component — not verified by Zylos team.'));
       }
@@ -190,7 +207,9 @@ export async function addComponent(args) {
         console.log(`\n${warn('No release found for this component.')}`);
         console.log(dim(`Use "zylos add ${resolved.name} --branch main" to install from a branch.`));
       } else {
-        let installTarget = (!branch && resolved.version) ? `${resolved.name}@${resolved.version}` : resolved.name;
+        let installTarget = resolved.repo && !branch && resolved.version
+          ? `${resolved.name}@${resolved.version}`
+          : resolved.installTarget;
         if (branch) installTarget += ` --branch ${branch}`;
         console.log(`\n${dim(`Run "zylos add ${installTarget} --yes" to install.`)}`);
       }
@@ -202,7 +221,7 @@ export async function addComponent(args) {
   if (!jsonOutput) {
     const versionInfo = branch ? ` (branch: ${bold(branch)})` : (resolved.version ? `@${bold(resolved.version)}` : '');
     console.log(`\n${heading('Component:')} ${bold(resolved.name)}${versionInfo}`);
-    console.log(`${heading('Repository:')} ${dim('https://github.com/' + resolved.repo)}`);
+    console.log(`${heading(resolved.sourceHeading)} ${dim(resolved.sourceLabel)}`);
 
     if (resolved.isThirdParty) {
       console.log(warn('Third-party component — not verified by Zylos team.'));
@@ -243,11 +262,7 @@ export async function addComponent(args) {
   if (!jsonOutput) console.log(`\n${cyan('Downloading')} ${bold(downloadLabel)}...`);
 
   let downloadResult;
-  if (branch) {
-    downloadResult = downloadBranch(resolved.repo, branch, skillDir);
-  } else if (resolved.version) {
-    downloadResult = downloadArchive(resolved.repo, resolved.version, skillDir);
-  } else {
+  if (!resolved.source) {
     // No release tag found and no --branch specified
     const errType = resolved.fetchError ? 'fetch_failed' : 'no_release';
     const errMsg = resolved.fetchError
@@ -265,6 +280,7 @@ export async function addComponent(args) {
     }
     process.exit(1);
   }
+  downloadResult = acquireSource(resolved.source, skillDir);
 
   if (!downloadResult.success) {
     if (jsonOutput) {
@@ -321,6 +337,7 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
   // by fetchLatestTag and doesn't reflect the actual branch code)
   const componentVersion = (branch ? null : resolved.version)
     || fm.version
+    || readVersionFile(skillDir)
     || (() => {
       try {
         const pkg = JSON.parse(fs.readFileSync(path.join(skillDir, 'package.json'), 'utf8'));
@@ -372,6 +389,7 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
     installedAt: new Date().toISOString(),
     skillDir,
     dataDir,
+    source: resolved.source,
   };
   if (branch) componentEntry.branch = branch;
   components[resolved.name] = componentEntry;
@@ -567,6 +585,7 @@ function installAI(resolved, skillDir, branch) {
         return skill?.frontmatter?.version;
       } catch { return null; }
     })()
+    || readVersionFile(skillDir)
     || (() => {
       try {
         const pkg = JSON.parse(fs.readFileSync(path.join(skillDir, 'package.json'), 'utf8'));
@@ -585,6 +604,7 @@ function installAI(resolved, skillDir, branch) {
     installedAt: new Date().toISOString(),
     skillDir,
     setupComplete: false,
+    source: resolved.source,
   };
   if (branch) aiEntry.branch = branch;
   components[resolved.name] = aiEntry;
@@ -623,11 +643,19 @@ function cleanup(dir) {
   }
 }
 
+function readVersionFile(skillDir) {
+  try {
+    return fs.readFileSync(path.join(skillDir, 'VERSION'), 'utf8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 function printUsage() {
   console.log(`Usage: zylos add <target> [options]
 
 Arguments:
-  target    Component name, org/repo, or GitHub URL
+  target    Component name, org/repo, GitHub URL, local directory, or .tar.gz
 
 Options:
   --branch <name>  Install from a specific git branch (for testing)
@@ -641,5 +669,7 @@ Examples:
   zylos add lark --branch main                  Install from branch
   zylos add lark --branch feature/new-thing     Install from PR branch
   zylos add user/my-component                   Third-party
-  zylos add https://github.com/user/zylos-my-component`);
+  zylos add https://github.com/user/zylos-my-component
+  zylos add ./my-component
+  zylos add ./my-component.tar.gz`);
 }

--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -9,7 +9,7 @@ import { ZYLOS_DIR, SKILLS_DIR, COMPONENTS_DIR, getZylosConfig } from '../lib/co
 import { bold, dim, green, red, yellow, cyan, success, error, warn, heading } from '../lib/colors.js';
 import { loadRegistry } from '../lib/registry.js';
 import { loadComponents, saveComponents } from '../lib/components.js';
-import { checkForUpdates, getRepo, runUpgrade, downloadToTemp, readChangelog, filterChangelog, cleanupTemp } from '../lib/upgrade.js';
+import { checkForUpdates, getLocalSourceUpgradeError, getRepo, runUpgrade, downloadToTemp, readChangelog, filterChangelog, cleanupTemp } from '../lib/upgrade.js';
 import {
   checkForCoreUpdates, runSelfUpgrade,
   downloadCoreToTemp, readChangelog as readCoreChangelog,
@@ -338,6 +338,22 @@ export async function upgradeComponent(args) {
       console.log(JSON.stringify(result, null, 2));
     } else {
       console.error(`Error: ${result.message}`);
+    }
+    process.exit(1);
+  }
+
+  const localSourceError = getLocalSourceUpgradeError(target, components[target]);
+  if (localSourceError) {
+    const result = {
+      action: checkOnly ? 'check' : 'upgrade',
+      component: target,
+      ...localSourceError,
+      reply: localSourceError.message,
+    };
+    if (jsonOutput) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.error(`Error: ${localSourceError.message}`);
     }
     process.exit(1);
   }
@@ -796,6 +812,8 @@ async function upgradeAllComponents({ checkOnly, jsonOutput, skipConfirm, skipEv
 
     if (!jsonOutput && check.success && check.hasUpdate) {
       console.log(`  ${dim(check.current)} → ${bold(check.latest)}`);
+    } else if (!jsonOutput && !check.success) {
+      console.log(`  ${warn(check.message || check.error)}`);
     }
   }
 
@@ -814,7 +832,12 @@ async function upgradeAllComponents({ checkOnly, jsonOutput, skipConfirm, skipEv
   }
 
   if (updatable.length === 0) {
-    console.log(`\n${success('All components are up to date.')}`);
+    const failed = results.filter(r => !r.success);
+    if (failed.length > 0) {
+      console.log(`\n${warn('No remotely updatable components found; see checks above.')}`);
+    } else {
+      console.log(`\n${success('All components are up to date.')}`);
+    }
     return;
   }
 

--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -171,13 +171,26 @@ function formatC4Reply(type, data) {
     }
     case 'check-all': {
       const { total, updatable, components } = data;
-      if (updatable === 0) return 'All components are up to date.';
-      let r = `${updatable} of ${total} component(s) have updates:`;
-      for (const c of components) {
-        if (c.hasUpdate) r += `\n  ${c.component}: ${c.current} -> ${c.latest}`;
+      const failed = components.filter(c => !c.success);
+      if (updatable === 0 && failed.length === 0) return 'All components are up to date.';
+
+      const sections = [];
+      if (failed.length > 0) {
+        let failures = `${failed.length} of ${total} component check(s) failed:`;
+        for (const c of failed) {
+          failures += `\n  ${c.component}: ${c.message || c.error || 'unknown error'}`;
+        }
+        sections.push(failures);
       }
-      r += '\n\nUse "check <name>" to see details, or "upgrade <name>" to preview.';
-      return r;
+      if (updatable > 0) {
+        let updates = `${updatable} of ${total} component(s) have updates:`;
+        for (const c of components) {
+          if (c.success && c.hasUpdate) updates += `\n  ${c.component}: ${c.current} -> ${c.latest}`;
+        }
+        updates += '\n\nUse "check <name>" to see details, or "upgrade <name>" to preview.';
+        sections.push(updates);
+      }
+      return sections.join('\n\n');
     }
     case 'info': {
       const { name, version, description, type: compType, repo, service } = data;
@@ -818,21 +831,28 @@ async function upgradeAllComponents({ checkOnly, jsonOutput, skipConfirm, skipEv
   }
 
   const updatable = results.filter(r => r.success && r.hasUpdate);
+  const failed = results.filter(r => !r.success);
 
   if (jsonOutput) {
     const output = {
       action: checkOnly ? 'check_all' : 'upgrade_all',
+      success: failed.length === 0,
       total: names.length,
       updatable: updatable.length,
+      failed: failed.length,
       components: results,
     };
     output.reply = formatC4Reply('check-all', { total: names.length, updatable: updatable.length, components: results });
+    if (failed.length > 0) {
+      output.error = 'component_checks_failed';
+      output.message = `${failed.length} component check(s) failed`;
+    }
     console.log(JSON.stringify(output, null, 2));
+    if (failed.length > 0) process.exit(1);
     return;
   }
 
   if (updatable.length === 0) {
-    const failed = results.filter(r => !r.success);
     if (failed.length > 0) {
       console.log(`\n${warn('No remotely updatable components found; see checks above.')}`);
     } else {

--- a/cli/lib/__tests__/local-source.e2e.test.js
+++ b/cli/lib/__tests__/local-source.e2e.test.js
@@ -45,6 +45,15 @@ function runAdd({ cwd, zylosDir, target, env = {} }) {
   return JSON.parse(result.stdout);
 }
 
+function runCli({ cwd, zylosDir, args, env = {} }) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    env: { ...process.env, ZYLOS_DIR: zylosDir, ...env },
+    encoding: 'utf8',
+    timeout: 30000,
+  });
+}
+
 function readInstalled(zylosDir, name) {
   const components = JSON.parse(fs.readFileSync(path.join(zylosDir, '.zylos', 'components.json'), 'utf8'));
   const skillDir = path.join(zylosDir, '.claude', 'skills', name);
@@ -52,12 +61,12 @@ function readInstalled(zylosDir, name) {
 }
 
 describe('zylos add local source E2E', () => {
-  it('installs a bare relative directory through the complete add pipeline', () => {
+  it('installs an explicit relative directory through the complete add pipeline', () => {
     const { root, zylosDir } = makeFixture();
     const sourceName = 'relative-component';
     writeSkill(path.join(root, sourceName), { name: 'local-directory-e2e', version: '3.1.4' });
 
-    const output = runAdd({ cwd: root, zylosDir, target: sourceName });
+    const output = runAdd({ cwd: root, zylosDir, target: `./${sourceName}` });
     const { components, skillDir } = readInstalled(zylosDir, 'local-directory-e2e');
 
     assert.equal(output.success, true);
@@ -67,6 +76,33 @@ describe('zylos add local source E2E', () => {
     assert.equal(components['local-directory-e2e'].source.type, 'local-dir');
     assert.equal(fs.readFileSync(path.join(skillDir, 'payload.txt'), 'utf8'), 'local-directory-e2e payload\n');
     assert.equal(fs.existsSync(path.join(skillDir, '.zylos', 'manifest.json')), true);
+  });
+
+  it('uses an absolute local path in --check confirmation output', () => {
+    const { root, zylosDir } = makeFixture();
+    const sourceName = 'relative-component';
+    const sourceDir = path.join(root, sourceName);
+    writeSkill(sourceDir, { name: 'local-check-e2e', version: '4.5.6' });
+
+    const result = runCli({ cwd: root, zylosDir, args: ['add', `./${sourceName}`, '--check', '--json'] });
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    const canonicalSourceDir = fs.realpathSync(sourceDir);
+    assert.equal(output.source.path, canonicalSourceDir);
+    assert.match(output.reply, new RegExp(canonicalSourceDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  it('does not let a cwd directory hijack a bare component name', () => {
+    const { root, zylosDir } = makeFixture();
+    writeSkill(path.join(root, 'not-in-registry'), { name: 'hijacked-local', version: '1.0.0' });
+
+    const result = runCli({ cwd: root, zylosDir, args: ['add', 'not-in-registry', '--json'] });
+
+    assert.equal(result.status, 1);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.error, 'not_found');
+    assert.equal(fs.existsSync(path.join(zylosDir, '.claude', 'skills', 'hijacked-local')), false);
   });
 
   it('installs a local tarball and records its VERSION metadata', () => {
@@ -95,10 +131,11 @@ describe('zylos add local source E2E', () => {
     const tarball = path.join(root, 'github-release.tar.gz');
     const fakeBin = path.join(root, 'bin');
     const fakeCurl = path.join(fakeBin, 'curl');
+    const fakeCurlModule = path.join(fakeBin, 'curl.mjs');
     writeSkill(wrapper, { name: 'github-fixture', version: '9.9.9' });
     execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
     fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(fakeCurl, `#!/usr/bin/env node
+    fs.writeFileSync(fakeCurlModule, `
 import fs from 'node:fs';
 const args = process.argv.slice(2);
 const outputIndex = args.indexOf('-o');
@@ -108,6 +145,9 @@ if (outputIndex !== -1 && url.includes('/archive/refs/tags/')) {
   process.exit(0);
 }
 process.exit(22);
+`, 'utf8');
+    fs.writeFileSync(fakeCurl, `#!/bin/sh
+exec "${process.execPath}" "$(dirname "$0")/curl.mjs" "$@"
 `, { mode: 0o755 });
 
     const output = runAdd({
@@ -133,5 +173,64 @@ process.exit(22);
       refType: 'tag',
     });
     assert.equal(fs.readFileSync(path.join(skillDir, 'payload.txt'), 'utf8'), 'github-fixture payload\n');
+  });
+
+  it('rejects upgrade checks for locally installed components with reinstall guidance', () => {
+    const { root, zylosDir } = makeFixture();
+    const sourceDir = path.join(root, 'local-upgrade-source');
+    writeSkill(sourceDir, { name: 'local-upgrade-e2e', version: '1.0.0' });
+    runAdd({ cwd: root, zylosDir, target: './local-upgrade-source' });
+
+    const result = runCli({
+      cwd: root,
+      zylosDir,
+      args: ['upgrade', 'local-upgrade-e2e', '--check', '--json'],
+    });
+
+    assert.equal(result.status, 1);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.error, 'local_source_upgrade_unsupported');
+    assert.equal(output.source.path, fs.realpathSync(sourceDir));
+    assert.match(output.message, /Reinstall it from/);
+
+    const branchResult = runCli({
+      cwd: root,
+      zylosDir,
+      args: ['upgrade', 'local-upgrade-e2e', '--check', '--branch', 'main', '--json'],
+    });
+    assert.equal(branchResult.status, 1);
+    assert.equal(JSON.parse(branchResult.stdout).error, 'local_source_upgrade_unsupported');
+  });
+
+  it('reports and skips locally installed components during upgrade --all', () => {
+    const { root, zylosDir } = makeFixture();
+    const sourceDir = path.join(root, 'local-upgrade-all-source');
+    writeSkill(sourceDir, { name: 'local-upgrade-all-e2e', version: '1.0.0' });
+    runAdd({ cwd: root, zylosDir, target: './local-upgrade-all-source' });
+
+    fs.writeFileSync(
+      path.join(sourceDir, 'payload.txt'),
+      'changed source must not overwrite the installed component\n',
+      'utf8'
+    );
+    const result = runCli({
+      cwd: root,
+      zylosDir,
+      args: ['upgrade', '--all', '--yes', '--json'],
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.updatable, 0);
+    assert.equal(output.components.length, 1);
+    assert.equal(output.components[0].component, 'local-upgrade-all-e2e');
+    assert.equal(output.components[0].error, 'local_source_upgrade_unsupported');
+    assert.equal(
+      fs.readFileSync(
+        path.join(zylosDir, '.claude', 'skills', 'local-upgrade-all-e2e', 'payload.txt'),
+        'utf8'
+      ),
+      'local-upgrade-all-e2e payload\n'
+    );
   });
 });

--- a/cli/lib/__tests__/local-source.e2e.test.js
+++ b/cli/lib/__tests__/local-source.e2e.test.js
@@ -202,7 +202,7 @@ exec "${process.execPath}" "$(dirname "$0")/curl.mjs" "$@"
     assert.equal(JSON.parse(branchResult.stdout).error, 'local_source_upgrade_unsupported');
   });
 
-  it('reports and skips locally installed components during upgrade --all', () => {
+  it('fails the upgrade --all JSON aggregate for a local-only install', () => {
     const { root, zylosDir } = makeFixture();
     const sourceDir = path.join(root, 'local-upgrade-all-source');
     writeSkill(sourceDir, { name: 'local-upgrade-all-e2e', version: '1.0.0' });
@@ -219,12 +219,17 @@ exec "${process.execPath}" "$(dirname "$0")/curl.mjs" "$@"
       args: ['upgrade', '--all', '--yes', '--json'],
     });
 
-    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.status, 1, result.stderr);
     const output = JSON.parse(result.stdout);
+    assert.equal(output.success, false);
+    assert.equal(output.failed, 1);
+    assert.equal(output.error, 'component_checks_failed');
     assert.equal(output.updatable, 0);
     assert.equal(output.components.length, 1);
     assert.equal(output.components[0].component, 'local-upgrade-all-e2e');
     assert.equal(output.components[0].error, 'local_source_upgrade_unsupported');
+    assert.match(output.reply, /1 of 1 component check\(s\) failed/);
+    assert.doesNotMatch(output.reply, /All components are up to date/);
     assert.equal(
       fs.readFileSync(
         path.join(zylosDir, '.claude', 'skills', 'local-upgrade-all-e2e', 'payload.txt'),
@@ -232,5 +237,67 @@ exec "${process.execPath}" "$(dirname "$0")/curl.mjs" "$@"
       ),
       'local-upgrade-all-e2e payload\n'
     );
+  });
+
+  it('fails the upgrade --all JSON aggregate while preserving remote updates', () => {
+    const { root, zylosDir } = makeFixture();
+    const sourceDir = path.join(root, 'local-mixed-source');
+    writeSkill(sourceDir, { name: 'local-mixed-e2e', version: '1.0.0' });
+    runAdd({ cwd: root, zylosDir, target: './local-mixed-source' });
+
+    const remoteName = 'remote-mixed-e2e';
+    writeSkill(
+      path.join(zylosDir, '.claude', 'skills', remoteName),
+      { name: remoteName, version: '1.0.0' }
+    );
+    const componentsPath = path.join(zylosDir, '.zylos', 'components.json');
+    const components = JSON.parse(fs.readFileSync(componentsPath, 'utf8'));
+    components[remoteName] = {
+      version: '1.0.0',
+      repo: 'example/zylos-remote-mixed-e2e',
+      source: {
+        type: 'github-release',
+        repo: 'example/zylos-remote-mixed-e2e',
+        ref: '1.0.0',
+        refType: 'tag',
+      },
+    };
+    fs.writeFileSync(componentsPath, `${JSON.stringify(components, null, 2)}\n`, 'utf8');
+
+    const fakeBin = path.join(root, 'bin');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, 'curl'),
+      '#!/bin/sh\ncat >/dev/null\nprintf \'%s\\n\' \'[{"name":"v2.0.0"}]\'\n',
+      { mode: 0o755 }
+    );
+
+    const result = runCli({
+      cwd: root,
+      zylosDir,
+      args: ['upgrade', '--all', '--yes', '--json'],
+      env: {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        GITHUB_TOKEN: 'test-token',
+        GH_TOKEN: '',
+      },
+    });
+
+    assert.equal(result.status, 1, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.success, false);
+    assert.equal(output.failed, 1);
+    assert.equal(output.updatable, 1);
+    assert.equal(output.error, 'component_checks_failed');
+    const local = output.components.find(c => c.component === 'local-mixed-e2e');
+    const remote = output.components.find(c => c.component === remoteName);
+    assert.equal(local.error, 'local_source_upgrade_unsupported');
+    assert.equal(remote.success, true);
+    assert.equal(remote.hasUpdate, true);
+    assert.equal(remote.current, '1.0.0');
+    assert.equal(remote.latest, '2.0.0');
+    assert.match(output.reply, /1 of 2 component check\(s\) failed/);
+    assert.match(output.reply, /1 of 2 component\(s\) have updates/);
+    assert.doesNotMatch(output.reply, /All components are up to date/);
   });
 });

--- a/cli/lib/__tests__/local-source.e2e.test.js
+++ b/cli/lib/__tests__/local-source.e2e.test.js
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { afterEach, describe, it } from 'node:test';
+
+const CLI = path.join(import.meta.dirname, '..', '..', 'zylos.js');
+const tmpDirs = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-local-add-e2e-'));
+  tmpDirs.push(root);
+  const zylosDir = path.join(root, 'zylos-home');
+  fs.mkdirSync(path.join(zylosDir, '.zylos'), { recursive: true });
+  fs.writeFileSync(path.join(zylosDir, '.zylos', 'components.json'), '{}\n', 'utf8');
+  return { root, zylosDir };
+}
+
+function writeSkill(dir, { name, version = null }) {
+  fs.mkdirSync(dir, { recursive: true });
+  const versionLine = version ? `\nversion: ${version}` : '';
+  fs.writeFileSync(
+    path.join(dir, 'SKILL.md'),
+    `---\nname: ${name}${versionLine}\ndescription: Local source E2E fixture\n---\n\n# Fixture\n`,
+    'utf8'
+  );
+  fs.writeFileSync(path.join(dir, 'payload.txt'), `${name} payload\n`, 'utf8');
+}
+
+function runAdd({ cwd, zylosDir, target, env = {} }) {
+  const result = spawnSync(process.execPath, [CLI, 'add', target, '--json'], {
+    cwd,
+    env: { ...process.env, ZYLOS_DIR: zylosDir, ...env },
+    encoding: 'utf8',
+    timeout: 30000,
+  });
+  assert.equal(result.status, 0, `add failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function readInstalled(zylosDir, name) {
+  const components = JSON.parse(fs.readFileSync(path.join(zylosDir, '.zylos', 'components.json'), 'utf8'));
+  const skillDir = path.join(zylosDir, '.claude', 'skills', name);
+  return { components, skillDir };
+}
+
+describe('zylos add local source E2E', () => {
+  it('installs a bare relative directory through the complete add pipeline', () => {
+    const { root, zylosDir } = makeFixture();
+    const sourceName = 'relative-component';
+    writeSkill(path.join(root, sourceName), { name: 'local-directory-e2e', version: '3.1.4' });
+
+    const output = runAdd({ cwd: root, zylosDir, target: sourceName });
+    const { components, skillDir } = readInstalled(zylosDir, 'local-directory-e2e');
+
+    assert.equal(output.success, true);
+    assert.equal(output.component, 'local-directory-e2e');
+    assert.equal(output.version, '3.1.4');
+    assert.equal(components['local-directory-e2e'].version, '3.1.4');
+    assert.equal(components['local-directory-e2e'].source.type, 'local-dir');
+    assert.equal(fs.readFileSync(path.join(skillDir, 'payload.txt'), 'utf8'), 'local-directory-e2e payload\n');
+    assert.equal(fs.existsSync(path.join(skillDir, '.zylos', 'manifest.json')), true);
+  });
+
+  it('installs a local tarball and records its VERSION metadata', () => {
+    const { root, zylosDir } = makeFixture();
+    const wrapper = path.join(root, 'tar-wrapper');
+    const tarball = path.join(root, 'component.tar.gz');
+    writeSkill(wrapper, { name: 'local-tarball-e2e' });
+    fs.writeFileSync(path.join(wrapper, 'VERSION'), '5.6.7\n', 'utf8');
+    execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+
+    const output = runAdd({ cwd: root, zylosDir, target: './component.tar.gz' });
+    const { components, skillDir } = readInstalled(zylosDir, 'local-tarball-e2e');
+
+    assert.equal(output.success, true);
+    assert.equal(output.component, 'local-tarball-e2e');
+    assert.equal(output.version, '5.6.7');
+    assert.equal(components['local-tarball-e2e'].version, '5.6.7');
+    assert.equal(components['local-tarball-e2e'].source.type, 'local-tarball');
+    assert.equal(fs.readFileSync(path.join(skillDir, 'payload.txt'), 'utf8'), 'local-tarball-e2e payload\n');
+    assert.equal(fs.existsSync(path.join(skillDir, '.zylos', 'manifest.json')), true);
+  });
+
+  it('keeps the GitHub release acquisition path working', () => {
+    const { root, zylosDir } = makeFixture();
+    const wrapper = path.join(root, 'github-wrapper');
+    const tarball = path.join(root, 'github-release.tar.gz');
+    const fakeBin = path.join(root, 'bin');
+    const fakeCurl = path.join(fakeBin, 'curl');
+    writeSkill(wrapper, { name: 'github-fixture', version: '9.9.9' });
+    execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(fakeCurl, `#!/usr/bin/env node
+import fs from 'node:fs';
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf('-o');
+const url = args.at(-1) || '';
+if (outputIndex !== -1 && url.includes('/archive/refs/tags/')) {
+  fs.copyFileSync(process.env.FAKE_GITHUB_TARBALL, args[outputIndex + 1]);
+  process.exit(0);
+}
+process.exit(22);
+`, { mode: 0o755 });
+
+    const output = runAdd({
+      cwd: root,
+      zylosDir,
+      target: 'example/zylos-github-fixture@1.0.0',
+      env: {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        FAKE_GITHUB_TARBALL: tarball,
+        GITHUB_TOKEN: '',
+        GH_TOKEN: '',
+      },
+    });
+    const { components, skillDir } = readInstalled(zylosDir, 'github-fixture');
+
+    assert.equal(output.success, true);
+    assert.equal(output.version, '1.0.0');
+    assert.equal(components['github-fixture'].repo, 'example/zylos-github-fixture');
+    assert.deepEqual(components['github-fixture'].source, {
+      type: 'github-release',
+      repo: 'example/zylos-github-fixture',
+      ref: '1.0.0',
+      refType: 'tag',
+    });
+    assert.equal(fs.readFileSync(path.join(skillDir, 'payload.txt'), 'utf8'), 'github-fixture payload\n');
+  });
+});

--- a/cli/lib/__tests__/local-source.test.js
+++ b/cli/lib/__tests__/local-source.test.js
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, describe, it } from 'node:test';
+import { acquireSource, inspectLocalSource, registerSourceResolver } from '../download.js';
+import { resolveTarget } from '../components.js';
+
+const tmpDirs = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-local-source-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeSkill(dir, frontmatter) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${frontmatter}\n---\n\n# Fixture\n`, 'utf8');
+  fs.writeFileSync(path.join(dir, 'payload.txt'), 'fixture payload\n', 'utf8');
+}
+
+describe('local component source resolution', () => {
+  it('reads name and version from SKILL.md for a local directory', async () => {
+    const root = makeTmpDir();
+    const sourceDir = path.join(root, 'source-dir');
+    writeSkill(sourceDir, 'name: directory-fixture\nversion: 1.2.3');
+
+    const inspected = inspectLocalSource(sourceDir);
+    const resolved = await resolveTarget(sourceDir);
+
+    assert.deepEqual(inspected, {
+      name: 'directory-fixture',
+      version: '1.2.3',
+      source: { type: 'local-dir', path: sourceDir },
+    });
+    assert.equal(resolved.name, 'directory-fixture');
+    assert.equal(resolved.version, '1.2.3');
+    assert.equal(resolved.source.type, 'local-dir');
+  });
+
+  it('reads VERSION from a wrapped local tarball and acquires its contents', () => {
+    const root = makeTmpDir();
+    const wrapper = path.join(root, 'wrapped-component');
+    const tarball = path.join(root, 'fixture.tar.gz');
+    const dest = path.join(root, 'dest');
+    writeSkill(wrapper, 'name: tarball-fixture');
+    fs.writeFileSync(path.join(wrapper, 'VERSION'), '2.4.6\n', 'utf8');
+    execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+
+    const inspected = inspectLocalSource(tarball);
+    const acquired = acquireSource(inspected.source, dest);
+
+    assert.equal(inspected.name, 'tarball-fixture');
+    assert.equal(inspected.version, '2.4.6');
+    assert.equal(inspected.source.type, 'local-tarball');
+    assert.equal(acquired.success, true);
+    assert.equal(fs.readFileSync(path.join(dest, 'payload.txt'), 'utf8'), 'fixture payload\n');
+    assert.equal(fs.existsSync(path.join(dest, path.basename(wrapper))), false);
+  });
+
+  it('keeps an absent org/repo target on the GitHub path', async () => {
+    const resolved = await resolveTarget('example/zylos-demo@9.8.7');
+
+    assert.equal(resolved.name, 'demo');
+    assert.equal(resolved.repo, 'example/zylos-demo');
+    assert.deepEqual(resolved.source, {
+      type: 'github-release',
+      repo: 'example/zylos-demo',
+      ref: '9.8.7',
+      refType: 'tag',
+    });
+  });
+
+  it('allows future acquire resolvers to be registered without changing add', () => {
+    const root = makeTmpDir();
+    const dest = path.join(root, 'dest');
+    registerSourceResolver('test-resolver', {
+      acquire(source, targetDir) {
+        fs.mkdirSync(targetDir, { recursive: true });
+        fs.writeFileSync(path.join(targetDir, 'value'), source.value, 'utf8');
+        return { success: true, extractedDir: targetDir };
+      },
+    });
+
+    const result = acquireSource({ type: 'test-resolver', value: 'extension seam' }, dest);
+
+    assert.equal(result.success, true);
+    assert.equal(fs.readFileSync(path.join(dest, 'value'), 'utf8'), 'extension seam');
+  });
+});

--- a/cli/lib/__tests__/local-source.test.js
+++ b/cli/lib/__tests__/local-source.test.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { afterEach, describe, it } from 'node:test';
 import { acquireSource, inspectLocalSource, registerSourceResolver } from '../download.js';
-import { resolveTarget } from '../components.js';
+import { isLocalPathSpecifier, resolveTarget } from '../components.js';
 
 const tmpDirs = [];
 
@@ -25,6 +25,10 @@ function writeSkill(dir, frontmatter) {
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'SKILL.md'), `---\n${frontmatter}\n---\n\n# Fixture\n`, 'utf8');
   fs.writeFileSync(path.join(dir, 'payload.txt'), 'fixture payload\n', 'utf8');
+}
+
+function writePackage(dir, version) {
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ version }), 'utf8');
 }
 
 describe('local component source resolution', () => {
@@ -64,6 +68,109 @@ describe('local component source resolution', () => {
     assert.equal(acquired.success, true);
     assert.equal(fs.readFileSync(path.join(dest, 'payload.txt'), 'utf8'), 'fixture payload\n');
     assert.equal(fs.existsSync(path.join(dest, path.basename(wrapper))), false);
+  });
+
+  it('recognizes only explicit local path forms without cwd-based bare-name collisions', () => {
+    for (const value of ['./telegram', '../telegram', '/tmp/telegram', '~/telegram', 'build.tgz', 'build.tar.gz']) {
+      assert.equal(isLocalPathSpecifier(value), true, value);
+    }
+    for (const value of [
+      'telegram',
+      'lark',
+      'example/zylos-demo',
+      'https://github.com/example/zylos-demo/archive/refs/tags/v1.0.0.tar.gz',
+    ]) {
+      assert.equal(isLocalPathSpecifier(value), false, value);
+    }
+  });
+
+  it('keeps an unknown local version null', async () => {
+    const root = makeTmpDir();
+    const sourceDir = path.join(root, 'source-dir');
+    writeSkill(sourceDir, 'name: unknown-version-fixture');
+
+    const inspected = inspectLocalSource(sourceDir);
+    const resolved = await resolveTarget(sourceDir);
+
+    assert.equal(inspected.version, null);
+    assert.equal(resolved.version, null);
+  });
+
+  it('reads a package-only version from a local directory', () => {
+    const root = makeTmpDir();
+    const sourceDir = path.join(root, 'source-dir');
+    writeSkill(sourceDir, 'name: package-directory-fixture');
+    writePackage(sourceDir, '6.7.8');
+
+    assert.equal(inspectLocalSource(sourceDir).version, '6.7.8');
+  });
+
+  it('reads a package-only version from a wrapped local tarball', () => {
+    const root = makeTmpDir();
+    const wrapper = path.join(root, 'wrapped-component');
+    const tarball = path.join(root, 'fixture.tar.gz');
+    writeSkill(wrapper, 'name: package-tarball-fixture');
+    writePackage(wrapper, '7.8.9');
+    execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+
+    assert.equal(inspectLocalSource(tarball).version, '7.8.9');
+  });
+
+  it('rejects local tarballs containing symbolic links before extraction', () => {
+    const root = makeTmpDir();
+    const wrapper = path.join(root, 'wrapped-component');
+    const tarball = path.join(root, 'fixture.tar.gz');
+    writeSkill(wrapper, 'name: malicious-tarball-fixture\nversion: 1.0.0');
+    fs.symlinkSync('../../outside', path.join(wrapper, 'escape'));
+    execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+
+    assert.throws(
+      () => inspectLocalSource(tarball),
+      /symbolic or hard link; links are not allowed/
+    );
+  });
+
+  it('rejects local tarballs containing hard links before extraction', () => {
+    const root = makeTmpDir();
+    const wrapper = path.join(root, 'wrapped-component');
+    const tarball = path.join(root, 'fixture.tar.gz');
+    writeSkill(wrapper, 'name: malicious-hardlink-fixture\nversion: 1.0.0');
+    fs.linkSync(path.join(wrapper, 'payload.txt'), path.join(wrapper, 'payload-hardlink.txt'));
+    execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+
+    assert.throws(
+      () => inspectLocalSource(tarball),
+      /symbolic or hard link; links are not allowed/
+    );
+  });
+
+  it('rejects missing paths and invalid local component names', async () => {
+    const root = makeTmpDir();
+    const missing = await resolveTarget(path.join(root, 'missing'));
+    assert.match(missing.resolutionError, /Local source not found/);
+
+    const invalidDir = path.join(root, 'invalid');
+    writeSkill(invalidDir, 'name: invalid/name');
+    const invalid = await resolveTarget(invalidDir);
+    assert.match(invalid.resolutionError, /Invalid local component name/);
+  });
+
+  it('excludes generated and private runtime directories when copying a local source', () => {
+    const root = makeTmpDir();
+    const sourceDir = path.join(root, 'source-dir');
+    const dest = path.join(root, 'dest');
+    writeSkill(sourceDir, 'name: copy-filter-fixture\nversion: 1.0.0');
+    for (const excluded of ['node_modules', '.zylos', '.backup', '.git']) {
+      fs.mkdirSync(path.join(sourceDir, excluded), { recursive: true });
+      fs.writeFileSync(path.join(sourceDir, excluded, 'private.txt'), 'do not copy', 'utf8');
+    }
+
+    const result = acquireSource(inspectLocalSource(sourceDir).source, dest);
+
+    assert.equal(result.success, true);
+    for (const excluded of ['node_modules', '.zylos', '.backup', '.git']) {
+      assert.equal(fs.existsSync(path.join(dest, excluded)), false, excluded);
+    }
   });
 
   it('keeps an absent org/repo target on the GitHub path', async () => {

--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -8,6 +8,7 @@ import { spawnSync } from 'node:child_process';
 import { COMPONENTS_FILE } from './config.js';
 import { loadRegistry } from './registry.js';
 import { fetchLatestTag } from './github.js';
+import { inspectLocalSource } from './download.js';
 
 /**
  * Load installed components from components.json
@@ -31,11 +32,46 @@ export function saveComponents(components) {
 }
 
 /**
- * Resolve component target from name or URL
- * Supports: name, name@version, org/repo, org/repo@version, github-url
- * @returns {object} { name, repo, version, fetchError, isThirdParty }
+ * Resolve component target from a registry name, GitHub reference, or local path.
+ *
+ * The returned `source` descriptor is intentionally independent from `add` so
+ * the same descriptor can be persisted and consumed by a future upgrade flow.
+ *
+ * @param {string} nameOrUrl
+ * @param {{ branch?: string | null }} [options]
+ * @returns {Promise<object>}
  */
-export async function resolveTarget(nameOrUrl) {
+export async function resolveTarget(nameOrUrl, { branch = null } = {}) {
+  if (isLocalPathSpecifier(nameOrUrl)) {
+    try {
+      const inspected = inspectLocalSource(nameOrUrl);
+      return {
+        name: inspected.name,
+        repo: null,
+        version: inspected.version || '0.0.0',
+        fetchError: null,
+        isThirdParty: true,
+        source: inspected.source,
+        sourceLabel: inspected.source.path,
+        sourceHeading: 'Source:',
+        sourceReplyLabel: 'Source',
+        installTarget: nameOrUrl,
+      };
+    } catch (err) {
+      return {
+        name: localFallbackName(nameOrUrl),
+        repo: null,
+        version: null,
+        fetchError: null,
+        isThirdParty: true,
+        source: null,
+        sourceLabel: path.resolve(expandHome(nameOrUrl)),
+        installTarget: nameOrUrl,
+        resolutionError: err.message,
+      };
+    }
+  }
+
   // Extract version if present (name@version or org/repo@version)
   let version = null;
   let target = nameOrUrl;
@@ -59,32 +95,108 @@ export async function resolveTarget(nameOrUrl) {
   if (githubMatch) {
     const repo = githubMatch[1].replace(/\.git$/, '');
     const name = repo.split('/')[1].replace(/^zylos-/, '');
-    const tag = version ? { version, fetchError: null } : tryFetchLatestTag(repo);
-    return { name, repo, version: tag.version, fetchError: tag.fetchError, isThirdParty: !repo.startsWith('zylos-ai/') };
+    return resolveGitHubTarget({ name, repo, version, branch, tryFetchLatestTag, installTarget: nameOrUrl });
   }
 
   // Check if it's in format org/repo
   if (target.includes('/')) {
     const name = target.split('/')[1].replace(/^zylos-/, '');
-    const tag = version ? { version, fetchError: null } : tryFetchLatestTag(target);
-    return { name, repo: target, version: tag.version, fetchError: tag.fetchError, isThirdParty: !target.startsWith('zylos-ai/') };
+    return resolveGitHubTarget({ name, repo: target, version, branch, tryFetchLatestTag, installTarget: nameOrUrl });
   }
 
   // Look up in registry
   const registry = await loadRegistry();
   if (registry[target]) {
-    const tag = version ? { version, fetchError: null } : tryFetchLatestTag(registry[target].repo);
-    return {
+    return resolveGitHubTarget({
       name: target,
       repo: registry[target].repo,
-      version: tag.version,
-      fetchError: tag.fetchError,
+      version,
+      branch,
+      tryFetchLatestTag,
+      installTarget: nameOrUrl,
       isThirdParty: false,
-    };
+    });
   }
 
   // Unknown - treat as third party
-  return { name: target, repo: null, version, fetchError: null, isThirdParty: true };
+  return {
+    name: target,
+    repo: null,
+    version,
+    fetchError: null,
+    isThirdParty: true,
+    source: null,
+    sourceLabel: null,
+    installTarget: nameOrUrl,
+  };
+}
+
+/**
+ * Registry metadata is presentation-only. Local sources must remain fully
+ * offline, so they never trigger the remote registry fallback chain.
+ */
+export async function loadTargetRegistryInfo(resolved) {
+  if (!resolved.repo) return {};
+  const registry = await loadRegistry();
+  return registry[resolved.name] || {};
+}
+
+function resolveGitHubTarget({
+  name,
+  repo,
+  version,
+  branch,
+  tryFetchLatestTag,
+  installTarget,
+  isThirdParty = !repo.startsWith('zylos-ai/'),
+}) {
+  const tag = branch
+    ? { version: null, fetchError: null }
+    : (version ? { version, fetchError: null } : tryFetchLatestTag(repo));
+  const resolvedVersion = tag.version;
+  const ref = branch || resolvedVersion;
+  return {
+    name,
+    repo,
+    version: resolvedVersion,
+    fetchError: tag.fetchError,
+    isThirdParty,
+    source: ref ? {
+      type: 'github-release',
+      repo,
+      ref,
+      refType: branch ? 'branch' : 'tag',
+    } : null,
+    sourceLabel: `https://github.com/${repo}`,
+    sourceHeading: 'Repository:',
+    sourceReplyLabel: 'Repo',
+    installTarget,
+  };
+}
+
+function isLocalPathSpecifier(value) {
+  const resolvedPath = path.resolve(expandHome(value));
+  return fs.existsSync(resolvedPath)
+    || path.isAbsolute(value)
+    || value === '.'
+    || value === '..'
+    || value.startsWith(`.${path.sep}`)
+    || value.startsWith(`..${path.sep}`)
+    || value.startsWith('./')
+    || value.startsWith('../')
+    || value.startsWith('~/')
+    || value.endsWith('.tar.gz')
+    || value.endsWith('.tgz');
+}
+
+function expandHome(value) {
+  if (value === '~') return process.env.HOME || value;
+  if (value.startsWith('~/')) return path.join(process.env.HOME || '~', value.slice(2));
+  return value;
+}
+
+function localFallbackName(value) {
+  return path.basename(value).replace(/\.(?:tar\.gz|tgz)$/i, '').replace(/^zylos-/, '') || 'local-component';
 }
 
 /**

--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -8,7 +8,7 @@ import { spawnSync } from 'node:child_process';
 import { COMPONENTS_FILE } from './config.js';
 import { loadRegistry } from './registry.js';
 import { fetchLatestTag } from './github.js';
-import { inspectLocalSource } from './download.js';
+import { inspectLocalSource, resolveLocalPath } from './download.js';
 
 /**
  * Load installed components from components.json
@@ -48,14 +48,14 @@ export async function resolveTarget(nameOrUrl, { branch = null } = {}) {
       return {
         name: inspected.name,
         repo: null,
-        version: inspected.version || '0.0.0',
+        version: inspected.version,
         fetchError: null,
         isThirdParty: true,
         source: inspected.source,
         sourceLabel: inspected.source.path,
         sourceHeading: 'Source:',
         sourceReplyLabel: 'Source',
-        installTarget: nameOrUrl,
+        installTarget: inspected.source.path,
       };
     } catch (err) {
       return {
@@ -65,7 +65,7 @@ export async function resolveTarget(nameOrUrl, { branch = null } = {}) {
         fetchError: null,
         isThirdParty: true,
         source: null,
-        sourceLabel: path.resolve(expandHome(nameOrUrl)),
+        sourceLabel: resolveLocalPath(nameOrUrl),
         installTarget: nameOrUrl,
         resolutionError: err.message,
       };
@@ -174,10 +174,9 @@ function resolveGitHubTarget({
   };
 }
 
-function isLocalPathSpecifier(value) {
-  const resolvedPath = path.resolve(expandHome(value));
-  return fs.existsSync(resolvedPath)
-    || path.isAbsolute(value)
+export function isLocalPathSpecifier(value) {
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(value)) return false;
+  return path.isAbsolute(value)
     || value === '.'
     || value === '..'
     || value.startsWith(`.${path.sep}`)
@@ -185,14 +184,7 @@ function isLocalPathSpecifier(value) {
     || value.startsWith('./')
     || value.startsWith('../')
     || value.startsWith('~/')
-    || value.endsWith('.tar.gz')
-    || value.endsWith('.tgz');
-}
-
-function expandHome(value) {
-  if (value === '~') return process.env.HOME || value;
-  if (value.startsWith('~/')) return path.join(process.env.HOME || '~', value.slice(2));
-  return value;
+    || /\.(?:tar\.gz|tgz)$/i.test(value);
 }
 
 function localFallbackName(value) {

--- a/cli/lib/download.js
+++ b/cli/lib/download.js
@@ -9,6 +9,7 @@ import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 import { getGitHubToken, sanitizeError, withRateLimitRetrySync } from './github.js';
 import { copyTree } from './fs-utils.js';
+import { parseSkillMd } from './skill.js';
 
 function getWritableTmpBase() {
   let base = os.tmpdir();
@@ -146,6 +147,96 @@ export function copyLocal(localPath, destDir) {
 }
 
 /**
+ * Inspect a local source without coupling target resolution to the add command.
+ * Local tarballs are unpacked to a temporary directory for metadata discovery.
+ *
+ * @param {string} localPath
+ * @returns {{ name: string, version: string | null, source: object }}
+ */
+export function inspectLocalSource(localPath) {
+  const srcPath = resolveLocalPath(localPath);
+  if (!fs.existsSync(srcPath)) {
+    throw new Error(`Local source not found: ${srcPath}`);
+  }
+
+  const stat = fs.statSync(srcPath);
+  if (stat.isDirectory()) {
+    const metadata = readLocalMetadata(srcPath, path.basename(srcPath));
+    return { ...metadata, source: { type: 'local-dir', path: srcPath } };
+  }
+
+  if (!stat.isFile() || !/\.(?:tar\.gz|tgz)$/i.test(srcPath)) {
+    throw new Error(`Local source must be a directory or .tar.gz archive: ${srcPath}`);
+  }
+
+  const tmpDir = createDownloadTmpDir();
+  try {
+    const result = extractLocalTarball(srcPath, tmpDir);
+    if (!result.success) throw new Error(result.error);
+    const fallback = path.basename(srcPath).replace(/\.(?:tar\.gz|tgz)$/i, '');
+    const metadata = readLocalMetadata(tmpDir, fallback);
+    return { ...metadata, source: { type: 'local-tarball', path: srcPath } };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Acquire a normalized component source into its installation directory.
+ * Resolver registration keeps source-specific behavior at the acquire boundary
+ * and leaves manifest, registration, hooks, PM2, and Caddy flows source-agnostic.
+ *
+ * @param {object} source
+ * @param {string} destDir
+ * @returns {{ success: boolean, extractedDir?: string, error?: string }}
+ */
+export function acquireSource(source, destDir) {
+  const resolver = SOURCE_RESOLVERS.get(source?.type);
+  if (!resolver) {
+    return { success: false, error: `Unsupported component source: ${source?.type || 'unknown'}` };
+  }
+  try {
+    return resolver.acquire(source, destDir);
+  } catch (err) {
+    return { success: false, error: sanitizeError(err.message) };
+  }
+}
+
+/**
+ * Register an additional source resolver. This is the upgrade/mirror extension
+ * seam; v1 ships only GitHub releases/branches and local filesystem sources.
+ */
+export function registerSourceResolver(type, resolver) {
+  if (!type || typeof resolver?.acquire !== 'function') {
+    throw new TypeError('A source resolver requires a type and acquire(source, destDir)');
+  }
+  SOURCE_RESOLVERS.set(type, resolver);
+}
+
+const SOURCE_RESOLVERS = new Map();
+
+registerSourceResolver('github-release', {
+  acquire(source, destDir) {
+    if (source.refType === 'branch') {
+      return downloadBranch(source.repo, source.ref, destDir);
+    }
+    return downloadArchive(source.repo, source.ref, destDir);
+  },
+});
+
+registerSourceResolver('local-dir', {
+  acquire(source, destDir) {
+    return copyLocal(source.path, destDir);
+  },
+});
+
+registerSourceResolver('local-tarball', {
+  acquire(source, destDir) {
+    return extractLocalTarball(source.path, destDir);
+  },
+});
+
+/**
  * Download a GitHub branch archive and extract it.
  * Used for versionless installs (no tagged release).
  *
@@ -208,6 +299,72 @@ export function extractTarball(tarballPath, destDir) {
       success: false,
       extractedDir: null,
       error: `Failed to extract tarball: ${err.message}`,
+    };
+  }
+}
+
+function resolveLocalPath(localPath) {
+  if (localPath === '~') return fs.realpathSync(process.env.HOME);
+  const expanded = localPath.startsWith('~/')
+    ? path.join(process.env.HOME, localPath.slice(2))
+    : localPath;
+  return path.resolve(expanded);
+}
+
+function readLocalMetadata(componentDir, fallbackName) {
+  const frontmatter = parseSkillMd(componentDir)?.frontmatter || {};
+  const name = normalizeLocalComponentName(frontmatter.name || fallbackName);
+  let version = frontmatter.version == null ? null : String(frontmatter.version).trim();
+  if (!version) {
+    try {
+      version = fs.readFileSync(path.join(componentDir, 'VERSION'), 'utf8').trim() || null;
+    } catch {
+      version = null;
+    }
+  }
+  return { name, version };
+}
+
+function normalizeLocalComponentName(value) {
+  const name = String(value).trim().replace(/^zylos-/, '');
+  if (!name || !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(name) || name === '.' || name === '..') {
+    throw new Error(`Invalid local component name: ${value}`);
+  }
+  return name;
+}
+
+function extractLocalTarball(tarballPath, destDir) {
+  try {
+    const srcPath = path.resolve(tarballPath);
+    if (!fs.existsSync(srcPath)) {
+      return { success: false, extractedDir: null, error: `Local source not found: ${srcPath}` };
+    }
+
+    const listing = execFileSync('tar', ['tzf', srcPath], {
+      timeout: 30000,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const entries = listing
+      .split('\n')
+      .map(entry => entry.replace(/^\.\//, '').replace(/\/$/, ''))
+      .filter(Boolean);
+    if (entries.length === 0) {
+      return { success: false, extractedDir: null, error: 'Local tarball is empty' };
+    }
+
+    const firstParts = new Set(entries.map(entry => entry.split('/')[0]));
+    const hasSingleWrapper = firstParts.size === 1 && entries.some(entry => entry.includes('/'));
+    fs.mkdirSync(destDir, { recursive: true });
+    const args = ['xzf', srcPath, '-C', destDir];
+    if (hasSingleWrapper) args.push('--strip-components=1');
+    execFileSync('tar', args, { timeout: 30000, stdio: 'pipe' });
+    return { success: true, extractedDir: destDir };
+  } catch (err) {
+    return {
+      success: false,
+      extractedDir: null,
+      error: `Failed to extract local tarball: ${sanitizeError(err.message)}`,
     };
   }
 }

--- a/cli/lib/download.js
+++ b/cli/lib/download.js
@@ -127,7 +127,7 @@ export function downloadArchive(repo, version, destDir) {
  * @returns {{ success: boolean, error?: string }}
  */
 export function copyLocal(localPath, destDir) {
-  const srcPath = path.resolve(localPath);
+  const srcPath = resolveLocalPath(localPath);
 
   if (!fs.existsSync(srcPath)) {
     return { success: false, error: `Source path not found: ${srcPath}` };
@@ -139,7 +139,7 @@ export function copyLocal(localPath, destDir) {
   }
 
   try {
-    copyTree(srcPath, destDir, { excludes: ['.git'] });
+    copyTree(srcPath, destDir, { excludes: ['.git', 'node_modules', '.zylos', '.backup'] });
     return { success: true };
   } catch (err) {
     return { success: false, error: `Failed to copy from ${srcPath}: ${err.message}` };
@@ -303,10 +303,10 @@ export function extractTarball(tarballPath, destDir) {
   }
 }
 
-function resolveLocalPath(localPath) {
-  if (localPath === '~') return fs.realpathSync(process.env.HOME);
+export function resolveLocalPath(localPath) {
+  if (localPath === '~') return fs.realpathSync(os.homedir());
   const expanded = localPath.startsWith('~/')
-    ? path.join(process.env.HOME, localPath.slice(2))
+    ? path.join(os.homedir(), localPath.slice(2))
     : localPath;
   return path.resolve(expanded);
 }
@@ -318,6 +318,14 @@ function readLocalMetadata(componentDir, fallbackName) {
   if (!version) {
     try {
       version = fs.readFileSync(path.join(componentDir, 'VERSION'), 'utf8').trim() || null;
+    } catch {
+      version = null;
+    }
+  }
+  if (!version) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(componentDir, 'package.json'), 'utf8'));
+      version = pkg.version == null ? null : String(pkg.version).trim() || null;
     } catch {
       version = null;
     }
@@ -335,7 +343,7 @@ function normalizeLocalComponentName(value) {
 
 function extractLocalTarball(tarballPath, destDir) {
   try {
-    const srcPath = path.resolve(tarballPath);
+    const srcPath = resolveLocalPath(tarballPath);
     if (!fs.existsSync(srcPath)) {
       return { success: false, extractedDir: null, error: `Local source not found: ${srcPath}` };
     }
@@ -352,6 +360,25 @@ function extractLocalTarball(tarballPath, destDir) {
     if (entries.length === 0) {
       return { success: false, extractedDir: null, error: 'Local tarball is empty' };
     }
+    if (entries.some(isUnsafeArchivePath)) {
+      return { success: false, extractedDir: null, error: 'Local tarball contains an unsafe path' };
+    }
+
+    const verboseListing = execFileSync('tar', ['tvzf', srcPath], {
+      timeout: 30000,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const linkEntry = verboseListing
+      .split('\n')
+      .find(line => line.startsWith('l') || line.startsWith('h'));
+    if (linkEntry) {
+      return {
+        success: false,
+        extractedDir: null,
+        error: 'Local tarball contains a symbolic or hard link; links are not allowed',
+      };
+    }
 
     const firstParts = new Set(entries.map(entry => entry.split('/')[0]));
     const hasSingleWrapper = firstParts.size === 1 && entries.some(entry => entry.includes('/'));
@@ -367,4 +394,9 @@ function extractLocalTarball(tarballPath, destDir) {
       error: `Failed to extract local tarball: ${sanitizeError(err.message)}`,
     };
   }
+}
+
+function isUnsafeArchivePath(entry) {
+  if (path.posix.isAbsolute(entry) || path.win32.isAbsolute(entry)) return true;
+  return entry.split(/[\\/]+/).some(part => part === '..');
 }

--- a/cli/lib/upgrade.js
+++ b/cli/lib/upgrade.js
@@ -51,10 +51,22 @@ function getLocalVersion(skillDir) {
  */
 export function getRepo(component) {
   const components = loadComponents();
+  if (components[component]?.source?.type?.startsWith('local-')) return null;
   if (components[component]?.repo) return components[component].repo;
   const registry = loadLocalRegistry();
   if (registry[component]?.repo) return registry[component].repo;
   return null;
+}
+
+export function getLocalSourceUpgradeError(component, installed = loadComponents()[component]) {
+  if (!installed?.source?.type?.startsWith('local-')) return null;
+  const sourcePath = installed.source.path || 'the original local source';
+  return {
+    success: false,
+    error: 'local_source_upgrade_unsupported',
+    message: `Component '${component}' was installed from a local source. Reinstall it from ${sourcePath} to update it.`,
+    source: installed.source,
+  };
 }
 
 /**
@@ -122,6 +134,9 @@ export function checkForUpdates(component, { beta = false } = {}) {
       message: `Component '${component}' is not installed`,
     };
   }
+
+  const localSourceError = getLocalSourceUpgradeError(component);
+  if (localSourceError) return localSourceError;
 
   const localVersion = getLocalVersion(skillDir);
   if (!localVersion.success) {

--- a/cli/zylos.js
+++ b/cli/zylos.js
@@ -106,7 +106,7 @@ Service Management:
 
 Component Management:
   add <target>        Add a component
-                      target: name[@ver] | org/repo[@ver] | url
+                      target: name[@ver] | org/repo[@ver] | url | local path
                       --branch <name>  Install from a git branch
                       --check   Show component info without installing
                       --yes/-y  Skip confirmation prompts


### PR DESCRIPTION
Part B of #695.

## Summary

- accept existing relative or absolute directories and local `.tar.gz` / `.tgz` archives in `zylos add`
- normalize all acquisition inputs into source descriptors and dispatch through a resolver registry at the download/acquire boundary
- keep manifest generation, registration, hooks, PM2, Caddy, and AI/declarative installation flows shared
- read local versions from `SKILL.md` frontmatter, falling back to `VERSION`, and persist the normalized source for a future upgrade implementation
- keep local installs offline; local resolution does not query the remote component registry

## Resolver design

Built-in source types are `github-release`, `local-tarball`, and `local-dir`. GitHub tags and branches share the existing GitHub resolver behavior. `registerSourceResolver()` is the extension seam for later upgrade, mirror, or registry work; v1 wires only `add` and does not add checksum/signature policy.

Existing local paths win before GitHub `org/repo` parsing, so bare relative directories work while absent `org/repo` targets remain GitHub references.

## Validation

- focused unit + real CLI E2E: 7/7
  - bare relative directory full add pipeline
  - local tarball full add pipeline
  - fake-curl GitHub release full add pipeline regression
  - metadata, archive extraction, resolver extension, and target parsing assertions
- Jest: 112/112
- Node suite: 605/606; the sole failure is the pre-existing Codex launch assertion expecting no bootstrap arg while current main writes `hello` (`runtime-launch.test.js`), unrelated to this PR
- `git diff --check` and syntax checks pass

No release or merge is included.