### PR TITLE
docs: route machine-local standing directives to the custom session-start shard (#719)

### DIFF
--- a/docs/custom-session-start.md
+++ b/docs/custom-session-start.md
@@ -45,7 +45,7 @@ Ownership boundary: `memory/` is agent-written and audited/trimmed/archived by M
 ## Pitfalls
 
 - **Never place explanatory/readme `*.md` files inside the directory.** Every `.md` file there is injected into every session — a readme becomes a permanent token tax. Put documentation outside the directory (like this file), or use a non-`.md` filename/dotfile, which the emitter ignores.
-- **Symlinks are followed.** A `*.md` symlink injects its target's content into every session. This supports sharing directive files across deployments (conf.d style), but the effective security boundary is write access to the directory: never symlink files that may contain secrets or content you don't control.
+- **Symlinks are followed.** A `*.md` symlink injects its target's content into every session. This supports sharing directive files across deployments (conf.d style), but note what it does to the security boundary: injected content is controlled by write access to the directory **and to every reachable symlink target (and its path)** — anyone who can modify or replace a link target changes what the next session start injects. Only symlink files you own and control; never link anything that may contain secrets or content you don't control.
 - Do not duplicate content that already lives in `memory/` or ZYLOS.md — the directory should hold only directives that genuinely need always-on injection.
 
 ## Example

--- a/docs/custom-session-start.md
+++ b/docs/custom-session-start.md
@@ -20,7 +20,8 @@ The hook-scoped layout (`custom-hooks/<hook-name>/`) leaves room for future hook
 - **When it fires:** at every session start — fresh startup, after `/clear`, and after context compaction. The content is (re)injected each time, so it survives context rotation.
 - **Where it lands:** as the numbered shard right after the identity shard (`=== ZYLOS STARTUP CONTEXT [2/N] custom ===`), so custom directives frame everything that follows (references, state, conversation context).
 - **Ordering:** files concatenate in lexicographic filename order, conf.d style — use numeric prefixes (`10-`, `20-`, ...) to control precedence.
-- **What is read:** regular `*.md` files only. Dotfiles and non-`.md` entries are ignored. An unreadable file is skipped (it never breaks session start).
+- **What is read:** entries whose **name** ends in `.md`; dotfiles and other extensions are ignored. The filter is name-based only — **a symlink named `*.md` is followed and its target's content is injected**, so only link to files you own and intend to inject, never to anything that may hold sensitive content. An unreadable file is skipped (it never breaks session start).
+- **How content lands:** each file's content is trimmed of leading/trailing whitespace; non-empty files are concatenated with one blank line between them (not byte-for-byte verbatim).
 - **Empty states:** a missing directory, no `.md` files, or all-empty content emits just the shard header — chain and numbering are unaffected.
 - **No lifecycle steps:** no registration, no config entry, no service restart. Create/edit/delete files; the next session start picks the change up.
 
@@ -43,7 +44,8 @@ Ownership boundary: `memory/` is agent-written and audited/trimmed/archived by M
 
 ## Pitfalls
 
-- **Never place explanatory/readme `*.md` files inside the directory.** Every `.md` file there is injected verbatim into every session — a readme becomes a permanent token tax. Put documentation outside the directory (like this file), or use a non-`.md` filename/dotfile, which the emitter ignores.
+- **Never place explanatory/readme `*.md` files inside the directory.** Every `.md` file there is injected into every session — a readme becomes a permanent token tax. Put documentation outside the directory (like this file), or use a non-`.md` filename/dotfile, which the emitter ignores.
+- **Symlinks are followed.** A `*.md` symlink injects its target's content into every session. This supports sharing directive files across deployments (conf.d style), but the effective security boundary is write access to the directory: never symlink files that may contain secrets or content you don't control.
 - Do not duplicate content that already lives in `memory/` or ZYLOS.md — the directory should hold only directives that genuinely need always-on injection.
 
 ## Example

--- a/docs/custom-session-start.md
+++ b/docs/custom-session-start.md
@@ -1,0 +1,61 @@
+# Custom Session-Start Directives
+
+`~/zylos/custom-hooks/session-start/` lets an operator (or an installing platform) inject standing directives into **every** agent session — machine- or deployment-local rules that must be in force from the first moment of a session, without anyone asking. Typical content: toolchain constraints ("always use the GVM-managed Go, never system Go"), platform policies, house rules.
+
+This is a **content** directory, not a code hook: files are plain markdown, read fresh at each session start by fixed core code (`skills/activity-monitor/scripts/emit-custom-inject.js`). Users supply content, never code.
+
+## Location and layout
+
+```
+~/zylos/custom-hooks/
+└── session-start/          # content for the session-start injection point
+    ├── 10-go-toolchain.md
+    └── 20-platform-rules.md
+```
+
+The hook-scoped layout (`custom-hooks/<hook-name>/`) leaves room for future hook types to get their own content subdirectory; `session-start` is the only one today.
+
+## Semantics
+
+- **When it fires:** at every session start — fresh startup, after `/clear`, and after context compaction. The content is (re)injected each time, so it survives context rotation.
+- **Where it lands:** as the numbered shard right after the identity shard (`=== ZYLOS STARTUP CONTEXT [2/N] custom ===`), so custom directives frame everything that follows (references, state, conversation context).
+- **Ordering:** files concatenate in lexicographic filename order, conf.d style — use numeric prefixes (`10-`, `20-`, ...) to control precedence.
+- **What is read:** regular `*.md` files only. Dotfiles and non-`.md` entries are ignored. An unreadable file is skipped (it never breaks session start).
+- **Empty states:** a missing directory, no `.md` files, or all-empty content emits just the shard header — chain and numbering are unaffected.
+- **No lifecycle steps:** no registration, no config entry, no service restart. Create/edit/delete files; the next session start picks the change up.
+
+## Budget
+
+Each shard has a per-shard budget (default 10,000 chars / ~2,200 estimated tokens — see `shard-registry.js`). Content over budget is tail-trimmed inline, with a notice pointing at a spill file holding the full text. Practically: keep this directory far below the budget — every line here is a **permanent per-session token cost**, paid on every startup, `/clear`, and compaction.
+
+## What belongs here (and what doesn't)
+
+| Content | Home |
+|---------|------|
+| Deployment/machine-local standing directives, active every session | `custom-hooks/session-start/` |
+| Who the agent is (personality, principles, assets) | `memory/identity.md` (agent-maintained) |
+| Working conventions consulted on demand | `memory/reference/preferences.md` |
+| Facts, history, work state | `memory/` (state, references, reference/, sessions) |
+| Cross-deployment behavior shipped to every install | `ZYLOS.md` core template |
+| Complex reusable task-triggered workflows | a skill |
+
+Ownership boundary: `memory/` is agent-written and audited/trimmed/archived by Memory Sync. `custom-hooks/` is operator-placed configuration — the agent does not manage it, and writes here only when explicitly asked to make a rule permanent for every session.
+
+## Pitfalls
+
+- **Never place explanatory/readme `*.md` files inside the directory.** Every `.md` file there is injected verbatim into every session — a readme becomes a permanent token tax. Put documentation outside the directory (like this file), or use a non-`.md` filename/dotfile, which the emitter ignores.
+- Do not duplicate content that already lives in `memory/` or ZYLOS.md — the directory should hold only directives that genuinely need always-on injection.
+
+## Example
+
+```bash
+mkdir -p ~/zylos/custom-hooks/session-start
+cat > ~/zylos/custom-hooks/session-start/10-go-toolchain.md <<'EOF'
+# Go toolchain (this machine)
+
+Always use the GVM-managed Go toolchain (`gvm use go1.22`); never invoke the
+system Go. Go builds and tests must run through the GVM environment.
+EOF
+```
+
+From the next session start onward, the directive arrives in the `[2/N] custom` shard of the startup context.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -75,7 +75,7 @@ Persistent memory stored in `~/zylos/memory/` with an Inside Out-inspired archit
 | Tier | Path | Purpose | Loading |
 |------|------|---------|---------|
 | **Identity** | `memory/identity.md` | Bot soul: personality, principles, digital assets | Always (session start) |
-| **Custom** | `custom-hooks/session-start/*.md` | Operator-placed standing directives (machine/deployment-local); injected as-is, not agent-managed | Always (session start) |
+| **Custom** | `custom-hooks/session-start/*.md` | Operator-placed standing directives (machine/deployment-local); not agent-managed | Always (session start) |
 | **State** | `memory/state.md` | Active work, pending tasks | Always (session start) |
 | **References** | `memory/references.md` | Pointers to config files, key paths | Always (session start) |
 | **User Profiles** | `memory/users/<id>/profile.md` | Per-user preferences | On demand |

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -75,6 +75,7 @@ Persistent memory stored in `~/zylos/memory/` with an Inside Out-inspired archit
 | Tier | Path | Purpose | Loading |
 |------|------|---------|---------|
 | **Identity** | `memory/identity.md` | Bot soul: personality, principles, digital assets | Always (session start) |
+| **Custom** | `custom-hooks/session-start/*.md` | Operator-placed standing directives (machine/deployment-local); injected as-is, not agent-managed | Always (session start) |
 | **State** | `memory/state.md` | Active work, pending tasks | Always (session start) |
 | **References** | `memory/references.md` | Pointers to config files, key paths | Always (session start) |
 | **User Profiles** | `memory/users/<id>/profile.md` | Per-user preferences | On demand |
@@ -98,7 +99,7 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
 
 - **decisions.md:** Deliberate choices that close off alternatives
 - **projects.md:** Work efforts with defined scope and lifecycle
-- **preferences.md:** Standing instructions for how things should be done (shared across users)
+- **preferences.md:** Standing instructions for how things should be done (shared across users). Exception: an instruction that must be in effect from the start of **every** session (machine/deployment-local standing directive) goes to `custom-hooks/session-start/` instead — preferences.md is only read on demand
 - **ideas.md:** Uncommitted plans, explorations, hypotheses
 
 When in doubt, write to sessions/current.md.

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -95,7 +95,7 @@ Persistent memory stored in `~/zylos/memory/` with an Inside Out-inspired archit
 | Tier | Path | Purpose | Loading |
 |------|------|---------|---------|
 | **Identity** | `memory/identity.md` | Bot soul: personality, principles, digital assets | Always (session start) |
-| **Custom** | `custom-hooks/session-start/*.md` | Operator-placed standing directives (machine/deployment-local); injected as-is, not agent-managed | Always (session start) |
+| **Custom** | `custom-hooks/session-start/*.md` | Operator-placed standing directives (machine/deployment-local); not agent-managed | Always (session start) |
 | **State** | `memory/state.md` | Active work, pending tasks | Always (session start) |
 | **References** | `memory/references.md` | Pointers to config files, key paths | Always (session start) |
 | **User Profiles** | `memory/users/<id>/profile.md` | Per-user preferences | On demand |
@@ -105,7 +105,7 @@ Persistent memory stored in `~/zylos/memory/` with an Inside Out-inspired archit
 
 ### Custom Standing Directives (`custom-hooks/session-start/`)
 
-`~/zylos/custom-hooks/session-start/*.md` holds **standing directives that must be in force from the first moment of every session** — machine- or deployment-local rules such as toolchain constraints, platform policies, or house rules. Files are injected verbatim at every session start (including after `/clear` and context compaction), concatenated in filename order (`10-rules.md`, `20-platform.md`, ...). No registration or service restart is needed; edits take effect at the next session start.
+`~/zylos/custom-hooks/session-start/*.md` holds **standing directives that must be in force from the first moment of every session** — machine- or deployment-local rules such as toolchain constraints, platform policies, or house rules. File content is injected at every session start (including after `/clear` and context compaction) — trimmed of leading/trailing whitespace and concatenated in filename order (`10-rules.md`, `20-platform.md`, ...), one blank line between files. No registration or service restart is needed; edits take effect at the next session start.
 
 Routing test: *"must this be active in every session, without anyone asking?"* → custom. Contrast with its neighbors:
 - `memory/identity.md` — who the agent **is** (agent-maintained, e.g. via reflection)

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -95,12 +95,26 @@ Persistent memory stored in `~/zylos/memory/` with an Inside Out-inspired archit
 | Tier | Path | Purpose | Loading |
 |------|------|---------|---------|
 | **Identity** | `memory/identity.md` | Bot soul: personality, principles, digital assets | Always (session start) |
+| **Custom** | `custom-hooks/session-start/*.md` | Operator-placed standing directives (machine/deployment-local); injected as-is, not agent-managed | Always (session start) |
 | **State** | `memory/state.md` | Active work, pending tasks | Always (session start) |
 | **References** | `memory/references.md` | Pointers to config files, key paths | Always (session start) |
 | **User Profiles** | `memory/users/<id>/profile.md` | Per-user preferences | On demand |
 | **Reference** | `memory/reference/*.md` | Decisions, projects, shared prefs, ideas | On demand |
 | **Sessions** | `memory/sessions/current.md` | Today's event log | On demand |
 | **Archive** | `memory/archive/` | Cold storage for old data | Rarely |
+
+### Custom Standing Directives (`custom-hooks/session-start/`)
+
+`~/zylos/custom-hooks/session-start/*.md` holds **standing directives that must be in force from the first moment of every session** — machine- or deployment-local rules such as toolchain constraints, platform policies, or house rules. Files are injected verbatim at every session start (including after `/clear` and context compaction), concatenated in filename order (`10-rules.md`, `20-platform.md`, ...). No registration or service restart is needed; edits take effect at the next session start.
+
+Routing test: *"must this be active in every session, without anyone asking?"* → custom. Contrast with its neighbors:
+- `memory/identity.md` — who the agent **is** (agent-maintained, e.g. via reflection)
+- `custom-hooks/session-start/` — how this **deployment must operate** (placed by the operator, or by the agent when explicitly asked to make a rule permanent for every session)
+- `reference/preferences.md` — conventions consulted **on demand** while working
+
+Example: "always use the GVM-managed Go toolchain on this machine, never the system Go" → `custom-hooks/session-start/10-go-toolchain.md`. Writing it to `preferences.md` instead would leave it out of context until someone thinks to look.
+
+Keep this directory small — every line is a permanent per-session token cost. Never place explanatory/readme files with a `.md` extension inside it (every `.md` file there is injected into every session); non-`.md` files and dotfiles are ignored. Full mechanics: `docs/custom-session-start.md` in the zylos-core repo.
 
 ### Multi-User
 
@@ -125,7 +139,7 @@ Route user-specific preferences to the correct profile file. Bot identity stays 
 
 - **decisions.md:** Deliberate choices that close off alternatives
 - **projects.md:** Work efforts with defined scope and lifecycle
-- **preferences.md:** Standing instructions for how things should be done (shared across users)
+- **preferences.md:** Standing instructions for how things should be done (shared across users). Exception: an instruction that must be in effect from the start of **every** session (machine/deployment-local standing directive) goes to `custom-hooks/session-start/` instead — preferences.md is only read on demand
 - **ideas.md:** Uncommitted plans, explorations, hypotheses
 
 When in doubt, write to sessions/current.md.

--- a/templates/ZYLOS.md
+++ b/templates/ZYLOS.md
@@ -114,7 +114,7 @@ Routing test: *"must this be active in every session, without anyone asking?"* �
 
 Example: "always use the GVM-managed Go toolchain on this machine, never the system Go" → `custom-hooks/session-start/10-go-toolchain.md`. Writing it to `preferences.md` instead would leave it out of context until someone thinks to look.
 
-Keep this directory small — every line is a permanent per-session token cost. Never place explanatory/readme files with a `.md` extension inside it (every `.md` file there is injected into every session); non-`.md` files and dotfiles are ignored. Full mechanics: `docs/custom-session-start.md` in the zylos-core repo.
+Keep this directory small — every line is a permanent per-session token cost. Never place explanatory/readme files with a `.md` extension inside it (every `.md` file there is injected into every session); non-`.md` files and dotfiles are ignored.
 
 ### Multi-User
 


### PR DESCRIPTION
Closes #719. Doc-only, no mechanism changes. Final frozen SHA `daea8b038bd97d053f940eef2f756c287b89c3a0` (3 commits, 3 files, +80/−4 net).

## What

- **`templates/ZYLOS.md`**: `Custom` row in the Memory Tiers table; new **Custom Standing Directives** subsection (routing test, identity/custom/preferences contrast, GVM worked example, token-cost warning, no-`.md`-readme rule); disambiguation sentence at the `preferences.md` classification entry — the direct competitor that was capturing "remember this rule for every session" traffic.
- **`templates/CLAUDE.md`** (legacy template): mirrors the tiers row + preferences disambiguation.
- **`docs/custom-session-start.md`** (new): ops guide — location, hook-scoped layout, lexicographic ordering, startup/clear/compact semantics, shard budget/spill, content-boundary table, symlink behavior and its security-boundary implications, seed-file `.md` trap, worked example.

## Process

Approved by Howard in the #695 group (both design questions answered: keep the directory outside `memory/`; two-line routing fix). dev-workflow simple mode with independent review by zylos0t (original discoverability-scenario owner): R1 NEEDS FIX (P2 symlink-follow contradicted the documented regular-file boundary — reproduced; P3 "verbatim" inaccurate vs trim+join) → R2 NEEDS FIX (boundary statement still too narrow: symlink-target writers also control injection) → **final CLEAN at `daea8b0`**. Both rounds' findings documented honestly; the question of mechanically restricting the emitter to regular files is deliberately split out as #720 for a separate design decision.

## Propagation note

Templates seed **fresh installs only** — existing installs rebuild instruction files from their own `~/zylos/ZYLOS.md` (self-upgrade step 7) and must hand-apply the two ZYLOS.md edits once. A how-to will be posted to the fleet after merge.

Tests: full Jest 147/147 + Node 687/687 (doc-only; no code paths changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)