### PR TITLE
feat(zylos-memory): content rules + sync-time audit for state.md

### DIFF
--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -80,9 +80,16 @@ exist, report them as historical records and do not create a replacement.
    `archive/`, or a pointer to the config file) instead of leaving or
    appending them. If the file exceeds the 8KB warn threshold
    (`memory-status.js` reports WARN), trim until it is back under.
-7. Create checkpoint (only if conversations were fetched in step 2):
+7. Audit `state.md` against its content rules
+   (`references/state-format.md`): relocate rule-violating content to its
+   routed destination (`reference/projects.md`, `reference/decisions.md`,
+   `archive/`, or a pointer to the on-demand file that already holds it)
+   instead of leaving or appending it. If the file exceeds the 10KB warn
+   threshold (`memory-status.js` reports WARN), trim until it is back
+   under.
+8. Create checkpoint (only if conversations were fetched in step 2):
    `node ~/zylos/.claude/skills/comm-bridge/scripts/c4-checkpoint.js create <end_id> --summary "SUMMARY"`
-8. Confirm completion.
+9. Confirm completion.
 
 ## Classification Rules
 
@@ -91,7 +98,9 @@ exist, report them as historical records and do not create a replacement.
 - `reference/preferences.md`: standing team-wide preferences.
 - `reference/ideas.md`: uncommitted proposals.
 - `users/<id>/profile.md`: user-specific preferences.
-- `state.md`: active focus and pending tasks.
+- `state.md`: active focus, pending items, and blockers only, per the
+  content rules in `references/state-format.md`; completed-task narrative,
+  decisions, and run history are routed out, never accumulated.
 - `references.md`: pointers and stable identifiers only, per the content
   rules in `references/references-file-format.md`; never duplicate config
   values, never accumulate narrative history.
@@ -145,7 +154,9 @@ Review the report and apply these rules:
     and one-off lessons elsewhere.
   - `state.md`: keep active focus, pending tasks, and recent completions.
     Move completed or historical detail to `sessions/current.md` or
-    `reference/`.
+    `reference/`. Apply the content rules in `references/state-format.md`;
+    the sync-time audit (Sync Flow step 7) should keep it under the 10KB
+    warn threshold.
   - `references.md`: keep pointers and lookup facts only. Move prose,
     project history, and detailed decisions to `reference/`. Apply the
     content rules in `references/references-file-format.md`; the sync-time

--- a/skills/zylos-memory/references/state-format.md
+++ b/skills/zylos-memory/references/state-format.md
@@ -11,8 +11,11 @@ Always loaded at session start via SessionStart hook.
 
 ## Size Guideline
 
-~16KB max. This file is in every session's context. Every line must earn
-its place.
+Target ≤10KB (warn threshold, reported as WARN by `memory-status.js`);
+hard budget 16KB. This file is in every session's context. Every line must
+earn its place. A healthy instance sits well under the warn threshold —
+sustained growth past it means completed-task narrative or history is
+accumulating and the content rules below are being violated.
 
 ## Update Frequency
 
@@ -29,10 +32,35 @@ Every memory sync. Also updated proactively when work focus changes.
 
 See `examples/state.md` for a full example.
 
-## Rules
+## Content Rules
+
+state.md answers "what am I doing right now" — it is not a project log.
+
+### Allowed
+
+- Current focus: status + next step + a pointer to the file holding the
+  full detail (`reference/projects.md`, a workspace path, an issue ID)
+- Genuinely pending items: not-yet-done tasks with requester and date
+- Blocker/waiting notes: what is blocked, on whom, since when
+
+### Disallowed — route instead of accumulating
+
+| Content class | Route to |
+|---------------|----------|
+| Completed-task narrative (how it was done, verification detail) | `reference/projects.md`; collapse to a one-line ✅ in state.md, or delete |
+| Decision records and rationale | `reference/decisions.md` |
+| Run history, superseded attempts, obsolete detail | `archive/` |
+| Content already held in an on-demand file | replace with a pointer to that file |
+
+### Rules
 
 1. Keep it lean -- this is the tightest budget file.
 2. Move completed tasks out promptly (to session log or reference files).
+   A finished item earns at most one ✅ line; the story of how it finished
+   does not belong here.
 3. Pending tasks should include who requested and when.
 4. Current Focus should reflect the most recent work, not a backlog.
+   Point to detail files instead of inlining detail.
 5. One-off tasks belong here, not in `reference/projects.md`.
+6. Memory Sync audits this file against these rules on every sync
+   (see SKILL.md Sync Flow): violations are relocated, not left in place.

--- a/skills/zylos-memory/scripts/shared.js
+++ b/skills/zylos-memory/scripts/shared.js
@@ -19,9 +19,10 @@ export const BUDGETS = {
 
 // Early-warning thresholds below the hard budget: a file over its warn
 // threshold is still within budget, but must be audited on the next
-// Memory Sync before the always-loaded set bloats (#696).
+// Memory Sync before the always-loaded set bloats (#696, #702).
 export const WARN_THRESHOLDS = {
-  'references.md': 8 * 1024
+  'references.md': 8 * 1024,
+  'state.md': 10 * 1024
 };
 
 export const REFERENCE_FILES = [

--- a/skills/zylos-memory/scripts/tests/test-shared.js
+++ b/skills/zylos-memory/scripts/tests/test-shared.js
@@ -102,6 +102,10 @@ describe('WARN_THRESHOLDS', () => {
     assert.equal(WARN_THRESHOLDS['references.md'], 8 * 1024);
   });
 
+  it('warns for state.md at 10KB', () => {
+    assert.equal(WARN_THRESHOLDS['state.md'], 10 * 1024);
+  });
+
   it('every warn threshold is below its hard budget', () => {
     for (const [key, value] of Object.entries(WARN_THRESHOLDS)) {
       assert.ok(BUDGETS[key] !== undefined, `${key} must also have a hard budget`);

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -116,6 +116,10 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
    - **Allowed:** stable identifiers (bot/app/member IDs), endpoints and ports, key paths, active policy pointers ("dmPolicy=owner, see config.json"), pointers to source-of-truth files (.env, config.json).
    - **Disallowed — route instead of appending:** version/upgrade history and breaking-change notes → `reference/decisions.md`; incident caveats and lessons → `reference/decisions.md`; entries for uninstalled/dead components → `archive/`; any value that already lives in a config file → replace with a pointer to that file.
    - Keep entries terse. Target ≤8KB; Memory Sync audits this file against these rules (see zylos-memory skill).
+5. **state.md is an active-work file with strict content rules.**
+   - **Allowed:** current focus (status + next step + pointer to the detail file), genuinely pending items, blocker/waiting notes.
+   - **Disallowed — route instead of accumulating:** completed-task narrative → `reference/projects.md` (collapse to a one-line ✅ in state.md, or delete); decision records and rationale → `reference/decisions.md`; run history and superseded detail → `archive/`; anything already held in an on-demand file → replace with a pointer.
+   - Keep entries terse. Target ≤10KB; Memory Sync audits this file against these rules (see zylos-memory skill).
 
 ### Classification Rules for reference/ Files
 


### PR DESCRIPTION
Closes #702

Same structure as #697 (references.md content rules, merged as `f94f149`) — this is the state.md counterpart, per the proposal in #702 which Howard approved routing as a #696-pattern follow-up.

## Problem

state.md is always-loaded but its rules only said "keep it lean" / "move completed tasks out promptly" — nothing defines what *classes* of content belong there or where evicted content routes. On the live instance it hit **83KB (519% over the 16KB budget)** on 2026-07-08, and after a manual consolidation was already back to **19KB two days later**: single in-flight project bullets accumulate the full delivery chronology (commit hashes, test counts, review rounds) inline instead of pointing to `reference/projects.md`.

## Changes

**`templates/ZYLOS.md`** — new point 5 in Memory Update Practices, parallel to the references.md point #697 added:
- **Allowed:** current focus (status + next step + pointer to detail file), genuinely pending items, blocker/waiting notes
- **Disallowed with routing:** completed-task narrative → `reference/projects.md` (collapse to one ✅ line or delete); decisions → `reference/decisions.md`; run history / superseded detail → `archive/`; anything already in an on-demand file → pointerize

**`skills/zylos-memory/SKILL.md`** — new Sync Flow step 7: audit state.md against the content rules each sync, *relocate violations instead of accumulating*; trim if over the 10KB warn threshold. Classification-rules entry and consolidation-review bullet updated to match.

**`skills/zylos-memory/references/state-format.md`** — full allowed/disallowed table + 10KB warn / 16KB hard budget (mirrors `references-file-format.md` from #697), one-✅-line-per-completion rule.

**`scripts/shared.js` + test** — one `WARN_THRESHOLDS` entry (`state.md: 10KB`), reusing the exact wiring #697 built: `memory-status.js` reports WARN and `consolidate.js` flags `nearBudget` with zero further code change. Two new test assertions (threshold value; the existing warn<budget invariant covers it too).

## Not in this PR

One-time cleanup of the live instance's 19KB state.md (proposal item 3) — same as #697's rollout, I'll do it on my instance as dogfood right after merge (references.md went 14KB→6.1KB that way).

## Verification

- zylos-memory suite: 57/57 pass (includes the 2 new assertions; note this suite is not scanned by root `npm test`, run via `node --test 'skills/zylos-memory/scripts/tests/*.js'`)
- Root suite: jest 112/112, node 652/652

🤖 Generated with [Claude Code](https://claude.com/claude-code)
