### PR TITLE
fix: detect content filtering API errors for session recovery

### DIFF
--- a/cli/lib/__tests__/heartbeat-api-error-patterns.test.js
+++ b/cli/lib/__tests__/heartbeat-api-error-patterns.test.js
@@ -23,6 +23,20 @@ describe('heartbeat API error patterns', () => {
     assert.equal(result.pattern, 'APIError: 400');
   });
 
+  it('detects API Error with space (content filtering)', () => {
+    const result = detectApiErrorText('API Error: 400 Output blocked by content filtering policy');
+
+    assert.equal(result.detected, true);
+    assert.equal(result.pattern, 'API Error: 400');
+  });
+
+  it('detects content filtering policy text standalone', () => {
+    const result = detectApiErrorText('Output blocked by content filtering policy');
+
+    assert.equal(result.detected, true);
+    assert.match(result.pattern, /content filtering policy/i);
+  });
+
   it('does not match ordinary image discussion text', () => {
     const result = detectApiErrorText('Please resize this image to 2000px before sending it.');
 

--- a/cli/lib/heartbeat/api-error-patterns.js
+++ b/cli/lib/heartbeat/api-error-patterns.js
@@ -2,10 +2,11 @@
 // Keep these specific to CLI/runtime error displays to avoid matching normal
 // conversation text.
 const API_ERROR_PATTERNS = [
-  /APIError:\s*\d{3}/,                                    // "APIError: 400 ..."
-  /\b(400|422)\b.*(?:bad request|invalid request)/i,      // "400 Bad Request"
-  /invalid_request_error/,                                 // Anthropic error type
-  /overloaded_error/,                                      // Anthropic overloaded
+  /API\s*Error:\s*\d{3}/,                                  // "APIError: 400 ..." or "API Error: 400 ..."
+  /\b(400|422)\b.*(?:bad request|invalid request)/i,       // "400 Bad Request"
+  /invalid_request_error/,                                  // Anthropic error type
+  /overloaded_error/,                                       // Anthropic overloaded
+  /output blocked by content filtering policy/i,            // content filter block (needs session restart)
   /an image in the conversation exceeds the dimension limit for many-image requests/i,
   /dimension limit for many-image requests\s*\(\s*2000px\s*\)/i,
 ];


### PR DESCRIPTION
## Summary
- Widen `APIError:` regex to `API\s*Error:` to match both "APIError: 400" and "API Error: 400" formats
- Add dedicated pattern for "output blocked by content filtering policy" — a fatal error requiring session restart
- Add 2 test cases for the new patterns

Fixes activity monitor not detecting content filtering blocks, which left sessions stuck until manual restart.

## Test plan
- [x] `node --test cli/lib/__tests__/heartbeat-api-error-patterns.test.js` — 5/5 pass
- [x] `node --test skills/activity-monitor/scripts/__tests__/health-engine.test.js` — 98/98 pass
- [x] Verified old patterns ("APIError: 400") still match

🤖 Generated with [Claude Code](https://claude.com/claude-code)