### PR TITLE
test: update stale Codex launch-spec assertion for the #681 kick prompt

### DIFF
--- a/cli/lib/__tests__/runtime-launch.test.js
+++ b/cli/lib/__tests__/runtime-launch.test.js
@@ -333,7 +333,9 @@ describe('Codex launch — new session', () => {
 
     const spec = readLaunchSpec();
     assert.ok(spec, 'spec should be written');
-    assert.deepEqual(spec.args, []);
+    // Since #681 the only launch arg is the kick prompt that triggers the
+    // SessionStart hook — never the retired text bootstrap payload.
+    assert.deepEqual(spec.args, ['hello']);
     assert.ok(!JSON.stringify(spec).includes('session-start-inject.js'));
   });
 });


### PR DESCRIPTION
Fixes the single deterministic node-test failure on `main`.

## What

`runtime-launch.test.js` › *"launch spec does not contain the retired text bootstrap prompt"* asserted `spec.args` deep-equals `[]` (from #675, which retired the text bootstrap payload). #681 later deliberately added the `'hello'` kick prompt to the Codex launch args (to trigger the SessionStart hook on a fresh session) without updating this assertion, so the test has been failing on every machine since — this is the "638/639" failure noted e.g. in #698's test results, and it is a stale assertion, not an environmental issue.

## Fix

Pin the assertion to exactly `['hello']`: the test still rejects any resurrected bootstrap payload (that was its intent), while accepting the intentional kick prompt. One assertion + clarifying comment.

## Verification

- `runtime-launch.test.js`: 14/14 pass
- Full node suite on this branch: **600/600 pass** (the previously-failing test was the only red on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)