### PR TITLE
fix: emit original message content in the session-start c4-conversations shard (#724)

### DIFF
--- a/skills/comm-bridge/scripts/__tests__/c4-conversations-budget.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-conversations-budget.test.js
@@ -62,8 +62,9 @@ function withTmpDir(fn) {
   }
 }
 
-// Messages must stay under the 2,048-byte per-message delivery threshold so
-// the DB stores them verbatim (no attachment preview) and sizes stay exact.
+// Most packing tests keep messages under the 2,048-byte dispatch spill
+// threshold so sizes stay exact on every path (the budgeted shard path emits
+// originals regardless — #724 — but the legacy no-budget path still spills).
 const marker = i => `UNIQ_MARK_${i}`;
 
 describe('emitC4Conversations budget packing (message-boundary, newest-first)', () => {
@@ -134,15 +135,84 @@ describe('emitC4Conversations budget packing (message-boundary, newest-first)', 
 
   it('never drops below one message — the newest stays even if it alone overflows', () => {
     withTmpDir(({ env }) => {
-      receive(`${marker(1)} ${'x'.repeat(1800)}`, env);
-      receive(`${marker(2)} ${'x'.repeat(1800)}`, env);
+      // Over the 2,048-byte dispatch spill threshold so the lone-message
+      // fallback has a pointer form to reach for.
+      receive(`${marker(1)} ${'x'.repeat(3000)}`, env);
+      receive(`${marker(2)} ${'x'.repeat(3000)}`, env);
 
-      // Budget smaller than a single message: packing keeps the newest one
-      // and leaves the last-resort generic trim+spill to the orchestrator.
-      const out = emitConversations(env, { maxChars: 300, maxTokens: 50 });
+      // Budget smaller than a single message: packing keeps the newest one,
+      // which falls back to its preview + pointer form (#724) instead of
+      // handing the orchestrator an over-budget body to tail-trim blindly.
+      const out = emitConversations(env, { maxChars: 600, maxTokens: 200 });
 
       assert.ok(out.includes(marker(2)), 'the newest message is always kept');
       assert.ok(!out.includes(marker(1)));
+      assert.ok(out.includes('[C4] Full message'), 'lone over-budget message must use the pointer form');
+      assert.ok(!out.includes('x'.repeat(3000)), 'lone over-budget message must not be emitted in full');
+    });
+  });
+
+  it('emits a sub-threshold message in full even when it alone overflows a tiny budget', () => {
+    withTmpDir(({ env }) => {
+      // Under the 2,048-byte spill threshold there is no pointer form to
+      // fall back to; the emitter keeps the original and the orchestrator's
+      // generic trim stays the last resort. Unreachable with the real shard
+      // budget (a sub-threshold message can never exceed 10K chars) — this
+      // pins the synthetic edge so the fallback never mangles small messages.
+      receive(`${marker(1)} ${'x'.repeat(1800)}`, env);
+
+      const out = emitConversations(env, { maxChars: 300, maxTokens: 50 });
+
+      assert.ok(out.includes(`${marker(1)} ${'x'.repeat(1800)}`), 'sub-threshold message stays original');
+      assert.ok(!out.includes('[C4] Full message'));
+    });
+  });
+
+  it('emits messages over the per-message delivery threshold in FULL when the shard budget fits them (#724)', () => {
+    withTmpDir(({ tmpDir, env }) => {
+      // 3,000 chars — well over the 2,048-byte dispatch spill threshold but
+      // comfortably inside the default 10K-char shard budget.
+      const body = `${marker(1)} ${'y'.repeat(3000)}`;
+      receive(body, env);
+
+      const out = emitConversations(env, DEFAULT_SHARD_BUDGET);
+
+      assert.ok(out.includes(body), 'original content must be emitted inline, not a preview');
+      assert.ok(!out.includes('[C4] Full message'), 'no attachment pointer when the budget fits the original');
+      const attachmentsDir = path.join(tmpDir, 'comm-bridge', 'attachments');
+      assert.ok(
+        !fs.existsSync(attachmentsDir) || fs.readdirSync(attachmentsDir).length === 0,
+        'no spill file must be written when the original is emitted inline',
+      );
+    });
+  });
+
+  it('packs whole original long messages newest-first when several exceed the dispatch threshold', () => {
+    withTmpDir(({ env }) => {
+      // Four ~3K messages ≈ 12K chars against the 10K-char default budget:
+      // at least the newest must survive IN FULL, the oldest must drop whole.
+      for (let i = 1; i <= 4; i++) receive(`${marker(i)} ${'z'.repeat(3000)}`, env);
+
+      const out = emitConversations(env, { maxChars: 10000, maxTokens: 100000 });
+
+      assert.ok(out.includes(`${marker(4)} ${'z'.repeat(3000)}`), 'newest long message must survive in full');
+      assert.ok(!out.includes(marker(1)), 'oldest message must be dropped whole');
+      assert.ok(!out.includes('[C4] Full message'), 'kept messages must be originals, not previews');
+      assert.match(out, /showing the newest \d+ of 4 unsummarized messages/);
+      assert.ok(out.length <= 10000, `packed output must fit the char budget (got ${out.length})`);
+    });
+  });
+
+  it('keeps the legacy no-budget path byte-identical: per-message spill still applies', () => {
+    withTmpDir(({ env }) => {
+      const body = `${marker(1)} ${'w'.repeat(3000)}`;
+      receive(body, env);
+
+      const out = emitConversations(env, null);
+
+      assert.ok(out.includes('[C4] Full message'), 'legacy path must keep the preview + pointer form');
+      assert.ok(!out.includes(body), 'legacy path must not emit the full over-threshold message');
+      assert.ok(out.includes(marker(1)), 'preview must still lead with the message head');
     });
   });
 
@@ -164,10 +234,9 @@ describe('emitC4Conversations budget packing (message-boundary, newest-first)', 
 
   it('registry closure passes the shard budget: shard-mode output always fits inline', () => {
     withTmpDir(({ env }) => {
-      // 650 CJK chars ≈ 500 estimated tokens per message while staying under
-      // the 2,048-byte per-message delivery threshold (bigger messages become
-      // 100-char previews + attachment pointers and would never overflow).
-      // Six of them ≈ 3,000 tokens blow the default 2,200-token shard budget.
+      // 650 CJK chars ≈ 500 estimated tokens per message. Six of them
+      // ≈ 3,000 tokens blow the default 2,200-token shard budget, so the
+      // whole-message packer must kick in.
       for (let i = 1; i <= 6; i++) receive(`${marker(i)} ${'守'.repeat(650)}`, env);
 
       const out = emitViaRegistry(env);

--- a/skills/comm-bridge/scripts/c4-db.js
+++ b/skills/comm-bridge/scripts/c4-db.js
@@ -747,9 +747,15 @@ export function formatConversations(conversations) {
  * formatConversations(), this adds reply routing only while each original
  * record is still available, never by post-processing the flattened output.
  * @param {array} conversations - array of conversation records
+ * @param {object} [options]
+ * @param {boolean} [options.spill=true] - when true, messages over the
+ *   per-message delivery threshold are replaced by a preview + attachment
+ *   pointer (dispatch-style). Pass false when a caller has its own size
+ *   control (e.g. the session-start shard's whole-message budget packer)
+ *   and wants original content inline (#724).
  * @returns {string} - formatted text for agent delivery/session init
  */
-export function formatConversationsForAgent(conversations) {
+export function formatConversationsForAgent(conversations, { spill = true } = {}) {
   if (!conversations || conversations.length === 0) {
     return '';
   }
@@ -765,7 +771,9 @@ export function formatConversationsForAgent(conversations) {
       !hasLegacyReplyViaSuffix(content)
     ) ? buildReplyViaSuffix(conv.channel, conv.endpoint_id) : '';
     lines.push(`[${conv.timestamp}] ${dir} (${conv.channel}${endpoint}):`);
-    lines.push(truncateForDelivery(content, replyViaSuffix, conv.id));
+    lines.push(spill
+      ? truncateForDelivery(content, replyViaSuffix, conv.id)
+      : content + replyViaSuffix);
     lines.push('');
   }
 

--- a/skills/comm-bridge/scripts/c4-session-init.js
+++ b/skills/comm-bridge/scripts/c4-session-init.js
@@ -59,14 +59,22 @@ export async function emitC4Checkpoint() {
  * Emit the unsummarized-conversations section (including the "no new
  * conversations" fallback and, above threshold, the Memory Sync instruction).
  *
- * In shard mode the orchestrator passes the shard's budget, and over-budget
- * output is packed at MESSAGE granularity: whole oldest messages are dropped
- * until the newest ones fit inline. This shard must never rely on the generic
- * tail-trim + spill fallback — that would cut the NEWEST messages (the text
- * is chronological) and depend on the agent following a read-this-file
- * pointer. Dropped messages are not lost: Memory Sync reads c4.db directly,
- * so they are covered by the next checkpoint summary. Without a budget
- * (legacy single-stdout path) the output is byte-identical to before.
+ * In shard mode the orchestrator passes the shard's budget, and messages are
+ * emitted as ORIGINAL content — never the dispatch-style preview + attachment
+ * pointer (#724): the DB stores originals, and compressing them at session
+ * start would make the agent's own recent history lossy while budget room
+ * goes unused. Over-budget output is packed at MESSAGE granularity instead:
+ * whole oldest messages are dropped until the newest ones fit inline. This
+ * shard must never rely on the generic tail-trim + spill fallback — that
+ * would cut the NEWEST messages (the text is chronological) and depend on
+ * the agent following a read-this-file pointer. Dropped messages are not
+ * lost: Memory Sync reads c4.db directly, so they are covered by the next
+ * checkpoint summary. Only when a SINGLE message alone overflows the whole
+ * shard budget does that message fall back to the preview + pointer form —
+ * a compressed newest message plus intact section structure beats the
+ * orchestrator's blind tail-trim. Without a budget (legacy single-stdout
+ * path, no packer to bound the output) behavior is unchanged: per-message
+ * spill applies as before and the output is byte-identical to before.
  */
 export async function emitC4Conversations(_payload, budget = null) {
   return withC4Db('c4 conversations init', async ({
@@ -88,13 +96,13 @@ export async function emitC4Conversations(_payload, budget = null) {
       ? getUnsummarizedConversations(SESSION_INIT_RECENT_COUNT)
       : getUnsummarizedConversations();
 
-    const assemble = kept => {
+    const assemble = (kept, { spill = true } = {}) => {
       // Informational only — no file to read. Kept within the section so it
       // survives exactly as long as the section does.
       const note = kept.length < conversations.length
         ? `(showing the newest ${kept.length} of ${range.count} unsummarized messages inline; older ones are covered by the next Memory Sync checkpoint)\n\n`
         : '';
-      const sections = [formatSection('RECENT CONVERSATIONS', note + formatConversationsForAgent(kept))];
+      const sections = [formatSection('RECENT CONVERSATIONS', note + formatConversationsForAgent(kept, { spill }))];
 
       // If over threshold, append Memory Sync instruction
       if (needsSync) {
@@ -107,9 +115,13 @@ export async function emitC4Conversations(_payload, budget = null) {
       return sections.join('\n\n');
     };
 
+    // Legacy single-stdout path: no packer bounds the output, so keep the
+    // per-message spill exactly as before (byte-identical).
+    if (!budget) return assemble(conversations);
+
+    // Budgeted shard path: original content, whole-message packing.
     let kept = conversations;
-    let body = assemble(kept);
-    if (!budget) return body;
+    let body = assemble(kept, { spill: false });
 
     // Reserve room for the [k/N] shard header the orchestrator prepends.
     const packBudget = {
@@ -118,7 +130,13 @@ export async function emitC4Conversations(_payload, budget = null) {
     };
     while (kept.length > 1 && !withinBudget(body, packBudget)) {
       kept = kept.slice(1); // drop the oldest whole message
-      body = assemble(kept);
+      body = assemble(kept, { spill: false });
+    }
+    if (!withinBudget(body, packBudget)) {
+      // The single newest message alone overflows the shard budget: fall
+      // back to its preview + pointer form rather than handing the
+      // orchestrator an over-budget body to tail-trim blindly.
+      body = assemble(kept, { spill: true });
     }
     return body;
   });


### PR DESCRIPTION
Closes #724.

## What

The session-start `c4-conversations` shard (budgeted path) now injects **original message content** instead of the dispatch-style 2KB-spill compressed form (100-char preview + `[C4] Full message` attachment pointer).

## Why

c4.db stores originals, and the shard already has a whole-message newest-first budget packer bounding its output at 10K chars / 2,200 tokens — compressing per-message at session start made the agent's own recent history lossy while budget room went unused (a 3KB message arrived as a 100-char stub). Requested by Howard after the storage-vs-render investigation on 2026-07-12.

## How

- `formatConversationsForAgent()` gains a `spill` option; the default (`true`) keeps every existing caller byte-identical.
- `emitC4Conversations()` budgeted path assembles with `spill: false`; the existing packer drops whole oldest messages until the newest fit. New last-resort: if the **single newest message alone** overflows the shard budget, it falls back to the preview + pointer form (intact section structure beats the orchestrator's blind tail-trim). With the real shard budget this fires only for messages over the 2,048-byte dispatch threshold — a sub-threshold message can never overflow 10K chars.
- Legacy no-budget path (`initC4Session` single-stdout, used by the un-sharded orchestrator fallback on older installs): **unchanged, byte-identical** — it has no packer to bound the output, so per-message spill stays.
- Live dispatcher delivery path: untouched.

## Tests

- `c4-conversations-budget.test.js`: 4 new cases — over-threshold message emitted in full under budget (and no spill file written); whole-original-message packing with several over-threshold messages; lone over-budget message uses pointer form; legacy no-budget path still spills. Plus a pin for the synthetic sub-threshold/tiny-budget edge.
- Full suites: Jest 147/147, node 687/687.
- Live verification against a production c4.db (13 unsummarized, CJK-heavy): originals inline, token dimension drove packing to newest-3, zero generated pointer forms (the only `[C4] Full message` strings in output were quoted inside message content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)