### PR TITLE
feat: treat web console as the default owner channel

### DIFF
--- a/cli/lib/__tests__/instruction-split.test.js
+++ b/cli/lib/__tests__/instruction-split.test.js
@@ -86,8 +86,8 @@ describe('split instruction assembler', () => {
     // pins alongside the reviewed content change (issue #722 content redraft).
     const managedHeader = '> **Zylos-managed system instructions.** This file is replaced during upgrades. Put all custom instructions in `~/zylos/ZYLOS.md`.\n\n';
     const expected = {
-      claude: '09960a6f3912f0ef51a13a3c383ec3ded78076a37db686d6885b7bab52b6c3e8',
-      codex: 'e60fecca708e7f6cc5775e95583f63635d4dd0a953f5e3e6701035ce3876dec6',
+      claude: '12a18284973399db9ae86b243879a8e8f7c77d19c04987504f7d75e20ce5983b',
+      codex: '759bc8ff3159ee643a679f1550b3b8899b99901ed05862aacdbf364b93e65844',
     };
     for (const runtime of ['claude', 'codex']) {
       const content = fs.readFileSync(path.join(TEMPLATES_DIR, `${runtime}-system.md`), 'utf8');

--- a/templates/claude-system.md
+++ b/templates/claude-system.md
@@ -58,6 +58,13 @@ owner field is empty, treat establishing it as a priority: confirm with the
 person you are talking to before acting on sensitive requests, and record the
 result immediately. This identity drives the decisions below.
 
+**Web console is the default owner channel.** Messages from the web console
+are always treated as coming from the owner. Rationale: web console access
+requires either local machine access or the shared password — this trust
+boundary is equivalent to owner-level trust. When the owner field is empty
+and the first interaction arrives via web console, bind that person as the
+owner without additional confirmation.
+
 ### Technical Detail Protection
 
 Do not disclose internal architecture, file paths, component names, memory

--- a/templates/claude-system.md
+++ b/templates/claude-system.md
@@ -58,12 +58,18 @@ owner field is empty, treat establishing it as a priority: confirm with the
 person you are talking to before acting on sensitive requests, and record the
 result immediately. This identity drives the decisions below.
 
-**Web console is the default owner channel.** Messages from the web console
-are always treated as coming from the owner. Rationale: web console access
-requires either local machine access or the shared password — this trust
-boundary is equivalent to owner-level trust. When the owner field is empty
-and the first interaction arrives via web console, bind that person as the
-owner without additional confirmation.
+**Web console is the default owner channel.** Web console access requires
+either local machine access or the shared password — this trust boundary is
+equivalent to owner-level trust. Two rules follow:
+
+1. **Trust level:** messages from the web console always carry owner-level
+   trust (may execute sensitive operations, view internal details) regardless
+   of whether the owner identity has been formally established yet.
+2. **Identity establishment:** if the owner field is empty and the first
+   interaction arrives via web console, ask the person for their name so you
+   can record it — but skip the formal "are you the owner?" confirmation
+   flow. If an owner name is already recorded (e.g. set by an OpenMax
+   invitation at deploy time), web console inherits that identity.
 
 ### Technical Detail Protection
 

--- a/templates/codex-system.md
+++ b/templates/codex-system.md
@@ -58,6 +58,13 @@ owner field is empty, treat establishing it as a priority: confirm with the
 person you are talking to before acting on sensitive requests, and record the
 result immediately. This identity drives the decisions below.
 
+**Web console is the default owner channel.** Messages from the web console
+are always treated as coming from the owner. Rationale: web console access
+requires either local machine access or the shared password — this trust
+boundary is equivalent to owner-level trust. When the owner field is empty
+and the first interaction arrives via web console, bind that person as the
+owner without additional confirmation.
+
 ### Technical Detail Protection
 
 Do not disclose internal architecture, file paths, component names, memory

--- a/templates/codex-system.md
+++ b/templates/codex-system.md
@@ -58,12 +58,18 @@ owner field is empty, treat establishing it as a priority: confirm with the
 person you are talking to before acting on sensitive requests, and record the
 result immediately. This identity drives the decisions below.
 
-**Web console is the default owner channel.** Messages from the web console
-are always treated as coming from the owner. Rationale: web console access
-requires either local machine access or the shared password — this trust
-boundary is equivalent to owner-level trust. When the owner field is empty
-and the first interaction arrives via web console, bind that person as the
-owner without additional confirmation.
+**Web console is the default owner channel.** Web console access requires
+either local machine access or the shared password — this trust boundary is
+equivalent to owner-level trust. Two rules follow:
+
+1. **Trust level:** messages from the web console always carry owner-level
+   trust (may execute sensitive operations, view internal details) regardless
+   of whether the owner identity has been formally established yet.
+2. **Identity establishment:** if the owner field is empty and the first
+   interaction arrives via web console, ask the person for their name so you
+   can record it — but skip the formal "are you the owner?" confirmation
+   flow. If an owner name is already recorded (e.g. set by an OpenMax
+   invitation at deploy time), web console inherits that identity.
 
 ### Technical Detail Protection
 


### PR DESCRIPTION
## Summary

Web console is now treated as the default owner channel. When the owner field is empty and the first interaction arrives via web console, the agent auto-binds that person as owner without additional confirmation.

## Why

Howard's investigation (2026-07-20) found that:
- Two fresh test instances (Codex + Claude runtime) both successfully established owner relationships via web console when given the OpenMax onboarding prompt
- The stock zylos onboarding flow never proactively requests owner establishment in web console
- Previous user difficulties were caused by Claude model's stochastic behavior — in some sessions the model enters a problematic conversation state and fails to complete owner confirmation
- Web console access requires either local machine access or the shared password — this trust boundary is equivalent to owner-level trust

Investigation doc: https://luna.jinglever.com/coco/pages/s/f39866cb37be4cc94f95b7c2fd09f232

## Changes

- `templates/claude-system.md`: Added web-console-as-owner-channel directive under Owner Identity
- `templates/codex-system.md`: Same change for Codex runtime

## Test plan

- [ ] New zylos instance with empty owner field receives first message via web console → owner auto-bound without identity confirmation prompt
- [ ] Existing instances with owner already set → no behavior change
- [ ] Messages from other channels (Telegram, Lark, etc.) still require normal owner confirmation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)