### PR TITLE
fix(activity-monitor): skip symlinked custom inject files

### DIFF
--- a/skills/activity-monitor/scripts/__tests__/emit-custom-inject.test.js
+++ b/skills/activity-monitor/scripts/__tests__/emit-custom-inject.test.js
@@ -71,6 +71,20 @@ describe('emitCustomInject', () => {
     assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), 'REAL');
   });
 
+  it('skips symlinked .md files while injecting regular .md files', () => {
+    const zylosDir = makeZylosDir();
+    writeCustomFile(zylosDir, '10-real.md', 'REAL');
+
+    const outsideFile = path.join(zylosDir, 'outside.md');
+    fs.writeFileSync(outsideFile, 'OUTSIDE');
+    fs.symlinkSync(
+      outsideFile,
+      path.join(zylosDir, 'custom-hooks', 'session-start', '20-linked.md')
+    );
+
+    assert.equal(emitCustomInject({ env: { ZYLOS_DIR: zylosDir } }), 'REAL');
+  });
+
   it('skips whitespace-only files but keeps the rest in order', () => {
     const zylosDir = makeZylosDir();
     writeCustomFile(zylosDir, '10-a.md', 'A');

--- a/skills/activity-monitor/scripts/emit-custom-inject.js
+++ b/skills/activity-monitor/scripts/emit-custom-inject.js
@@ -12,7 +12,7 @@
  *
  * - Files concatenate in lexicographic filename order (conf.d style:
  *   `10-rules.md`, `20-platform.md`, ... to control ordering).
- * - Dotfiles and non-.md entries are ignored.
+ * - Dotfiles, non-.md entries, and symlinks are ignored.
  * - A missing directory, no .md files, or all-empty content emits nothing
  *   — the shard's [k/N] header still goes out, so the chain and numbering
  *   are unaffected (same empty semantics as the other content shards).
@@ -37,14 +37,17 @@ export function emitCustomInject({ env = process.env } = {}) {
   const dir = customInjectDir(env);
   let entries;
   try {
-    entries = fs.readdirSync(dir);
+    entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch {
     // Directory absent (fresh installs have none) — nothing to inject.
     return '';
   }
 
   const files = entries
-    .filter(name => name.endsWith('.md') && !name.startsWith('.'))
+    .filter(
+      entry => entry.isFile() && entry.name.endsWith('.md') && !entry.name.startsWith('.')
+    )
+    .map(entry => entry.name)
     .sort();
 
   const parts = [];


### PR DESCRIPTION
## Summary
- Custom session-start emitter (`emit-custom-inject.js`) now uses `readdirSync({withFileTypes: true})` + `Dirent.isFile()` to skip symlinks
- Only regular `.md` files are injected; symlinked `.md` files are silently skipped
- Closes #720

## Context
Howard's decision: Option A (skip symlinks for security — prevent accidental injection of linked sensitive files). The custom-hooks directory now also hosts migration prompts (#729), making the symlink boundary more important.

## Test plan
- [x] Positive: regular `.md` files injected normally
- [x] Negative: symlink to external `.md` skipped
- [x] Jest 147/147, Node 805/805

🤖 Generated with [Claude Code](https://claude.com/claude-code)