### PR TITLE
test: use per-test tmpdir instead of hardcoded /tmp/zylos-project

### DIFF
--- a/cli/lib/__tests__/init-base-url.test.js
+++ b/cli/lib/__tests__/init-base-url.test.js
@@ -83,7 +83,7 @@ describe('base URL support', () => {
     try {
       const { writeCodexConfig } = await import('../runtime-setup.js');
 
-      assert.equal(writeCodexConfig('/tmp/zylos-project'), true);
+      assert.equal(writeCodexConfig(path.join(tmpRoot, 'zylos-project')), true);
 
       const configPath = path.join(tmpRoot, '.codex', 'config.toml');
       const config = fs.readFileSync(configPath, 'utf8');
@@ -111,7 +111,7 @@ describe('base URL support', () => {
       const { writeCodexConfig } = await import('../runtime-setup.js');
 
       assert.equal(
-        writeCodexConfig('/tmp/zylos-project', { openaiBaseUrl: 'https://explicit-proxy.example.com/v1' }),
+        writeCodexConfig(path.join(tmpRoot, 'zylos-project'), { openaiBaseUrl: 'https://explicit-proxy.example.com/v1' }),
         true
       );
 


### PR DESCRIPTION
Fixes #708.

The two `writeCodexConfig` cases in `cli/lib/__tests__/init-base-url.test.js` passed the fixed path `/tmp/zylos-project` as the project dir. On a shared multi-user host where another user owns that directory, `mkdirSync` inside it fails, `writeCodexConfig` returns `false`, and the suite fails on any commit.

**Fix:** point the project dir inside each test's existing `mkdtempSync` root (`path.join(tmpRoot, 'zylos-project')`) — unique per test, already cleaned up by the existing `rmSync` teardown. No second mkdtemp needed.

**Acceptance (per issue):**
- ✅ Verified on the original repro host, where `/tmp/zylos-project` is owned by a different user: previously these were the only 2 red tests on any commit; full suite now green — Node **682/682** (was 680/682), Jest pass, exit 0
- ✅ No fixed `/tmp` paths remain in the test file (`grep '/tmp/' → no matches`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)