### PR TITLE
feat: default X-Robots-Tag noindex in Caddyfile

### DIFF
--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -1472,7 +1472,7 @@ function generateCaddyfile(domain, protocol = 'https', port) {
 # Protocol: ${protocol}
 
 ${siteAddress} {
-    header X-Robots-Tag "noindex, nofollow"
+    header >X-Robots-Tag "noindex, nofollow"
 
     root * ${publicDir}
 

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -1472,6 +1472,8 @@ function generateCaddyfile(domain, protocol = 'https', port) {
 # Protocol: ${protocol}
 
 ${siteAddress} {
+    header X-Robots-Tag "noindex, nofollow"
+
     root * ${publicDir}
 
     file_server {

--- a/skills/http/Caddyfile.template
+++ b/skills/http/Caddyfile.template
@@ -3,6 +3,8 @@
 # Replace {DOMAIN} and {ZYLOS_DIR} with actual values
 
 {DOMAIN} {
+    header X-Robots-Tag "noindex, nofollow"
+
     root * {ZYLOS_DIR}/http/public
 
     file_server {

--- a/skills/http/Caddyfile.template
+++ b/skills/http/Caddyfile.template
@@ -3,7 +3,7 @@
 # Replace {DOMAIN} and {ZYLOS_DIR} with actual values
 
 {DOMAIN} {
-    header X-Robots-Tag "noindex, nofollow"
+    header >X-Robots-Tag "noindex, nofollow"
 
     root * {ZYLOS_DIR}/http/public
 

--- a/skills/http/scripts/setup-caddy.js
+++ b/skills/http/scripts/setup-caddy.js
@@ -98,7 +98,7 @@ async function main() {
 # Domain: ${domain}
 
 ${domain} {
-    header X-Robots-Tag "noindex, nofollow"
+    header >X-Robots-Tag "noindex, nofollow"
 
     root * ${publicDir}
 

--- a/skills/http/scripts/setup-caddy.js
+++ b/skills/http/scripts/setup-caddy.js
@@ -98,6 +98,8 @@ async function main() {
 # Domain: ${domain}
 
 ${domain} {
+    header X-Robots-Tag "noindex, nofollow"
+
     root * ${publicDir}
 
     file_server {

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -181,26 +181,55 @@ describe('applyCaddyRoutes', () => {
 });
 
 describe('X-Robots-Tag parity across all Caddyfile generation sources', () => {
-  const NOINDEX_HEADER = 'header X-Robots-Tag "noindex, nofollow"';
+  const NOINDEX_DIRECTIVE = '    header X-Robots-Tag "noindex, nofollow"';
 
-  test('cli/commands/init.js generateCaddyfile includes X-Robots-Tag', () => {
-    const initSrc = fs.readFileSync(
+  function extractTemplateLiterals(source) {
+    const literals = [];
+    let i = 0;
+    while (i < source.length) {
+      if (source[i] === '`') {
+        const start = i + 1;
+        i++;
+        let depth = 1;
+        while (i < source.length && depth > 0) {
+          if (source[i] === '\\') { i += 2; continue; }
+          if (source[i] === '`') { depth--; break; }
+          i++;
+        }
+        literals.push(source.slice(start, i));
+        i++;
+      } else {
+        i++;
+      }
+    }
+    return literals;
+  }
+
+  test('cli/commands/init.js embeds X-Robots-Tag in its Caddyfile template literal', () => {
+    const src = fs.readFileSync(
       path.join(__dirname, '..', 'cli', 'commands', 'init.js'), 'utf8'
     );
-    expect(initSrc).toContain(NOINDEX_HEADER);
+    const literals = extractTemplateLiterals(src);
+    const caddyLiterals = literals.filter(l => l.includes('Zylos Caddyfile'));
+    expect(caddyLiterals.length).toBeGreaterThan(0);
+    expect(caddyLiterals[0]).toContain(NOINDEX_DIRECTIVE);
   });
 
-  test('skills/http/Caddyfile.template includes X-Robots-Tag', () => {
+  test('skills/http/Caddyfile.template contains X-Robots-Tag as a Caddy directive', () => {
     const template = fs.readFileSync(
       path.join(__dirname, '..', 'skills', 'http', 'Caddyfile.template'), 'utf8'
     );
-    expect(template).toContain(NOINDEX_HEADER);
+    const lines = template.split('\n').filter(l => !l.trim().startsWith('#'));
+    expect(lines.some(l => l.includes('header X-Robots-Tag "noindex, nofollow"'))).toBe(true);
   });
 
-  test('skills/http/scripts/setup-caddy.js includes X-Robots-Tag', () => {
-    const standalone = fs.readFileSync(
+  test('skills/http/scripts/setup-caddy.js embeds X-Robots-Tag in its Caddyfile template literal', () => {
+    const src = fs.readFileSync(
       path.join(__dirname, '..', 'skills', 'http', 'scripts', 'setup-caddy.js'), 'utf8'
     );
-    expect(standalone).toContain(NOINDEX_HEADER);
+    const literals = extractTemplateLiterals(src);
+    const caddyLiterals = literals.filter(l => l.includes('Zylos Caddyfile'));
+    expect(caddyLiterals.length).toBeGreaterThan(0);
+    expect(caddyLiterals[0]).toContain(NOINDEX_DIRECTIVE);
   });
 });

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -1,6 +1,11 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, test, expect } from '@jest/globals';
 import { isLocalAddress } from '../cli/commands/init.js';
 import { applyCaddyRoutes, generateManualRouteSnippet, generateRouteBlocks } from '../cli/lib/caddy.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('isLocalAddress', () => {
   // Positive cases — should return true
@@ -172,5 +177,30 @@ describe('applyCaddyRoutes', () => {
     });
 
     expect(result).toEqual({ success: true, action: 'skipped' });
+  });
+});
+
+describe('X-Robots-Tag parity across all Caddyfile generation sources', () => {
+  const NOINDEX_HEADER = 'header X-Robots-Tag "noindex, nofollow"';
+
+  test('cli/commands/init.js generateCaddyfile includes X-Robots-Tag', () => {
+    const initSrc = fs.readFileSync(
+      path.join(__dirname, '..', 'cli', 'commands', 'init.js'), 'utf8'
+    );
+    expect(initSrc).toContain(NOINDEX_HEADER);
+  });
+
+  test('skills/http/Caddyfile.template includes X-Robots-Tag', () => {
+    const template = fs.readFileSync(
+      path.join(__dirname, '..', 'skills', 'http', 'Caddyfile.template'), 'utf8'
+    );
+    expect(template).toContain(NOINDEX_HEADER);
+  });
+
+  test('skills/http/scripts/setup-caddy.js includes X-Robots-Tag', () => {
+    const standalone = fs.readFileSync(
+      path.join(__dirname, '..', 'skills', 'http', 'scripts', 'setup-caddy.js'), 'utf8'
+    );
+    expect(standalone).toContain(NOINDEX_HEADER);
   });
 });

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -181,7 +181,7 @@ describe('applyCaddyRoutes', () => {
 });
 
 describe('X-Robots-Tag parity across all Caddyfile generation sources', () => {
-  const NOINDEX_DIRECTIVE = '    header X-Robots-Tag "noindex, nofollow"';
+  const NOINDEX_DIRECTIVE = '    header >X-Robots-Tag "noindex, nofollow"';
 
   function extractTemplateLiterals(source) {
     const literals = [];
@@ -220,7 +220,7 @@ describe('X-Robots-Tag parity across all Caddyfile generation sources', () => {
       path.join(__dirname, '..', 'skills', 'http', 'Caddyfile.template'), 'utf8'
     );
     const lines = template.split('\n').filter(l => !l.trim().startsWith('#'));
-    expect(lines.some(l => l.includes('header X-Robots-Tag "noindex, nofollow"'))).toBe(true);
+    expect(lines.some(l => l.includes('header >X-Robots-Tag "noindex, nofollow"'))).toBe(true);
   });
 
   test('skills/http/scripts/setup-caddy.js embeds X-Robots-Tag in its Caddyfile template literal', () => {


### PR DESCRIPTION
## Summary

- Add `header X-Robots-Tag "noindex, nofollow"` as a top-level directive in the generated Caddyfile
- Updated both `cli/commands/init.js` (the generator) and `skills/http/Caddyfile.template` (the reference template)
- All services exposed through a zylos instance's Caddy reverse proxy are now non-indexable by default

## Context

Howard identified that zylos instances expose multiple internal services (Pages, Recruit, Dashboard, Console, etc.) through Caddy, and none should be indexable by search engines. Rather than adding noindex to each component individually, a single top-level Caddy header covers all services — including future ones.

This is the framework-level half of a two-PR effort:
- **PR (zylos-pages #123)**: Component-level protection (HTTP header + HTML meta tags)
- **This PR**: Framework-level Caddy default covering all services

Already verified live: tested on luna.jinglever.com — all 6 routes (/health, /pages/, /recruit/, /dashboard/, /console/, /) return the header correctly.

## Test plan

- [x] Verified live on DGX Spark: X-Robots-Tag present on all routes
- [ ] Review that the header line is correctly placed in both the inline generator and the template file

🤖 Generated with [Claude Code](https://claude.com/claude-code)