### PR TITLE
fix(c4): make truncation notice imperative so agents read the spilled file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **C4 truncation notice is now imperative**: when a long message is spilled to disk, the delivered text ends with an explicit warning that the text above is only a preview (with preview/full sizes) and an instruction that the agent MUST read the complete message file before acting — previously the notice was descriptive metadata that weaker models ignored, replying from the preview alone. (#748)
-
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **C4 truncation notice is now imperative**: when a long message is spilled to disk, the delivered text ends with an explicit warning that the text above is only a preview (with preview/full sizes) and an instruction that the agent MUST read the complete message file before acting — previously the notice was descriptive metadata that weaker models ignored, replying from the preview alone. (#748)
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/skills/comm-bridge/scripts/__tests__/c4-conversations-budget.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-conversations-budget.test.js
@@ -147,7 +147,7 @@ describe('emitC4Conversations budget packing (message-boundary, newest-first)', 
 
       assert.ok(out.includes(marker(2)), 'the newest message is always kept');
       assert.ok(!out.includes(marker(1)));
-      assert.ok(out.includes('[C4] Full message'), 'lone over-budget message must use the pointer form');
+      assert.ok(out.includes('[C4] ⚠️ TRUNCATED'), 'lone over-budget message must use the pointer form');
       assert.ok(!out.includes('x'.repeat(3000)), 'lone over-budget message must not be emitted in full');
     });
   });
@@ -164,7 +164,7 @@ describe('emitC4Conversations budget packing (message-boundary, newest-first)', 
       const out = emitConversations(env, { maxChars: 300, maxTokens: 50 });
 
       assert.ok(out.includes(`${marker(1)} ${'x'.repeat(1800)}`), 'sub-threshold message stays original');
-      assert.ok(!out.includes('[C4] Full message'));
+      assert.ok(!out.includes('[C4] ⚠️ TRUNCATED'));
     });
   });
 
@@ -178,7 +178,7 @@ describe('emitC4Conversations budget packing (message-boundary, newest-first)', 
       const out = emitConversations(env, DEFAULT_SHARD_BUDGET);
 
       assert.ok(out.includes(body), 'original content must be emitted inline, not a preview');
-      assert.ok(!out.includes('[C4] Full message'), 'no attachment pointer when the budget fits the original');
+      assert.ok(!out.includes('[C4] ⚠️ TRUNCATED'), 'no attachment pointer when the budget fits the original');
       const attachmentsDir = path.join(tmpDir, 'comm-bridge', 'attachments');
       assert.ok(
         !fs.existsSync(attachmentsDir) || fs.readdirSync(attachmentsDir).length === 0,
@@ -197,7 +197,7 @@ describe('emitC4Conversations budget packing (message-boundary, newest-first)', 
 
       assert.ok(out.includes(`${marker(4)} ${'z'.repeat(3000)}`), 'newest long message must survive in full');
       assert.ok(!out.includes(marker(1)), 'oldest message must be dropped whole');
-      assert.ok(!out.includes('[C4] Full message'), 'kept messages must be originals, not previews');
+      assert.ok(!out.includes('[C4] ⚠️ TRUNCATED'), 'kept messages must be originals, not previews');
       assert.match(out, /showing the newest \d+ of 4 unsummarized messages/);
       assert.ok(out.length <= 10000, `packed output must fit the char budget (got ${out.length})`);
     });
@@ -210,7 +210,7 @@ describe('emitC4Conversations budget packing (message-boundary, newest-first)', 
 
       const out = emitConversations(env, null);
 
-      assert.ok(out.includes('[C4] Full message'), 'legacy path must keep the preview + pointer form');
+      assert.ok(out.includes('[C4] ⚠️ TRUNCATED'), 'legacy path must keep the preview + pointer form');
       assert.ok(!out.includes(body), 'legacy path must not emit the full over-threshold message');
       assert.ok(out.includes(marker(1)), 'preview must still lead with the message head');
     });

--- a/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-receive.test.js
@@ -222,7 +222,7 @@ describe('c4-receive basic intake', () => {
       db.close();
 
       assert.equal(row.content, longContent);
-      assert.ok(!row.content.includes('[C4] Full message'));
+      assert.ok(!row.content.includes('[C4] ⚠️ TRUNCATED'));
       assert.equal(fs.existsSync(path.join(tmpDir, 'comm-bridge', 'attachments')), false);
     });
   });

--- a/skills/comm-bridge/scripts/__tests__/c4-utils-spill.test.js
+++ b/skills/comm-bridge/scripts/__tests__/c4-utils-spill.test.js
@@ -25,7 +25,7 @@ process.on('exit', () => {
 
 /** Extract the spill file path from a truncated delivery string. */
 function spillPathOf(delivered) {
-  const m = delivered.match(/\[C4\] Full message \([\d.]+KB\) at: (\S+)/);
+  const m = delivered.match(/\[C4\] ⚠️ TRUNCATED — .* you MUST read the complete message file: (\S+)/);
   assert.ok(m, `expected truncated delivery with spill path, got: ${delivered.slice(0, 120)}`);
   return m[1];
 }
@@ -117,6 +117,30 @@ describe('truncateForDelivery fallback (no conv id) spill path collision', () =>
     const content = 'short message';
     const delivered = truncateForDelivery(content);
     assert.equal(delivered, content);
-    assert.ok(!delivered.includes('[C4] Full message'));
+    assert.ok(!delivered.includes('[C4] ⚠️ TRUNCATED'));
+  });
+});
+
+describe('truncation notice wording (#748)', () => {
+  it('states incompleteness, gives an imperative, and reports preview/full sizes', () => {
+    const content = 'F'.repeat(FILE_SIZE_THRESHOLD + 500);
+    const delivered = truncateForDelivery(content, '', 3001);
+
+    assert.ok(delivered.includes('only a preview'), 'must state the text above is incomplete');
+    assert.ok(
+      delivered.includes('you MUST read the complete message file:'),
+      'must carry an imperative naming the concrete action',
+    );
+    assert.match(delivered, /\([\d.]+KB of [\d.]+KB\)/, 'must report preview and full sizes');
+  });
+
+  it('keeps the reply-via suffix after the notice so routing survives truncation', () => {
+    const content = 'G'.repeat(FILE_SIZE_THRESHOLD + 500);
+    const suffix = ' ---- reply via: node /x/c4-send.js "telegram" "42"';
+    const delivered = truncateForDelivery(content, suffix, 3002);
+
+    assert.ok(delivered.endsWith(suffix), 'reply-via suffix must terminate the delivery');
+    const noticeIdx = delivered.indexOf('[C4] ⚠️ TRUNCATED');
+    assert.ok(noticeIdx !== -1 && noticeIdx < delivered.indexOf(suffix), 'notice precedes reply-via');
   });
 });

--- a/skills/comm-bridge/scripts/c4-utils.js
+++ b/skills/comm-bridge/scripts/c4-utils.js
@@ -46,5 +46,8 @@ export function truncateForDelivery(content, replyViaSuffix = '', convId) {
   const preview = content.substring(0, CONTENT_PREVIEW_CHARS);
   const ellipsis = preview.length < content.length ? '...' : '';
   const sizeKB = (byteLength / 1024).toFixed(1);
-  return `${preview}${ellipsis}\n\n[C4] Full message (${sizeKB}KB) at: ${filePath}${replyViaSuffix}`;
+  const previewKB = (Buffer.byteLength(preview, 'utf8') / 1024).toFixed(1);
+  // The notice must be an instruction, not metadata: weaker models otherwise
+  // reply from the preview alone while claiming to have read everything (#748).
+  return `${preview}${ellipsis}\n\n[C4] ⚠️ TRUNCATED — the text above is only a preview (${previewKB}KB of ${sizeKB}KB). Before acting or replying you MUST read the complete message file: ${filePath}${replyViaSuffix}`;
 }

--- a/test/web-console-routes.test.js
+++ b/test/web-console-routes.test.js
@@ -69,7 +69,7 @@ if (Buffer.byteLength(fullMessage, 'utf8') > 2048) {
   fs.mkdirSync(dir, { recursive: true });
   const filePath = path.join(dir, 'message.txt');
   fs.writeFileSync(filePath, fullMessage, 'utf8');
-  dbContent = content.substring(0, 100) + '\\n\\n[C4] Full message at: ' + filePath + suffix;
+  dbContent = content.substring(0, 100) + '\\n\\n[C4] ⚠️ TRUNCATED — the text above is only a preview. Before acting or replying you MUST read the complete message file: ' + filePath + suffix;
 }
 const db = new Database(${JSON.stringify(dbPath)});
 db.prepare('INSERT INTO conversations (direction, channel, endpoint_id, content, timestamp) VALUES (?, ?, ?, ?, ?)')
@@ -202,7 +202,7 @@ describe('web-console attachment routes', () => {
     expect(latest.content).toContain('[attachment:file ');
     expect(latest.content).toContain('name="report.txt" 3B]');
     expect(latest.content).toContain(' ---- reply via: node ');
-    expect(latest.content).not.toContain('[C4] Full message');
+    expect(latest.content).not.toContain('[C4] ⚠️ TRUNCATED');
   });
 
   test('WS attachment-only send queues verbatim annotation content', async () => {


### PR DESCRIPTION
Fixes #748.

## Problem

When C4 spills a long message to disk, the delivered text ended with descriptive metadata:

```
[C4] Full message (7.9KB) at: /home/.../conv-6955/message.txt ---- reply via: ...
```

Nothing told the model the text above was incomplete, or that it must read the file. Weaker models (observed: gpt-5.6 on a Codex runtime, screenshot evidence from Howard) replied from the ~200-char preview alone while claiming「已读完」. Stronger models following the path was luck, not design.

## Change

`truncateForDelivery()` in `skills/comm-bridge/scripts/c4-utils.js` now emits:

```
[C4] ⚠️ TRUNCATED — the text above is only a preview (0.2KB of 7.9KB). Before acting or replying you MUST read the complete message file: <path> ---- reply via: ...
```

- States incompleteness explicitly, with preview/full sizes.
- Imperative (MUST) + concrete action (read the file), runtime-neutral for Claude (Read tool) and Codex (shell).
- One line, so it survives further quoting; reply-via suffix placement unchanged.

## Scope notes

- Grepped the repo: no production code parses the old `[C4] Full message` marker — only test assertions, all updated (`c4-utils-spill`, `c4-conversations-budget`, `c4-receive`, `web-console-routes` mock).
- Two new tests pin the imperative semantics (incompleteness + MUST-read + sizes) and the reply-via suffix ordering.
- External deployments that grep for the old marker (none known) would need to match `[C4] ⚠️ TRUNCATED` after upgrading.

## Testing

- Full suite: jest 147/147; node tests 807/808 — the single failure is the pre-existing template hash-pin break on `main` from #742, unrelated (filed as #749, verified failing on pristine `origin/main` with this branch's changes stashed).
- Live sanity run of `truncateForDelivery()` against a 12.4KB mixed CJK/ASCII message confirms the emitted notice and suffix placement.

Per Howard: merge after review is fine, **no release** — zylos-core releases are Howard-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)