### PR TITLE
fix: remove same-round duplicate public request in no-token fallback

### DIFF
--- a/cli/lib/__tests__/download-no-token.test.js
+++ b/cli/lib/__tests__/download-no-token.test.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+const origEnv = {};
+for (const key of ['ZYLOS_GH_RETRY_DELAY_MS', 'GITHUB_TOKEN', 'GH_TOKEN', 'PATH']) {
+  origEnv[key] = process.env[key];
+}
+const tmpDirs = [];
+
+const { downloadArchive } = await import('../download.js');
+
+beforeEach(() => {
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(origEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+// Fake curl that always fails with the given status; fake gh that reports no
+// auth, so getGitHubToken() resolves to null on its first (cached) probe.
+function installFailingCurl({ status }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-download-fake-'));
+  tmpDirs.push(dir);
+  const callsFile = path.join(dir, 'calls');
+  const script = `#!/bin/sh
+n=$(cat "${callsFile}" 2>/dev/null || echo 0)
+n=$((n+1))
+echo $n > "${callsFile}"
+echo "curl: (22) The requested URL returned error: ${status}" >&2
+exit 22
+`;
+  fs.writeFileSync(path.join(dir, 'curl'), script, { mode: 0o755 });
+  fs.writeFileSync(path.join(dir, 'gh'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+  process.env.PATH = `${dir}${path.delimiter}${process.env.PATH}`;
+  return {
+    calls: () => {
+      if (!fs.existsSync(callsFile)) return 0;
+      return Number(fs.readFileSync(callsFile, 'utf8').trim());
+    },
+  };
+}
+
+function makeDestDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-download-dest-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe('downloadArchive no-token fallback (fake curl on PATH)', () => {
+  it('makes exactly one public request per failed no-token attempt and surfaces the error (#705)', () => {
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '';
+    const fake = installFailingCurl({ status: '404' });
+
+    const result = downloadArchive('org/repo', '1.0.0', makeDestDir());
+
+    assert.equal(result.success, false);
+    assert.match(result.error, /404/);
+    assert.equal(fake.calls(), 1);
+  });
+
+  it('retries no-token rate limiting via the outer loop only (#705)', () => {
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '0';
+    const fake = installFailingCurl({ status: '403' });
+
+    const result = downloadArchive('org/repo', '1.0.0', makeDestDir());
+
+    assert.equal(result.success, false);
+    assert.match(result.error, /403/);
+    // 1 public call per retry round: initial attempt + one configured retry
+    assert.equal(fake.calls(), 2);
+  });
+});

--- a/cli/lib/__tests__/github-rate-limit.test.js
+++ b/cli/lib/__tests__/github-rate-limit.test.js
@@ -329,31 +329,7 @@ esac
     assert.match(calls[2].args, /raw\.githubusercontent\.com\/org\/repo\/main\/SKILL\.md/);
   });
 
-  it('keeps the legacy immediate public retry without a token', async () => {
-    delete process.env.GITHUB_TOKEN;
-    delete process.env.GH_TOKEN;
-    process.env.ZYLOS_GH_RETRY_DELAY_MS = '';
-
-    for (const operation of ['sync tags', 'async tags', 'raw file']) {
-      const fake = installRecordingCommands({
-        publicFailuresBeforeSuccess: 1,
-        publicStatus: '500',
-      });
-      const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
-        await importFreshGitHub();
-
-      if (operation === 'sync tags') {
-        assert.equal(fetchLatestTag('org/repo'), '1.2.3');
-      } else if (operation === 'async tags') {
-        assert.equal(await fetchLatestTagAsync('org/repo'), '1.2.3');
-      } else {
-        assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
-      }
-      assert.equal(fake.publicCalls(), 2, operation);
-    }
-  });
-
-  it('makes exactly two public calls per failed no-token attempt', async () => {
+  it('fails fast without a token on non-rate-limit errors (single public call, #705)', async () => {
     delete process.env.GITHUB_TOKEN;
     delete process.env.GH_TOKEN;
     process.env.ZYLOS_GH_RETRY_DELAY_MS = '';
@@ -367,17 +343,42 @@ esac
         await importFreshGitHub();
 
       if (operation === 'sync tags') {
-        assert.throws(() => fetchLatestTag('org/repo'));
+        assert.throws(() => fetchLatestTag('org/repo'), /500/);
       } else if (operation === 'async tags') {
-        await assert.rejects(fetchLatestTagAsync('org/repo'));
+        await assert.rejects(fetchLatestTagAsync('org/repo'), /500/);
       } else {
-        assert.throws(() => fetchRawFileFresh('org/repo', 'SKILL.md'));
+        assert.throws(() => fetchRawFileFresh('org/repo', 'SKILL.md'), /500/);
       }
+      assert.equal(fake.publicCalls(), 1, operation);
+    }
+  });
+
+  it('recovers from no-token rate limiting via the outer retry loop only (#705)', async () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    process.env.ZYLOS_GH_RETRY_DELAY_MS = '0';
+
+    for (const operation of ['sync tags', 'async tags', 'raw file']) {
+      const fake = installRecordingCommands({
+        publicFailuresBeforeSuccess: 1,
+        publicStatus: '403',
+      });
+      const { fetchLatestTag, fetchLatestTagAsync, fetchRawFile: fetchRawFileFresh } =
+        await importFreshGitHub();
+
+      if (operation === 'sync tags') {
+        assert.equal(fetchLatestTag('org/repo'), '1.2.3');
+      } else if (operation === 'async tags') {
+        assert.equal(await fetchLatestTagAsync('org/repo'), '1.2.3');
+      } else {
+        assert.equal(fetchRawFileFresh('org/repo', 'SKILL.md').trim(), 'file-content');
+      }
+      // 1 public call per retry round: round 1 rate-limited, round 2 succeeds
       assert.equal(fake.publicCalls(), 2, operation);
     }
   });
 
-  it('makes six public calls when all three no-token rate-limit attempts fail', async () => {
+  it('makes three public calls when all three no-token rate-limit attempts fail (#705)', async () => {
     delete process.env.GITHUB_TOKEN;
     delete process.env.GH_TOKEN;
     process.env.ZYLOS_GH_RETRY_DELAY_MS = '0,0';
@@ -397,7 +398,7 @@ esac
       } else {
         assert.throws(() => fetchRawFileFresh('org/repo', 'SKILL.md'));
       }
-      assert.equal(fake.publicCalls(), 6, operation);
+      assert.equal(fake.publicCalls(), 3, operation);
     }
   });
 

--- a/cli/lib/download.js
+++ b/cli/lib/download.js
@@ -52,26 +52,24 @@ function curlDownloadOnce(repo, ref, refType, tarballPath) {
   const publicUrl = refType === 'tag'
     ? `https://github.com/${repo}/archive/refs/tags/${ref}.tar.gz`
     : `https://github.com/${repo}/archive/refs/heads/${ref}.tar.gz`;
+  let publicError;
   try {
     execFileSync('curl', ['-fsSL', '-o', tarballPath, publicUrl], {
       timeout: 60000,
       stdio: 'pipe',
     });
     return;
-  } catch {
+  } catch (err) {
     // Public download failed — repo may be private, try with auth
+    publicError = err;
   }
 
   // 2. Fall back to authenticated GitHub API (for private repos)
   const token = getGitHubToken();
   if (!token) {
-    // No token available — re-throw by attempting public download again
-    // (this gives the caller the original error message)
-    execFileSync('curl', ['-fsSL', '-o', tarballPath, publicUrl], {
-      timeout: 60000,
-      stdio: 'pipe',
-    });
-    return;
+    // No token available — surface the original public error; retry semantics
+    // belong exclusively to the outer withRateLimitRetrySync loop (#705)
+    throw publicError;
   }
 
   const apiUrl = `https://api.github.com/repos/${repo}/tarball/${ref}`;

--- a/cli/lib/github.js
+++ b/cli/lib/github.js
@@ -210,17 +210,10 @@ function fetchRawFileOnce(repo, filePath, branch) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
   } catch (publicError) {
-    if (!token) {
-      // Preserve the pre-auth-first behavior: without credentials, a failed
-      // public request gets one immediate re-attempt in the same retry cycle.
-      return execFileSync('curl', ['-fsSL', publicUrl], {
-        encoding: 'utf8',
-        timeout: 10000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-    }
     // A rate-limited public fallback must reach the outer retry loop even when
     // the authenticated request failed first with a non-rate-limit status.
+    // Without a token this surfaces the public error as-is — retry semantics
+    // belong exclusively to the outer withRateLimitRetry* loop (#705).
     throw preferredFallbackError(authenticatedError, publicError);
   }
 }
@@ -294,11 +287,6 @@ function fetchTagsJsonSync(repo) {
       encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
     });
   } catch (publicError) {
-    if (!token) {
-      return execFileSync('curl', ['-fsSL', url], {
-        encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'],
-      });
-    }
     throw preferredFallbackError(authenticatedError, publicError);
   }
 }
@@ -327,12 +315,6 @@ async function fetchTagsJsonAsync(repo) {
     });
     return stdout;
   } catch (publicError) {
-    if (!token) {
-      const { stdout } = await execFileAsync('curl', ['-fsSL', url], {
-        encoding: 'utf8', timeout: 10000,
-      });
-      return stdout;
-    }
     throw preferredFallbackError(authenticatedError, publicError);
   }
 }


### PR DESCRIPTION
Fixes #705 (decided by Howard 2026-07-11: fix separately from #699's zero-behavior-change scope).

## What

Without a token, four fallback helpers re-fired the **identical public request in the same retry round** purely to surface an error:

- `cli/lib/github.js` — `fetchRawFileOnce`, `fetchTagsJsonSync`, `fetchTagsJsonAsync`
- `cli/lib/download.js` — `curlDownloadOnce` (this one silently discarded the first error too)

This doubled failure latency, wasted a request under rate limiting, and made logs confusing. Now the first public error is captured and rethrown — retry semantics belong exclusively to `withRateLimitRetry*`.

## Behavior change (intended, per issue)

- No-token **failure** path: exactly **1** public request per retry round (was 2), error message/type surfaced unchanged.
- No-token **rate-limit** path: unchanged recovery via the outer retry loop (new pin test proves it).
- Side effect of removing the legacy duplicate: a transient non-rate-limit failure (e.g. one-off 500) no longer gets a free same-round second chance — consistent with how the token path already behaves.

## Tests

- Updated pins: 1 call per failed round; 3 calls across a full no-token rate-limit retry budget (was 2/6).
- New: no-token rate-limit recovery via outer loop only (2 calls: fail round + success round).
- New `download-no-token.test.js`: download path makes 1 call per round and surfaces the original error.
- Full suite: Jest 112/112; Node 682 pass + the 2 pre-existing `/tmp/zylos-project` env failures already fixed on main by #710 (unrelated to this diff).

## Acceptance (per issue)

- ✅ No-token failure path performs exactly 1 public request per retry round
- ✅ Error message/type surfaced to the caller unchanged
- ✅ Regression tests pin the single-attempt behavior (github + download paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)