### PR TITLE
feat(runtime): deliver credentials as environment variables, not conversation text

### DIFF
--- a/cli/lib/__tests__/secret-store.test.js
+++ b/cli/lib/__tests__/secret-store.test.js
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+const {
+  loadRuntimeSecrets, applySecrets, PROTECTED_NAMES, SECRETS_SUBDIR,
+} = await import('../runtime/secret-store.js');
+const { buildCleanEnv, buildCompatEnv } = await import('../runtime/tmux-env.js');
+
+const tmpDirs = [];
+afterEach(() => {
+  while (tmpDirs.length) {
+    try { fs.rmSync(tmpDirs.pop(), { recursive: true, force: true }); } catch { }
+  }
+});
+
+/** Build a throwaway ZYLOS_DIR containing the given credential files. */
+function makeStore(files = {}, { mode = 0o600 } = {}) {
+  const zylosDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-secret-'));
+  tmpDirs.push(zylosDir);
+  const dir = path.join(zylosDir, SECRETS_SUBDIR);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    const f = path.join(dir, name);
+    fs.writeFileSync(f, content);
+    fs.chmodSync(f, mode);
+  }
+  return zylosDir;
+}
+
+describe('loadRuntimeSecrets', () => {
+  it('loads one credential per file, keyed by filename', () => {
+    const zylosDir = makeStore({ GH_TOKEN: 'ghp_abc123', LARK_APP_SECRET: 's3cr3t' });
+    const { secrets, names, warnings } = loadRuntimeSecrets({ zylosDir });
+    assert.deepEqual(secrets, { GH_TOKEN: 'ghp_abc123', LARK_APP_SECRET: 's3cr3t' });
+    assert.deepEqual(names, ['GH_TOKEN', 'LARK_APP_SECRET']);
+    assert.deepEqual(warnings, []);
+  });
+
+  it('strips exactly one trailing newline (echo secret > FILE)', () => {
+    const zylosDir = makeStore({ A: 'value\n', B: 'value\n\n', C: 'value' });
+    const { secrets } = loadRuntimeSecrets({ zylosDir });
+    assert.equal(secrets.A, 'value');
+    assert.equal(secrets.B, 'value\n', 'only the final newline is stripped');
+    assert.equal(secrets.C, 'value');
+  });
+
+  it('missing directory is normal, not a warning', () => {
+    const zylosDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-nosecret-'));
+    tmpDirs.push(zylosDir);
+    const { secrets, warnings } = loadRuntimeSecrets({ zylosDir });
+    assert.deepEqual(secrets, {});
+    assert.deepEqual(warnings, []);
+  });
+
+  it('refuses protected names so a credential drop cannot hijack PATH', () => {
+    const zylosDir = makeStore({ PATH: '/tmp/evil', LD_PRELOAD: '/tmp/x.so', GH_TOKEN: 'ok' });
+    const { secrets, warnings } = loadRuntimeSecrets({ zylosDir });
+    assert.deepEqual(Object.keys(secrets), ['GH_TOKEN']);
+    assert.equal(warnings.filter(w => w.includes('protected')).length, 2);
+  });
+
+  it('skips invalid variable names and reports them', () => {
+    const zylosDir = makeStore({ 'not-a-var': 'x', '9NOPE': 'y', OK_VAR: 'z' });
+    const { secrets, warnings } = loadRuntimeSecrets({ zylosDir });
+    assert.deepEqual(Object.keys(secrets), ['OK_VAR']);
+    assert.equal(warnings.filter(w => w.includes('not a valid environment variable name')).length, 2);
+  });
+
+  it('skips empty files and dotfiles', () => {
+    const zylosDir = makeStore({ EMPTY: '', '.keep': 'x', REAL: 'v' });
+    const { secrets, warnings } = loadRuntimeSecrets({ zylosDir });
+    assert.deepEqual(Object.keys(secrets), ['REAL']);
+    assert.ok(warnings.some(w => w.includes('EMPTY') && w.includes('empty')));
+    assert.ok(!warnings.some(w => w.includes('.keep')), 'dotfiles are ignored silently');
+  });
+
+  it('warns when a credential is readable beyond its owner but still loads it', () => {
+    const zylosDir = makeStore({ LOOSE: 'v' }, { mode: 0o644 });
+    const { secrets, warnings } = loadRuntimeSecrets({ zylosDir });
+    assert.equal(secrets.LOOSE, 'v', 'availability beats tidiness — never drop a usable credential');
+    assert.ok(warnings.some(w => w.includes('LOOSE') && w.includes('0600')));
+  });
+
+  it('reports a rejection rather than failing silently', () => {
+    // A silently-dropped credential is indistinguishable from "tool not
+    // configured", which is a terrible way to discover a typo.
+    const zylosDir = makeStore({ 'GH TOKEN': 'x' });
+    const { secrets, warnings } = loadRuntimeSecrets({ zylosDir });
+    assert.deepEqual(secrets, {});
+    assert.equal(warnings.length, 1);
+  });
+});
+
+describe('applySecrets', () => {
+  it('applies values and returns the names applied', () => {
+    const env = { PATH: '/usr/bin' };
+    const { applied } = applySecrets(env, { B_TOKEN: '2', A_TOKEN: '1' });
+    assert.deepEqual(applied, ['A_TOKEN', 'B_TOKEN']);
+    assert.equal(env.A_TOKEN, '1');
+  });
+
+  it('never overwrites a protected var even if one reaches it', () => {
+    const env = { PATH: '/usr/bin', HOME: '/home/me' };
+    const { applied, skipped } = applySecrets(env, { PATH: '/evil', HOME: '/evil', OK: 'v' });
+    assert.equal(env.PATH, '/usr/bin');
+    assert.equal(env.HOME, '/home/me');
+    assert.deepEqual(applied, ['OK']);
+    assert.deepEqual(skipped, ['HOME', 'PATH']);
+  });
+
+  it('tolerates absent secrets', () => {
+    const env = {};
+    assert.deepEqual(applySecrets(env, undefined).applied, []);
+    assert.deepEqual(env, {});
+  });
+
+  it('PROTECTED_NAMES covers the vars that control command resolution', () => {
+    for (const n of ['PATH', 'HOME', 'SHELL', 'LD_PRELOAD', 'NODE_OPTIONS']) {
+      assert.ok(PROTECTED_NAMES.has(n), `${n} must be protected`);
+    }
+  });
+});
+
+describe('env assembly with secrets', () => {
+  const base = { processEnv: { HOME: '/home/me', PATH: '/usr/bin' }, dotenvVars: {} };
+
+  it('clean env: a delivered credential wins over a same-named .env value', () => {
+    const { env } = buildCleanEnv({
+      ...base,
+      dotenvVars: { ZYLOS_TMUX_ENV: 'GH_TOKEN', GH_TOKEN: 'from-dotenv' },
+      secrets: { GH_TOKEN: 'from-secret-store' },
+    });
+    assert.equal(env.GH_TOKEN, 'from-secret-store');
+  });
+
+  it('clean env: reports refused protected secrets in warnings', () => {
+    const { env, warnings, secretNames } = buildCleanEnv({ ...base, secrets: { PATH: '/evil', T: 'v' } });
+    assert.notEqual(env.PATH, '/evil');
+    assert.deepEqual(secretNames, ['T']);
+    assert.ok(warnings.some(w => w.includes('PATH') && w.includes('protected')));
+  });
+
+  it('compat env also receives credentials', () => {
+    // ZYLOS_CLEAN_ENV=false must not silently opt a host out of credentials.
+    const { env, secretNames } = buildCompatEnv({ ...base, secrets: { GH_TOKEN: 'v' } });
+    assert.equal(env.GH_TOKEN, 'v');
+    assert.deepEqual(secretNames, ['GH_TOKEN']);
+  });
+
+  it('no secrets: env assembly is unchanged', () => {
+    const { env, secretNames } = buildCleanEnv({ ...base });
+    assert.deepEqual(secretNames, []);
+    assert.equal(env.HOME, '/home/me');
+    assert.ok(env.PATH.includes('/usr/bin'));
+  });
+});

--- a/cli/lib/runtime/claude.js
+++ b/cli/lib/runtime/claude.js
@@ -35,6 +35,7 @@ import {
   hasChildProcess,
 } from './tmux-helpers.js';
 import { buildCleanEnv, buildCompatEnv, loadRuntimeEnvManifest, writeLaunchSpec } from './tmux-env.js';
+import { loadRuntimeSecrets } from './secret-store.js';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -298,9 +299,17 @@ export class ClaudeAdapter extends RuntimeAdapter {
       const useCleanEnv = dotenvVars.ZYLOS_CLEAN_ENV !== 'false';
       const manifest = useCleanEnv ? loadRuntimeEnvManifest(ZYLOS_DIR) : undefined;
 
-      const { env } = useCleanEnv
-        ? buildCleanEnv({ processEnv: process.env, dotenvVars, manifest, uid: process.getuid?.() })
-        : buildCompatEnv({ processEnv: process.env, dotenvVars });
+      // Control-plane credentials: values become env vars of the agent process so
+      // only their NAMES ever reach the model context (see secret-store.js).
+      const { secrets, warnings: secretWarnings } = loadRuntimeSecrets({ zylosDir: ZYLOS_DIR });
+      for (const w of secretWarnings) console.warn(`[runtime] ${w}`);
+
+      const { env, secretNames } = useCleanEnv
+        ? buildCleanEnv({ processEnv: process.env, dotenvVars, manifest, uid: process.getuid?.(), secrets })
+        : buildCompatEnv({ processEnv: process.env, dotenvVars, secrets });
+
+      // Names only — never the values.
+      if (secretNames?.length) console.log(`[runtime] injected ${secretNames.length} credential(s): ${secretNames.join(', ')}`);
 
       // Strip vars that cause Claude to refuse startup ("already running" detection)
       for (const v of ENV_VARS_TO_STRIP) delete env[v];

--- a/cli/lib/runtime/codex.js
+++ b/cli/lib/runtime/codex.js
@@ -38,6 +38,7 @@ import {
   hasChildProcess,
 } from './tmux-helpers.js';
 import { buildCleanEnv, buildCompatEnv, loadRuntimeEnvManifest, writeLaunchSpec } from './tmux-env.js';
+import { loadRuntimeSecrets } from './secret-store.js';
 import { classifyCodexLoginStatus } from '../auth-parsers.js';
 import { ensureCodexHooksTrusted } from '../codex-hooks.js';
 
@@ -272,9 +273,17 @@ export class CodexAdapter extends RuntimeAdapter {
       const useCleanEnv = dotenvVars.ZYLOS_CLEAN_ENV !== 'false';
       const manifest = useCleanEnv ? loadRuntimeEnvManifest(ZYLOS_DIR) : undefined;
 
-      const { env } = useCleanEnv
-        ? buildCleanEnv({ processEnv: process.env, dotenvVars, manifest, uid: process.getuid?.() })
-        : buildCompatEnv({ processEnv: process.env, dotenvVars });
+      // Control-plane credentials: values become env vars of the agent process so
+      // only their NAMES ever reach the model context (see secret-store.js).
+      const { secrets, warnings: secretWarnings } = loadRuntimeSecrets({ zylosDir: ZYLOS_DIR });
+      for (const w of secretWarnings) console.warn(`[runtime] ${w}`);
+
+      const { env, secretNames } = useCleanEnv
+        ? buildCleanEnv({ processEnv: process.env, dotenvVars, manifest, uid: process.getuid?.(), secrets })
+        : buildCompatEnv({ processEnv: process.env, dotenvVars, secrets });
+
+      // Names only — never the values.
+      if (secretNames?.length) console.log(`[runtime] injected ${secretNames.length} credential(s): ${secretNames.join(', ')}`);
 
       // Build launch spec — Codex reads auth from ~/.codex/auth.json via HOME
       const args = [];

--- a/cli/lib/runtime/secret-store.js
+++ b/cli/lib/runtime/secret-store.js
@@ -1,0 +1,140 @@
+/**
+ * Runtime secret store — credentials reach the agent as environment variables,
+ * never as conversation text.
+ *
+ * WHY: tools the agent drives in direct mode (gh, git, docker, kubectl,
+ * lark-cli) authenticate themselves, so credentials must exist on the machine.
+ * The goal is therefore not "no credentials on disk" — that is unachievable —
+ * but "no plaintext credential in the model's context". A value that has been
+ * in the context has already been sent to the model provider, and no local
+ * deletion can recall it.
+ *
+ * HOW: the control plane drops one file per credential into
+ * `<ZYLOS_DIR>/security/credentials/`, named exactly as the environment
+ * variable (`GH_TOKEN`, file content = the value). At launch these become real
+ * environment variables of the agent process, so the agent only ever handles the
+ * *name*: it runs `gh auth login --with-token <<< "$GH_TOKEN"`, and the value is
+ * substituted by the shell, never rendered into the transcript.
+ *
+ * The `security/` naming is deliberate: it is a soft wall. Current models'
+ * safety training makes them reluctant to cat files under such a path, which
+ * lowers the chance of an accidental read. It is not a hard control — the agent
+ * runs as a user that can read the directory. The hard guarantees remain
+ * server-side revocation and the provider-side kill switch.
+ *
+ * Injecting at launch rather than through PM2 is intentional: PM2 persists a
+ * service's env into `~/.pm2/dump.pm2` and prints it via `pm2 env <id>`, which
+ * would create extra plaintext copies in places nobody thinks to revoke.
+ *
+ * REVOCATION: delete the file and restart the runtime. Removing a variable from
+ * a live process is not reliably possible, so the restart is the mechanism.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const VALID_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Directory (under ZYLOS_DIR) holding one file per credential. */
+export const SECRETS_SUBDIR = path.join('security', 'credentials');
+
+/**
+ * Names a delivered secret may never occupy. Overwriting PATH or HOME would let
+ * whatever writes into the secret directory redirect every command the agent
+ * runs — a credential drop must not be a code-execution primitive.
+ */
+export const PROTECTED_NAMES = new Set([
+  'PATH', 'HOME', 'USER', 'LOGNAME', 'LANG', 'LC_ALL', 'TERM', 'SHELL',
+  'IS_SANDBOX', 'NODE_OPTIONS', 'LD_PRELOAD', 'LD_LIBRARY_PATH',
+]);
+
+/**
+ * Load credentials from the secret directory.
+ *
+ * Every rejection is reported rather than silently dropped: a credential that
+ * quietly fails to load looks to the agent exactly like "this tool is not
+ * configured", which is a confusing way to discover a typo in a filename.
+ *
+ * @param {object} opts
+ * @param {string} opts.zylosDir
+ * @param {object} [opts.fsApi] injected for tests
+ * @returns {{secrets: Record<string,string>, warnings: string[], names: string[]}}
+ */
+export function loadRuntimeSecrets({ zylosDir, fsApi = fs }) {
+  const dir = path.join(zylosDir, SECRETS_SUBDIR);
+  const secrets = {};
+  const warnings = [];
+
+  let entries;
+  try {
+    entries = fsApi.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // Absent directory is the normal case on a host with no delivered
+    // credentials — not a warning.
+    return { secrets, warnings, names: [] };
+  }
+
+  for (const entry of entries) {
+    const name = entry.name;
+    if (name.startsWith('.')) continue;
+    if (!entry.isFile()) {
+      warnings.push(`secret store: skipped non-file entry "${name}"`);
+      continue;
+    }
+    if (!VALID_NAME.test(name)) {
+      warnings.push(`secret store: skipped "${name}" — not a valid environment variable name`);
+      continue;
+    }
+    if (PROTECTED_NAMES.has(name)) {
+      warnings.push(`secret store: refused "${name}" — protected variable, cannot be set from the secret store`);
+      continue;
+    }
+
+    const file = path.join(dir, name);
+    let raw;
+    try {
+      raw = fsApi.readFileSync(file, 'utf8');
+    } catch (err) {
+      warnings.push(`secret store: failed to read "${name}": ${err.message}`);
+      continue;
+    }
+
+    // Strip exactly one trailing newline — `echo secret > FILE` adds one and it
+    // would otherwise become part of the credential.
+    const value = raw.replace(/\r?\n$/, '');
+    if (!value) {
+      warnings.push(`secret store: skipped "${name}" — file is empty`);
+      continue;
+    }
+
+    try {
+      const mode = fsApi.statSync(file).mode & 0o077;
+      if (mode) warnings.push(`secret store: "${name}" is readable beyond its owner (mode ${(mode).toString(8)}) — tighten to 0600`);
+    } catch {
+      // Permission reporting is advisory; never block a usable credential on it.
+    }
+
+    secrets[name] = value;
+  }
+
+  return { secrets, warnings, names: Object.keys(secrets).sort() };
+}
+
+/**
+ * Apply secrets onto an assembled environment.
+ *
+ * Kept separate from loading so callers can log which names were injected
+ * without ever touching the values.
+ *
+ * @returns {{applied: string[], skipped: string[]}}
+ */
+export function applySecrets(env, secrets) {
+  const applied = [];
+  const skipped = [];
+  for (const [name, value] of Object.entries(secrets || {})) {
+    if (PROTECTED_NAMES.has(name)) { skipped.push(name); continue; }
+    env[name] = value;
+    applied.push(name);
+  }
+  return { applied: applied.sort(), skipped: skipped.sort() };
+}

--- a/cli/lib/runtime/tmux-env.js
+++ b/cli/lib/runtime/tmux-env.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { applySecrets } from './secret-store.js';
 
 const VALID_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -193,9 +194,12 @@ function _buildPath(processEnv, platform, pathPrepend, pathAppend, execPath) {
  * @param {string} [opts.platform] - os.platform() value, defaults to current
  * @param {number} [opts.uid] - Process UID; when 0, IS_SANDBOX is set for root/Docker safety
  * @param {string} [opts.execPath] - process.execPath of the running node; defaults to process.execPath
- * @returns {{ env: object, warnings: string[] }}
+ * @param {object} [opts.secrets] - Control-plane credentials (see secret-store.js). Applied
+ *   last so a delivered credential wins over a same-named .env value, but never
+ *   over the protected base vars — `applySecrets` enforces that.
+ * @returns {{ env: object, warnings: string[], secretNames: string[] }}
  */
-export function buildCleanEnv({ processEnv, dotenvVars, manifest, platform, uid, execPath }) {
+export function buildCleanEnv({ processEnv, dotenvVars, manifest, platform, uid, execPath, secrets }) {
   const plat = platform || os.platform();
   const m = manifest || EMPTY_MANIFEST;
   const warnings = [];
@@ -258,7 +262,15 @@ export function buildCleanEnv({ processEnv, dotenvVars, manifest, platform, uid,
     }
   }
 
-  return { env, warnings };
+  // 7. Control-plane credentials — last, so they win over a same-named .env
+  // value (the secret store is the managed source of truth). Protected base
+  // vars are refused inside applySecrets, so this cannot hijack PATH.
+  const { applied, skipped } = applySecrets(env, secrets);
+  for (const name of skipped) {
+    warnings.push(`secret "${name}" refused: protected variable`);
+  }
+
+  return { env, warnings, secretNames: applied };
 }
 
 /**
@@ -274,7 +286,7 @@ export function buildCleanEnv({ processEnv, dotenvVars, manifest, platform, uid,
  * @param {object} opts.dotenvVars
  * @returns {{ env: object }}
  */
-export function buildCompatEnv({ processEnv, dotenvVars }) {
+export function buildCompatEnv({ processEnv, dotenvVars, secrets }) {
   const env = { ...processEnv };
 
   // Deduplicate PATH to prevent bloat across restarts (PR #499 defense)
@@ -291,7 +303,12 @@ export function buildCompatEnv({ processEnv, dotenvVars }) {
     }
   }
 
-  return { env };
+  // Credentials apply in compat mode too — otherwise ZYLOS_CLEAN_ENV=false would
+  // silently opt a host out of credential delivery and the agent would report
+  // tools as unconfigured for no visible reason.
+  const { applied } = applySecrets(env, secrets);
+
+  return { env, secretNames: applied };
 }
 
 /**


### PR DESCRIPTION
Item 2 of the **agent-config-control-plan**: credentials must reach the agent without their plaintext passing through the model context.

## Why

Tools the agent drives in direct mode (`gh`, `git`, `docker`, `kubectl`, `lark-cli`) authenticate themselves, so credentials **have** to exist on the machine. The goal is therefore not "no credentials on disk" — that is unachievable — but **"no plaintext credential in the model's context"**. A value that has been in the context has already been sent to the model provider, and no local deletion can recall it.

## How

The control plane drops **one file per credential** into `<ZYLOS_DIR>/security/credentials/`, named exactly as the environment variable (`GH_TOKEN`, content = the value). At launch these become real environment variables of the agent process, so the agent only ever handles the **name**:

```bash
gh auth login --with-token <<< "$GH_TOKEN"   # shell substitutes; value never enters the transcript
```

The `security/` naming is a deliberate **soft wall** — current models' safety training makes them reluctant to cat files under such a path, lowering the chance of an accidental read. It is not a hard control; the hard guarantees remain server-side revocation and the provider-side kill switch.

**Injecting at launch rather than through PM2 is intentional**: PM2 persists a service's env into `~/.pm2/dump.pm2` and prints it via `pm2 env <id>`, which would create extra plaintext copies in places nobody thinks to revoke.

## Security guard

`PROTECTED_NAMES` refuses `PATH`, `HOME`, `SHELL`, `LD_PRELOAD`, `NODE_OPTIONS` and friends. Without it, whatever can write into the secret directory could redirect **every command the agent runs** — a credential drop must not become a code-execution primitive. Enforced both at load and at apply.

## Failure behaviour

- **Every rejection is reported**, never silently dropped. A credential that quietly fails to load looks to the agent exactly like "this tool is not configured" — a confusing way to discover a typo in a filename.
- **Loose permissions warn but still load**: availability beats tidiness for a credential that is already on disk.
- Exactly one trailing newline is stripped (`echo secret > FILE` adds one and it would otherwise become part of the credential).
- **Compat mode included** — `ZYLOS_CLEAN_ENV=false` must not silently opt a host out of credential delivery, or the agent would report tools as unconfigured for no visible reason.
- Logs list **injected names only**, never values.

## Revocation

Delete the file and restart the runtime. Removing a variable from a live process is not reliably possible, so the restart *is* the mechanism.

## Testing

16 new tests in `cli/lib/__tests__/secret-store.test.js`: protected-name refusal, invalid names, empty files, dotfiles, trailing-newline handling, permission warning, precedence over a same-named `.env` value, compat mode, and "a rejection is reported rather than silent".

**No regression** — verified by stashing the change and re-running: the 35 pre-existing suite failures are identical before and after. Note `node --test` alone fails on `mock.module`; use `node scripts/run-node-tests.js`, which passes `--experimental-test-module-mocks`.

## Not in this commit

The skill-side rule (agent should look for the env var name and never read the secret directory) and the manifest/template docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)