### PR TITLE
feat(session-start): custom-inject core shard at chain position 2 (custom-hooks/session-start)

### DIFF
--- a/cli/lib/__tests__/codex-hooks.test.js
+++ b/cli/lib/__tests__/codex-hooks.test.js
@@ -81,7 +81,7 @@ describe('Codex core hook installer', () => {
     // one contiguous group in chain order.
     assert.deepEqual(
       coreGroup.hooks.map(h => h.command.match(/--shard (\S+)$/)?.[1]),
-      ['identity', 'references', 'state', 'c4-checkpoint', 'c4-conversations', 'fg', 'start-prompt']
+      ['identity', 'custom', 'references', 'state', 'c4-checkpoint', 'c4-conversations', 'fg', 'start-prompt']
     );
     for (const hook of coreGroup.hooks) {
       assert.equal(hook.timeout, 25);
@@ -103,15 +103,15 @@ describe('Codex core hook installer', () => {
 
     const installed = installCoreCodexHook({ zylosDir });
     // Install replaces the retired no-arg command with the shard command set.
-    assert.equal(installed.commands.length, 7);
+    assert.equal(installed.commands.length, 8);
     const migrated = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
     const migratedCommands = migrated.hooks.SessionStart.flatMap(group => group.hooks.map(h => h.command));
-    assert.equal(migratedCommands.filter(c => c.includes('session-start-orchestrator.js')).length, 7);
+    assert.equal(migratedCommands.filter(c => c.includes('session-start-orchestrator.js')).length, 8);
     assert.equal(migratedCommands.some(c => c.includes('session-start-orchestrator.js') && !c.includes('--shard')), false);
 
     const removed = uninstallCoreCodexHook({ zylosDir });
 
-    assert.equal(removed.removed, 7);
+    assert.equal(removed.removed, 8);
     const config = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
     assert.equal(config.hooks.SessionStart.length, 1);
     assert.equal(config.hooks.SessionStart[0].hooks[0].command, 'node /tmp/other.js');

--- a/cli/lib/__tests__/sync-settings-hooks.test.js
+++ b/cli/lib/__tests__/sync-settings-hooks.test.js
@@ -55,6 +55,7 @@ describe('Claude settings template', () => {
 
 const CORE_SHARD_SEQUENCE = [
   'identity',
+  'custom',
   'references',
   'state',
   'c4-checkpoint',
@@ -726,9 +727,9 @@ describe('syncHooks SessionStart orchestrator convergence', () => {
 
     const result = syncHooks(installed, makeOrchestratorTemplate(), { log: noopLog });
 
-    // 7 shard/side-effect commands x 3 SessionStart matchers + 7 other-event
+    // 8 shard/side-effect commands x 3 SessionStart matchers + 7 other-event
     // hooks added; 4 retired per-step hooks x 3 matchers removed.
-    assert.deepEqual(result, { added: 28, updated: 0, removed: 12 });
+    assert.deepEqual(result, { added: 31, updated: 0, removed: 12 });
     assertSessionStartUsesOrchestrator(installed);
   });
 
@@ -913,7 +914,7 @@ describe('component shard claim boundary (opt-in contract)', () => {
       .filter(h => h.command?.includes('session-start-orchestrator.js'))
       .map(h => extractShardArg(h.command));
     assert.deepEqual(shardArgs, [
-      'identity', 'references', 'state', 'c4-checkpoint', 'c4-conversations', 'role-inject', 'fg', 'start-prompt',
+      'identity', 'custom', 'references', 'state', 'c4-checkpoint', 'c4-conversations', 'role-inject', 'fg', 'start-prompt',
     ]);
     // User and undeclared hooks are untouched.
     assert.ok(startup.hooks.some(h => h.command?.includes('/custom/my-session-start.js')));

--- a/skills/activity-monitor/scripts/__tests__/emit-custom-inject.test.js
+++ b/skills/activity-monitor/scripts/__tests__/emit-custom-inject.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+import { customInjectDir, emitCustomInject } from '../emit-custom-inject.js';
+
+const tmpDirs = [];
+
+function makeZylosDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-inject-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeCustomFile(zylosDir, name, content) {
+  const dir = path.join(zylosDir, 'custom-inject');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content);
+}
+
+afterEach(() => {
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+});
+
+describe('customInjectDir', () => {
+  it('resolves under ZYLOS_DIR when set, else under ~/zylos', () => {
+    assert.equal(customInjectDir({ ZYLOS_DIR: '/opt/zy' }), path.join('/opt/zy', 'custom-inject'));
+    assert.equal(customInjectDir({}), path.join(os.homedir(), 'zylos', 'custom-inject'));
+  });
+});
+
+describe('emitCustomInject', () => {
+  it('emits nothing when the directory does not exist (fresh install)', () => {
+    const zylosDir = makeZylosDir();
+    assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), '');
+  });
+
+  it('emits nothing when the directory has no usable content', () => {
+    const zylosDir = makeZylosDir();
+    fs.mkdirSync(path.join(zylosDir, 'custom-inject'), { recursive: true });
+    assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), '');
+
+    // Whitespace-only and empty files count as no content.
+    writeCustomFile(zylosDir, '10-empty.md', '');
+    writeCustomFile(zylosDir, '20-blank.md', '  \n\n\t\n');
+    assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), '');
+  });
+
+  it('concatenates .md files in lexicographic order (conf.d-style prefixes)', () => {
+    const zylosDir = makeZylosDir();
+    // Written out of order on purpose — filename order must win.
+    writeCustomFile(zylosDir, '20-platform.md', 'PLATFORM RULES');
+    writeCustomFile(zylosDir, '10-rules.md', 'HOUSE RULES\n');
+
+    assert.equal(
+      emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }),
+      'HOUSE RULES\n\nPLATFORM RULES'
+    );
+  });
+
+  it('ignores dotfiles and non-md entries', () => {
+    const zylosDir = makeZylosDir();
+    writeCustomFile(zylosDir, '10-real.md', 'REAL');
+    writeCustomFile(zylosDir, '.05-hidden.md', 'HIDDEN');
+    writeCustomFile(zylosDir, 'notes.txt', 'TXT');
+    writeCustomFile(zylosDir, 'script.js', 'console.log("nope")');
+    fs.mkdirSync(path.join(zylosDir, 'custom-inject', 'subdir.md'), { recursive: true });
+
+    assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), 'REAL');
+  });
+
+  it('skips whitespace-only files but keeps the rest in order', () => {
+    const zylosDir = makeZylosDir();
+    writeCustomFile(zylosDir, '10-a.md', 'A');
+    writeCustomFile(zylosDir, '20-blank.md', '   \n');
+    writeCustomFile(zylosDir, '30-c.md', '\nC\n');
+
+    assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), 'A\n\nC');
+  });
+});

--- a/skills/activity-monitor/scripts/__tests__/emit-custom-inject.test.js
+++ b/skills/activity-monitor/scripts/__tests__/emit-custom-inject.test.js
@@ -15,7 +15,7 @@ function makeZylosDir() {
 }
 
 function writeCustomFile(zylosDir, name, content) {
-  const dir = path.join(zylosDir, 'custom-inject');
+  const dir = path.join(zylosDir, 'custom-hooks', 'session-start');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, name), content);
 }
@@ -26,8 +26,8 @@ afterEach(() => {
 
 describe('customInjectDir', () => {
   it('resolves under ZYLOS_DIR when set, else under ~/zylos', () => {
-    assert.equal(customInjectDir({ ZYLOS_DIR: '/opt/zy' }), path.join('/opt/zy', 'custom-inject'));
-    assert.equal(customInjectDir({}), path.join(os.homedir(), 'zylos', 'custom-inject'));
+    assert.equal(customInjectDir({ ZYLOS_DIR: '/opt/zy' }), path.join('/opt/zy', 'custom-hooks', 'session-start'));
+    assert.equal(customInjectDir({}), path.join(os.homedir(), 'zylos', 'custom-hooks', 'session-start'));
   });
 });
 
@@ -39,7 +39,7 @@ describe('emitCustomInject', () => {
 
   it('emits nothing when the directory has no usable content', () => {
     const zylosDir = makeZylosDir();
-    fs.mkdirSync(path.join(zylosDir, 'custom-inject'), { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, 'custom-hooks', 'session-start'), { recursive: true });
     assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), '');
 
     // Whitespace-only and empty files count as no content.
@@ -66,7 +66,7 @@ describe('emitCustomInject', () => {
     writeCustomFile(zylosDir, '.05-hidden.md', 'HIDDEN');
     writeCustomFile(zylosDir, 'notes.txt', 'TXT');
     writeCustomFile(zylosDir, 'script.js', 'console.log("nope")');
-    fs.mkdirSync(path.join(zylosDir, 'custom-inject', 'subdir.md'), { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, 'custom-hooks', 'session-start', 'subdir.md'), { recursive: true });
 
     assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), 'REAL');
   });

--- a/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
@@ -87,16 +87,17 @@ function fakeResolver(chain) {
 }
 
 describe('shard-registry chain', () => {
-  it('builds the 5 core shards in the agreed order', () => {
+  it('builds the 6 core shards in the agreed order', () => {
     const { chain } = buildChain({ zylosDir: makeTmpdir() });
     assert.deepEqual(
       chain.map(s => [s.name, s.chainIndex]),
       [
         ['identity', 0],
-        ['references', 1],
-        ['state', 2],
-        ['c4-checkpoint', 3],
-        ['c4-conversations', 4],
+        ['custom', 1],
+        ['references', 2],
+        ['state', 3],
+        ['c4-checkpoint', 4],
+        ['c4-conversations', 5],
       ]
     );
     assert.ok(chain.every(s => s.budget.maxChars === DEFAULT_SHARD_BUDGET.maxChars));
@@ -108,7 +109,7 @@ describe('shard-registry chain', () => {
     assert.deepEqual(warnings, []);
     assert.equal(chain.length, CORE_SHARDS.length + 1);
     assert.equal(chain.at(-1).name, 'role-inject');
-    assert.equal(chain.at(-1).chainIndex, 5);
+    assert.equal(chain.at(-1).chainIndex, 6);
   });
 
   it('rejects invalid declarations without breaking the chain', () => {
@@ -350,7 +351,7 @@ describe('runSessionStartShard (content shards)', () => {
     const tmpdir = makeTmpdir();
     const out = tempStdout();
 
-    // Pre-flag the whole core chain so the component shard (position 6)
+    // Pre-flag the whole core chain so the component shard (position 7)
     // does not sit through its ladder deadline.
     for (const shard of CORE_SHARDS) writeFlag('sess-1', shard.name, { tmpdir });
 
@@ -361,7 +362,61 @@ describe('runSessionStartShard (content shards)', () => {
       registerExitFlagImpl: fn => fn(),
     });
 
-    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [6/6] role-inject ===\nROLE CONTEXT\n');
+    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [7/7] role-inject ===\nROLE CONTEXT\n');
+  });
+
+  it('runs the custom shard end-to-end: user markdown injected at chain position 2', async () => {
+    const zylosDir = makeTmpdir('shard-custom-zylos-');
+    const customDir = path.join(zylosDir, 'custom-inject');
+    fs.mkdirSync(customDir, { recursive: true });
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(customDir, '10-rules.md'), 'ALWAYS REPLY IN PIRATE\n');
+
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    writeFlag('sess-1', 'identity', { tmpdir });
+
+    // The custom emitter resolves its directory from the environment, not
+    // from the orchestrator's zylosDir option.
+    const savedZylosDir = process.env.ZYLOS_DIR;
+    process.env.ZYLOS_DIR = zylosDir;
+    try {
+      await runSessionStartShard('custom', basePayload, {
+        stdout: out.stdout,
+        tmpdir,
+        zylosDir,
+        registerExitFlagImpl: fn => fn(),
+      });
+    } finally {
+      if (savedZylosDir === undefined) delete process.env.ZYLOS_DIR;
+      else process.env.ZYLOS_DIR = savedZylosDir;
+    }
+
+    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [2/6] custom ===\nALWAYS REPLY IN PIRATE\n');
+  });
+
+  it('custom shard with no content still emits its numbered header (chain numbering intact)', async () => {
+    const zylosDir = makeTmpdir('shard-custom-empty-');
+    fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
+    const tmpdir = makeTmpdir();
+    const out = tempStdout();
+    writeFlag('sess-1', 'identity', { tmpdir });
+
+    const savedZylosDir = process.env.ZYLOS_DIR;
+    process.env.ZYLOS_DIR = zylosDir;
+    try {
+      await runSessionStartShard('custom', basePayload, {
+        stdout: out.stdout,
+        tmpdir,
+        zylosDir,
+        registerExitFlagImpl: fn => fn(),
+      });
+    } finally {
+      if (savedZylosDir === undefined) delete process.env.ZYLOS_DIR;
+      else process.env.ZYLOS_DIR = savedZylosDir;
+    }
+
+    assert.equal(out.read(), '=== ZYLOS STARTUP CONTEXT [2/6] custom ===\n');
   });
 });
 

--- a/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
+++ b/skills/activity-monitor/scripts/__tests__/shard-mode.test.js
@@ -367,7 +367,7 @@ describe('runSessionStartShard (content shards)', () => {
 
   it('runs the custom shard end-to-end: user markdown injected at chain position 2', async () => {
     const zylosDir = makeTmpdir('shard-custom-zylos-');
-    const customDir = path.join(zylosDir, 'custom-inject');
+    const customDir = path.join(zylosDir, 'custom-hooks', 'session-start');
     fs.mkdirSync(customDir, { recursive: true });
     fs.mkdirSync(path.join(zylosDir, '.claude'), { recursive: true });
     fs.writeFileSync(path.join(customDir, '10-rules.md'), 'ALWAYS REPLY IN PIRATE\n');

--- a/skills/activity-monitor/scripts/emit-custom-inject.js
+++ b/skills/activity-monitor/scripts/emit-custom-inject.js
@@ -5,7 +5,10 @@
  * The content source is a plain directory the user (or an installing
  * platform) edits directly — no config file, no registration, no restart:
  *
- *   ~/zylos/custom-inject/*.md
+ *   ~/zylos/custom-hooks/session-start/*.md
+ *
+ * The hook-scoped layout (`custom-hooks/<hook-name>/`) leaves room for
+ * future hook types to get their own content subdirectory.
  *
  * - Files concatenate in lexicographic filename order (conf.d style:
  *   `10-rules.md`, `20-platform.md`, ... to control ordering).
@@ -27,7 +30,7 @@ import path from 'node:path';
 
 export function customInjectDir(env = process.env) {
   const zylosDir = path.resolve(env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
-  return path.join(zylosDir, 'custom-inject');
+  return path.join(zylosDir, 'custom-hooks', 'session-start');
 }
 
 export function emitCustomInject({ env = process.env } = {}) {

--- a/skills/activity-monitor/scripts/emit-custom-inject.js
+++ b/skills/activity-monitor/scripts/emit-custom-inject.js
@@ -1,0 +1,61 @@
+/**
+ * Custom-inject shard emitter (chain position 2, right after identity).
+ *
+ * Injects deployment/user-provided standing directives at session start.
+ * The content source is a plain directory the user (or an installing
+ * platform) edits directly — no config file, no registration, no restart:
+ *
+ *   ~/zylos/custom-inject/*.md
+ *
+ * - Files concatenate in lexicographic filename order (conf.d style:
+ *   `10-rules.md`, `20-platform.md`, ... to control ordering).
+ * - Dotfiles and non-.md entries are ignored.
+ * - A missing directory, no .md files, or all-empty content emits nothing
+ *   — the shard's [k/N] header still goes out, so the chain and numbering
+ *   are unaffected (same empty semantics as the other content shards).
+ * - Content is injected as-is (it is user-authored instruction text); the
+ *   orchestrator adds the numbered shard header and enforces the budget
+ *   (tail-trim + full-text spill) like any other shard.
+ *
+ * Security boundary: users supply CONTENT, never code — this emitter is
+ * fixed core code and only ever reads markdown text from the directory.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export function customInjectDir(env = process.env) {
+  const zylosDir = path.resolve(env.ZYLOS_DIR || path.join(os.homedir(), 'zylos'));
+  return path.join(zylosDir, 'custom-inject');
+}
+
+export function emitCustomInject({ env = process.env } = {}) {
+  const dir = customInjectDir(env);
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    // Directory absent (fresh installs have none) — nothing to inject.
+    return '';
+  }
+
+  const files = entries
+    .filter(name => name.endsWith('.md') && !name.startsWith('.'))
+    .sort();
+
+  const parts = [];
+  for (const file of files) {
+    let content;
+    try {
+      content = fs.readFileSync(path.join(dir, file), 'utf8');
+    } catch {
+      // Unreadable file: skip it — a bad file must not break session start.
+      continue;
+    }
+    const trimmed = content.trim();
+    if (trimmed) parts.push(trimmed);
+  }
+
+  return parts.join('\n\n');
+}

--- a/skills/activity-monitor/scripts/shard-registry.js
+++ b/skills/activity-monitor/scripts/shard-registry.js
@@ -64,8 +64,8 @@ export const CORE_SHARDS = Object.freeze([
   },
   {
     // Deployment/user-provided standing directives — reads
-    // ~/zylos/custom-inject/*.md at every session start. Sits right after
-    // identity so custom directives frame everything downstream.
+    // ~/zylos/custom-hooks/session-start/*.md at every session start. Sits right
+    // after identity so custom directives frame everything downstream.
     name: 'custom',
     order: 2,
     emit: async () =>

--- a/skills/activity-monitor/scripts/shard-registry.js
+++ b/skills/activity-monitor/scripts/shard-registry.js
@@ -63,20 +63,29 @@ export const CORE_SHARDS = Object.freeze([
       (await import('../../zylos-memory/scripts/session-start-inject.js')).emitMemoryPart('identity', payload),
   },
   {
-    name: 'references',
+    // Deployment/user-provided standing directives — reads
+    // ~/zylos/custom-inject/*.md at every session start. Sits right after
+    // identity so custom directives frame everything downstream.
+    name: 'custom',
     order: 2,
+    emit: async () =>
+      (await import('./emit-custom-inject.js')).emitCustomInject(),
+  },
+  {
+    name: 'references',
+    order: 3,
     emit: async payload =>
       (await import('../../zylos-memory/scripts/session-start-inject.js')).emitMemoryPart('references', payload),
   },
   {
     name: 'state',
-    order: 3,
+    order: 4,
     emit: async payload =>
       (await import('../../zylos-memory/scripts/session-start-inject.js')).emitMemoryPart('state', payload),
   },
   {
     name: 'c4-checkpoint',
-    order: 4,
+    order: 5,
     emit: async payload =>
       (await import('../../comm-bridge/scripts/c4-session-init.js')).emitC4Checkpoint(payload),
   },
@@ -85,7 +94,7 @@ export const CORE_SHARDS = Object.freeze([
     // newest-first instead of ever falling back to the generic tail-trim +
     // spill (which would cut the newest messages of the chronological text).
     name: 'c4-conversations',
-    order: 5,
+    order: 6,
     emit: async payload =>
       (await import('../../comm-bridge/scripts/c4-session-init.js')).emitC4Conversations(payload, DEFAULT_SHARD_BUDGET),
   },


### PR DESCRIPTION
## What

Adds the **custom-inject core shard** at chain position 2 of the session-start injection chain introduced by #698: deployment/user-provided standing directives are injected at every session start, right after identity, so custom rules frame everything downstream.

Content source (owner-decided layout, extensible to future hook types):

```
~/zylos/custom-hooks/
└── session-start/        ← *.md files, concatenated in lexicographic filename order
    ├── 10-house-rules.md
    └── 20-platform.md
```

- **Directory-as-config, conf.d style**: multiple writers (owner, platform installers, component installers) each own their file — add = drop a file, revoke = delete your file; numeric prefixes control order; dotfiles and non-`.md` ignored. No config file, no registration, no restart.
- **Empty passthrough**: missing directory (fresh installs), no `.md` files, or all-blank content emits an empty body — the `[2/N]` numbered header still goes out so the missing-number loss-detection convention is unaffected.
- **Content, never code**: the emitter is fixed core code that only reads markdown text.
- **Budget**: standard dual limit via `composeShardOutput` (tail-trim + spill on overflow) like any other shard.

## Commits

1. `845bd3a` feat — `emit-custom-inject.js` + CORE_SHARDS entry at position 2. Registry-driven sync: both Claude and Codex hook migrations pick up the new shard automatically (7→8 commands per matcher; only test assertions needed updating — which validates #698's registry-driven extension cost).
2. `e826cf4` test — 6-shard chain shape assertions updated; emitter unit tests (missing/empty/blank dirs, lexicographic order, dotfile/non-md filtering, unreadable-file resilience); real-registry e2e (content injected under `[2/6]`; empty content still emits the numbered header).
3. `cd0c351` refactor — content dir moved from `custom-inject/` to `custom-hooks/session-start/` per owner decision (name was too generic; hook-scoped layout leaves room for future hook types). Path constant + tests + comments only.

## Verification

- Suites on this branch (rebased onto post-#698 main `9ca24f9`): node 652/652, jest 112/112.
- Sandbox real-`claude -p` runs (config order deliberately reversed), post exit-order-race fix, re-run on the final path: content → exact chain order 1/6→6/6 ×3, `[2/6]` read from `custom-hooks/session-start/`; dir absent → header-only, chain intact; 32,500-char CJK overflow → tail-trim + byte-complete spill.
- Migration dry-run on a live instance: +24/−3 (8 shards × 3 matchers incl. custom at position 2; only legacy orchestrator commands removed), user hooks untouched.
- Codex smoke (codex-cli 0.142.0): 6-shard config order = chain order, custom content lands under `[2/6]`, budget trim effective on the Codex side.
- Note: the s2 sandbox work on this feature also surfaced the latent injection-order race fixed in #698 (`flag deferred to process exit`) — the ultra-light custom emitter was the trigger that exposed it.

Design/discussion trail: OpenMax Issue `c58337e2` (design comment + owner decisions on layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
