### PR TITLE
feat: auto-trigger pending migration on session start

### DIFF
--- a/skills/activity-monitor/scripts/session-start-prompt.js
+++ b/skills/activity-monitor/scripts/session-start-prompt.js
@@ -19,6 +19,7 @@ const execFileAsync = promisify(execFile);
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const C4_CONTROL = path.join(ZYLOS_DIR, '.claude/skills/comm-bridge/scripts/c4-control.js');
 const STATE_PATH = path.join(ZYLOS_DIR, 'memory', 'state.md');
+const MIGRATION_PROMPT_PATH = path.join(ZYLOS_DIR, 'custom-hooks', 'session-start', '90-migration-prompt.md');
 const DEFAULT_CHILD_TIMEOUT_MS = 2500;
 let diagnosticModule;
 let diagnosticLoadAttempted = false;
@@ -84,6 +85,17 @@ const prompt = [
   'and do not query c4.db for recent conversations unless explicitly required.'
 ].join(' ');
 
+const migrationPrompt = [
+  'A pending instruction migration was injected into this session\'s startup context.',
+  'Treat it as the active task for this turn and execute its Required action now.',
+  'Do not merely acknowledge or summarize it.',
+  'Follow the steps in the migration prompt: read the system template, compare with ZYLOS.md,',
+  'extract user-only content, and run `zylos migrate-instructions --apply --user-content <file>`.',
+  'If genuinely blocked, report the concrete blocker.',
+  'Meanwhile, reply to your human partner if they are waiting for your reply,',
+  'and do not query c4.db for recent conversations unless explicitly required.'
+].join(' ');
+
 export function isOnboardingPending({
   statePath = STATE_PATH,
   readFileSync = fs.readFileSync,
@@ -95,13 +107,23 @@ export function isOnboardingPending({
   }
 }
 
+export function isMigrationPending({
+  migrationPromptPath = MIGRATION_PROMPT_PATH,
+  existsSync = fs.existsSync,
+} = {}) {
+  return existsSync(migrationPromptPath);
+}
+
 export async function enqueueStartupPrompt(source, {
   execFile = execFileAsync,
   controlPath = C4_CONTROL,
   childTimeoutMs = DEFAULT_CHILD_TIMEOUT_MS,
   onboardingPending = isOnboardingPending,
+  migrationPending = isMigrationPending,
 } = {}) {
   if (onboardingPending()) return { skipped: true, reason: 'onboarding_pending' };
+
+  const activePrompt = migrationPending() ? migrationPrompt : prompt;
 
   // Async execFile (not execFileSync): keeps the event loop free so this step
   // genuinely runs in parallel with the foreground step, and so the
@@ -110,14 +132,14 @@ export async function enqueueStartupPrompt(source, {
   // #601-class enqueue hang even if the orchestrator budget is generous).
   await execFile('node', [
     controlPath, 'enqueue',
-    '--content', prompt,
+    '--content', activePrompt,
     '--priority', '2',
     '--no-ack-suffix'
   ], {
     timeout: childTimeoutMs,
     killSignal: 'SIGKILL',
   });
-  return { skipped: false };
+  return { skipped: false, migration: activePrompt === migrationPrompt };
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- When `90-migration-prompt.md` exists (written by upgrade step7 for C-class migrations), `session-start-prompt.js` now sends a migration-specific prompt that explicitly instructs the agent to execute the migration steps immediately
- Without this, the generic "continue ongoing tasks" prompt causes the agent to ignore the injected migration context — it treats it as passive information rather than an active task
- `isMigrationPending()` is injectable for testing; the migration prompt file lifecycle (created on upgrade, cleaned on success, retained on failure) is unchanged

Follows up on PR #735 (merged). Addresses the issue Howard found: the migration prompt was injected into context but the agent didn't auto-execute it.

## Test plan

- [x] All 806 existing tests pass
- [x] Verified zylos0t's ZYLOS.md remediation completed successfully (CLAUDE.md/AGENTS.md clean, no duplicate system content)
- [ ] End-to-end: upgrade a machine with C-class ZYLOS.md, verify the agent auto-executes the migration on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)