### PR TITLE
docs(system): add date-verification non-negotiable to Critical Reminders

### DIFF
--- a/templates/claude-system.md
+++ b/templates/claude-system.md
@@ -249,4 +249,7 @@ Non-negotiables worth restating (full rules in Behavioral Rules and Security
 above): confirm via C4 before any destructive or irreversible operation;
 reply via the exact `reply via:` path and never leak content across channels;
 never present interactive prompts or menus; never expose credentials in group
-chats, shared documents, or commits pushed to remotes.
+chats, shared documents, or commits pushed to remotes. Never compute dates
+mentally: for any weekday/date pairing or arithmetic-derived date (e.g.
+"周五 07-24", "三天后"), get the real date by running `date` before sending,
+and re-check dates reused from another agent.

--- a/templates/codex-system.md
+++ b/templates/codex-system.md
@@ -258,4 +258,7 @@ Non-negotiables worth restating (full rules in Behavioral Rules and Security
 above): confirm via C4 before any destructive or irreversible operation;
 reply via the exact `reply via:` path and never leak content across channels;
 never present interactive prompts or menus; never expose credentials in group
-chats, shared documents, or commits pushed to remotes.
+chats, shared documents, or commits pushed to remotes. Never compute dates
+mentally: for any weekday/date pairing or arithmetic-derived date (e.g.
+"周五 07-24", "三天后"), get the real date by running `date` before sending,
+and re-check dates reused from another agent.


### PR DESCRIPTION
## What
Adds one compressed line to the **Critical Reminders** section of both runtime system prompts (`templates/claude-system.md` + `templates/codex-system.md`):

> Never compute dates mentally: for any weekday/date pairing or arithmetic-derived date (e.g. "周五 07-24", "三天后"), get the real date by running `date` before sending, and re-check dates reused from another agent.

## Why
- **Model-general weakness, not a one-off.** Weekday/date mental arithmetic is a known LLM failure mode. Every zylos deployment (Jinglever, zylos0t, future bots) writes dates in outbound messages.
- **Cross-agent propagation observed.** A wrong hand-computed date recently leaked into an outbound message and was then reused verbatim by another agent — the class of error this closes.
- **Near-zero cost, cross-runtime by nature.** Two lines of permanent prompt budget; `date` exists in every runtime, so the rule is applied identically to the Claude and Codex system prompts.

## Wording note
The examples in parentheses are *trigger phrases* (the kind of text that must be checked), not arguments to `date`. Earlier phrasing (`... date ("周五 07-24", "三天后") with the date command`) could be misread as `date("周五 07-24")`, which is not a valid invocation — reworded so the command is plainly "run `date`" to get the real date.

## Scope
Docs-only. No version bump, no code, no test impact (no test references these template files). Placed in Critical Reminders per the existing "non-negotiables worth restating" pattern.

## Note
Opened for review per Howard — **do not merge without his go.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)