### PR TITLE
feat(cli): install official components from local tarballs via --file (#707)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Official component file delivery**: `zylos add <name>[@<version>] --file <tar.gz>` installs an official (registry) component from a local tarball, fully offline. The tarball is transport only — the persisted `source` keeps the `github-release` identity, so `zylos upgrade` works unchanged. Verification is mandatory and fail-closed: `--sha256 <hex>` verifies the archive before any unpacking (mismatch leaves no residue), or `--trust-file` explicitly skips verification and is recorded (and flagged by `zylos list`) as unverified. Name/version consistency between the command, the archive metadata, and the offline registry is enforced fail-closed. Delivery details are recorded in `components.json` under audit-only `deliveredVia`. (#707)
+
 ## [0.6.0] - 2026-07-14
 
 ### Added

--- a/cli/commands/add.js
+++ b/cli/commands/add.js
@@ -21,7 +21,8 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { SKILLS_DIR, COMPONENTS_DIR, BIN_DIR } from '../lib/config.js';
 import { loadComponents, saveComponents, resolveTarget, loadTargetRegistryInfo, outputTask } from '../lib/components.js';
-import { acquireSource } from '../lib/download.js';
+import { acquireSource, resolveLocalPath } from '../lib/download.js';
+import { sha256File, isValidSha256Hex } from '../lib/checksum.js';
 import { generateManifest, saveMergeBaseline } from '../lib/manifest.js';
 import { parseSkillMd, detectComponentType } from '../lib/skill.js';
 import { linkBins } from '../lib/bin.js';
@@ -69,8 +70,72 @@ export async function addComponent(args) {
     process.exit(1);
   }
 
+  // Parse --file <path.tar.gz> [--sha256 <hex> | --trust-file] (#707)
+  // Official component delivered as a local tarball: the tarball is only the
+  // transport; the component keeps its github-release identity so upgrades
+  // work unchanged.
+  const fileIndex = args.indexOf('--file');
+  const fileArg = fileIndex !== -1 ? args[fileIndex + 1] : null;
+  const sha256Index = args.indexOf('--sha256');
+  const sha256Arg = sha256Index !== -1 ? args[sha256Index + 1] : null;
+  const trustFile = args.includes('--trust-file');
+
+  const fileFlagError = (code, message) => {
+    if (jsonOutput) {
+      console.log(JSON.stringify({
+        action: 'add', success: false, error: code, message,
+        reply: `Error: ${message}`,
+      }, null, 2));
+    } else {
+      console.error(error(message));
+    }
+    process.exit(1);
+  };
+
+  if (fileIndex !== -1 && !fileArg) {
+    fileFlagError('missing_file', '--file requires a path to a .tar.gz archive');
+  }
+  if (sha256Index !== -1 && !sha256Arg) {
+    fileFlagError('missing_sha256', '--sha256 requires a hex digest');
+  }
+  if (!fileArg && (sha256Arg || trustFile)) {
+    fileFlagError('conflict', '--sha256 and --trust-file can only be used together with --file');
+  }
+
+  let file = null;
+  let fileSha256 = null;
+  if (fileArg) {
+    if (branch) {
+      fileFlagError('conflict', 'Cannot use both --file and --branch. Use one or the other.');
+    }
+    if (sha256Arg && trustFile) {
+      fileFlagError('conflict', 'Use either --sha256 or --trust-file, not both.');
+    }
+    if (!sha256Arg && !trustFile) {
+      fileFlagError('checksum_required', 'Installing from --file requires --sha256 <hex>, or --trust-file to explicitly skip verification.');
+    }
+    file = resolveLocalPath(fileArg);
+    if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
+      fileFlagError('file_not_found', `File not found: ${file}`);
+    }
+    if (!/\.(?:tar\.gz|tgz)$/i.test(file)) {
+      fileFlagError('invalid_file', `--file requires a .tar.gz archive: ${file}`);
+    }
+    if (sha256Arg) {
+      if (!isValidSha256Hex(sha256Arg)) {
+        fileFlagError('invalid_sha256', '--sha256 must be a 64-character hex digest.');
+      }
+      // Verified before anything is unpacked or written — a mismatch leaves no residue
+      fileSha256 = sha256Arg.toLowerCase();
+      const actual = sha256File(file);
+      if (actual !== fileSha256) {
+        fileFlagError('checksum_mismatch', `sha256 mismatch for ${file}\n  expected: ${fileSha256}\n  actual:   ${actual}`);
+      }
+    }
+  }
+
   // Find target (skip flags and their values)
-  const flagsWithValues = new Set(['--branch']);
+  const flagsWithValues = new Set(['--branch', '--file', '--sha256']);
   const skipNext = new Set();
   const target = args.find((a, i) => {
     if (skipNext.has(i)) return false;
@@ -84,7 +149,7 @@ export async function addComponent(args) {
   }
 
   // 1. Resolve target
-  const resolved = await resolveTarget(target, { branch });
+  const resolved = await resolveTarget(target, { branch, file });
 
   // Validate: --branch conflicts with explicit @version in target
   // (resolved.version may be auto-populated by fetchLatestTag for registry components)
@@ -132,6 +197,18 @@ export async function addComponent(args) {
     process.exit(1);
   }
 
+  // File delivery is audit-only metadata: recorded in components.json but
+  // never consulted by add/upgrade decisions.
+  if (resolved.acquisition) {
+    resolved.deliveredVia = {
+      type: 'file',
+      path: resolved.acquisition.path,
+      sha256: fileSha256,
+      verified: Boolean(fileSha256),
+      at: new Date().toISOString(),
+    };
+  }
+
   // 2. Check if already installed
   const components = loadComponents();
   if (components[resolved.name]) {
@@ -165,6 +242,7 @@ export async function addComponent(args) {
         type: regInfo.type || null,
         repo: resolved.repo,
         source: resolved.source,
+        deliveredVia: resolved.deliveredVia || null,
         isThirdParty: resolved.isThirdParty || false,
       };
       let reply = `${resolved.name}`;
@@ -173,6 +251,10 @@ export async function addComponent(args) {
       if (regInfo.description) reply += `\n${regInfo.description}`;
       reply += `\nType: ${regInfo.type || 'unknown'}`;
       reply += `\n${resolved.sourceReplyLabel}: ${resolved.sourceLabel}`;
+      if (resolved.deliveredVia) {
+        reply += `\nFile: ${resolved.deliveredVia.path}`;
+        reply += `\nChecksum: ${resolved.deliveredVia.verified ? 'sha256 verified' : 'NOT VERIFIED (--trust-file)'}`;
+      }
       if (resolved.isThirdParty) reply += '\nWarning: Third-party component';
       if (fetchFailed) {
         output.error = 'fetch_failed';
@@ -187,6 +269,10 @@ export async function addComponent(args) {
           ? `${resolved.name}@${resolved.version}`
           : resolved.installTarget;
         if (branch) confirmTarget += ` --branch ${branch}`;
+        if (resolved.deliveredVia) {
+          confirmTarget += ` --file ${resolved.deliveredVia.path}`;
+          confirmTarget += resolved.deliveredVia.verified ? ` --sha256 ${resolved.deliveredVia.sha256}` : ' --trust-file';
+        }
         reply += `\n\nReply "add ${confirmTarget} confirm" to install.`;
       }
       output.reply = reply;
@@ -195,6 +281,10 @@ export async function addComponent(args) {
       const versionInfo = branch ? ` (branch: ${bold(branch)})` : (resolved.version ? `@${bold(resolved.version)}` : '');
       console.log(`\n${heading('Component:')} ${bold(resolved.name)}${versionInfo}`);
       console.log(`${heading(resolved.sourceHeading)} ${dim(resolved.sourceLabel)}`);
+      if (resolved.deliveredVia) {
+        console.log(`${heading('File:')} ${dim(resolved.deliveredVia.path)}`);
+        console.log(`${heading('Checksum:')} ${resolved.deliveredVia.verified ? green('sha256 verified') : warn('NOT VERIFIED (--trust-file)')}`);
+      }
       if (resolved.isThirdParty) {
         console.log(warn('Third-party component — not verified by Zylos team.'));
       }
@@ -211,6 +301,10 @@ export async function addComponent(args) {
           ? `${resolved.name}@${resolved.version}`
           : resolved.installTarget;
         if (branch) installTarget += ` --branch ${branch}`;
+        if (resolved.deliveredVia) {
+          installTarget += ` --file ${resolved.deliveredVia.path}`;
+          installTarget += resolved.deliveredVia.verified ? ` --sha256 ${resolved.deliveredVia.sha256}` : ' --trust-file';
+        }
         console.log(`\n${dim(`Run "zylos add ${installTarget} --yes" to install.`)}`);
       }
     }
@@ -222,6 +316,11 @@ export async function addComponent(args) {
     const versionInfo = branch ? ` (branch: ${bold(branch)})` : (resolved.version ? `@${bold(resolved.version)}` : '');
     console.log(`\n${heading('Component:')} ${bold(resolved.name)}${versionInfo}`);
     console.log(`${heading(resolved.sourceHeading)} ${dim(resolved.sourceLabel)}`);
+
+    if (resolved.deliveredVia) {
+      console.log(`${heading('File:')} ${dim(resolved.deliveredVia.path)}`);
+      console.log(`${heading('Checksum:')} ${resolved.deliveredVia.verified ? green('sha256 verified') : warn('NOT VERIFIED (--trust-file)')}`);
+    }
 
     if (resolved.isThirdParty) {
       console.log(warn('Third-party component — not verified by Zylos team.'));
@@ -280,7 +379,9 @@ export async function addComponent(args) {
     }
     process.exit(1);
   }
-  downloadResult = acquireSource(resolved.source, skillDir);
+  // Identity/transport split: acquisition (when present) says where the bytes
+  // come from this once; resolved.source stays the persisted identity.
+  downloadResult = acquireSource(resolved.acquisition || resolved.source, skillDir);
 
   if (!downloadResult.success) {
     if (jsonOutput) {
@@ -392,6 +493,7 @@ async function installDeclarative(resolved, skillDir, skipConfirm, jsonOutput, b
     source: resolved.source,
   };
   if (branch) componentEntry.branch = branch;
+  if (resolved.deliveredVia) componentEntry.deliveredVia = resolved.deliveredVia;
   components[resolved.name] = componentEntry;
   saveComponents(components);
 
@@ -607,6 +709,7 @@ function installAI(resolved, skillDir, branch) {
     source: resolved.source,
   };
   if (branch) aiEntry.branch = branch;
+  if (resolved.deliveredVia) aiEntry.deliveredVia = resolved.deliveredVia;
   components[resolved.name] = aiEntry;
   saveComponents(components);
 
@@ -659,6 +762,10 @@ Arguments:
 
 Options:
   --branch <name>  Install from a specific git branch (for testing)
+  --file <path>    Install an official component from a local .tar.gz (offline);
+                   requires --sha256 or --trust-file
+  --sha256 <hex>   Verify the --file archive against this sha256 digest
+  --trust-file     Skip --file checksum verification (recorded as unverified)
   --check          Show component info without installing
   --yes, -y        Skip confirmation prompts
   --json           Output in JSON format (for programmatic use)
@@ -668,6 +775,7 @@ Examples:
   zylos add telegram@0.2.0                      Specific version
   zylos add lark --branch main                  Install from branch
   zylos add lark --branch feature/new-thing     Install from PR branch
+  zylos add telegram@0.2.0 --file ./zylos-telegram-0.2.0.tar.gz --sha256 <hex>
   zylos add user/my-component                   Third-party
   zylos add https://github.com/user/zylos-my-component
   zylos add ./my-component

--- a/cli/commands/component.js
+++ b/cli/commands/component.js
@@ -1659,6 +1659,9 @@ export async function listComponents() {
     console.log(`  Type: ${comp.type || 'unknown'}`);
     console.log(`  Repo: ${dim(comp.repo)}`);
     console.log(`  Installed: ${dim(comp.installedAt || 'unknown')}`);
+    if (comp.deliveredVia?.type === 'file' && !comp.deliveredVia.verified) {
+      console.log(`  ${yellow('Delivered via file — checksum NOT verified (--trust-file)')}`);
+    }
     console.log('');
   }
 }

--- a/cli/lib/__tests__/file-delivery.test.js
+++ b/cli/lib/__tests__/file-delivery.test.js
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { after, describe, it } from 'node:test';
+
+// Sandbox ZYLOS_DIR before importing so the offline registry lookup reads a
+// hermetic ~/.zylos/registry.json instead of the developer's real one.
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-file-delivery-test-'));
+process.env.ZYLOS_DIR = sandbox;
+fs.mkdirSync(path.join(sandbox, '.zylos'), { recursive: true });
+fs.writeFileSync(
+  path.join(sandbox, '.zylos', 'registry.json'),
+  JSON.stringify({
+    components: {
+      'file-fixture': { repo: 'zylos-ai/zylos-file-fixture', type: 'service' },
+    },
+  }),
+  'utf8'
+);
+
+const { resolveTarget } = await import('../components.js');
+const { sha256File, isValidSha256Hex } = await import('../checksum.js');
+
+const tmpDirs = [sandbox];
+
+after(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-file-delivery-tmp-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeTarball({ name = 'file-fixture', version = null, skillName = name } = {}) {
+  const root = makeTmpDir();
+  const wrapper = path.join(root, `zylos-${name}`);
+  fs.mkdirSync(wrapper, { recursive: true });
+  const versionLine = version ? `\nversion: ${version}` : '';
+  fs.writeFileSync(
+    path.join(wrapper, 'SKILL.md'),
+    `---\nname: ${skillName}${versionLine}\ndescription: File delivery fixture\n---\n\n# Fixture\n`,
+    'utf8'
+  );
+  fs.writeFileSync(path.join(wrapper, 'payload.txt'), 'file delivery payload\n', 'utf8');
+  const tarball = path.join(root, `zylos-${name}.tar.gz`);
+  execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+  return tarball;
+}
+
+describe('checksum utilities', () => {
+  it('computes the sha256 digest of a file', () => {
+    const dir = makeTmpDir();
+    const file = path.join(dir, 'payload.txt');
+    fs.writeFileSync(file, 'hello\n', 'utf8');
+    assert.equal(
+      sha256File(file),
+      '5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03'
+    );
+  });
+
+  it('validates sha256 hex digests strictly', () => {
+    assert.equal(isValidSha256Hex('a'.repeat(64)), true);
+    assert.equal(isValidSha256Hex('A0'.repeat(32)), true);
+    assert.equal(isValidSha256Hex('a'.repeat(63)), false);
+    assert.equal(isValidSha256Hex('a'.repeat(65)), false);
+    assert.equal(isValidSha256Hex('g'.repeat(64)), false);
+    assert.equal(isValidSha256Hex(null), false);
+    assert.equal(isValidSha256Hex(42), false);
+  });
+});
+
+describe('resolveTarget with --file (official file delivery)', () => {
+  it('resolves a registry name against a tarball with split identity and acquisition', async () => {
+    const tarball = makeTarball({ version: '1.2.3' });
+    const resolved = await resolveTarget('file-fixture', { file: tarball });
+
+    assert.equal(resolved.resolutionError, undefined);
+    assert.equal(resolved.name, 'file-fixture');
+    assert.equal(resolved.repo, 'zylos-ai/zylos-file-fixture');
+    assert.equal(resolved.version, '1.2.3');
+    assert.equal(resolved.isThirdParty, false);
+    assert.deepEqual(resolved.source, {
+      type: 'github-release',
+      repo: 'zylos-ai/zylos-file-fixture',
+      ref: '1.2.3',
+      refType: 'tag',
+    });
+    assert.deepEqual(resolved.acquisition, {
+      type: 'local-tarball',
+      path: path.resolve(tarball),
+    });
+  });
+
+  it('accepts a matching explicit version and normalizes a leading v', async () => {
+    const tarball = makeTarball({ version: '1.2.3' });
+    const resolved = await resolveTarget('file-fixture@v1.2.3', { file: tarball });
+
+    assert.equal(resolved.resolutionError, undefined);
+    assert.equal(resolved.version, '1.2.3');
+    assert.equal(resolved.source.ref, '1.2.3');
+  });
+
+  it('uses the explicit version when the archive has no version metadata', async () => {
+    const tarball = makeTarball({ version: null });
+    const resolved = await resolveTarget('file-fixture@2.0.0', { file: tarball });
+
+    assert.equal(resolved.resolutionError, undefined);
+    assert.equal(resolved.version, '2.0.0');
+    assert.deepEqual(resolved.source, {
+      type: 'github-release',
+      repo: 'zylos-ai/zylos-file-fixture',
+      ref: '2.0.0',
+      refType: 'tag',
+    });
+  });
+
+  it('fails closed when the name is not in the offline registry', async () => {
+    const tarball = makeTarball({ skillName: 'not-registered' });
+    const resolved = await resolveTarget('not-registered', { file: tarball });
+
+    assert.match(resolved.resolutionError, /not in the offline registry/);
+    assert.equal(resolved.source, null);
+  });
+
+  it('fails closed when the explicit version conflicts with archive metadata', async () => {
+    const tarball = makeTarball({ version: '1.2.3' });
+    const resolved = await resolveTarget('file-fixture@9.9.9', { file: tarball });
+
+    assert.match(resolved.resolutionError, /Version mismatch/);
+    assert.equal(resolved.source, null);
+  });
+
+  it('fails closed when no version source exists at all', async () => {
+    const tarball = makeTarball({ version: null });
+    const resolved = await resolveTarget('file-fixture', { file: tarball });
+
+    assert.match(resolved.resolutionError, /no version metadata/);
+    assert.equal(resolved.source, null);
+  });
+
+  it('fails closed when the archive SKILL.md name mismatches the command name', async () => {
+    const tarball = makeTarball({ version: '1.2.3', skillName: 'other-component' });
+    const resolved = await resolveTarget('file-fixture', { file: tarball });
+
+    assert.match(resolved.resolutionError, /name mismatch/i);
+    assert.equal(resolved.source, null);
+  });
+
+  it('rejects a directory passed to --file', async () => {
+    const dir = makeTmpDir();
+    const resolved = await resolveTarget('file-fixture', { file: dir });
+
+    assert.match(resolved.resolutionError, /\.tar\.gz archive/);
+    assert.equal(resolved.source, null);
+  });
+
+  it('rejects a missing --file path', async () => {
+    const resolved = await resolveTarget('file-fixture', { file: path.join(makeTmpDir(), 'missing.tar.gz') });
+
+    assert.match(resolved.resolutionError, /Local source not found/);
+    assert.equal(resolved.source, null);
+  });
+
+  it('rejects a path in place of the component name', async () => {
+    const tarball = makeTarball({ version: '1.2.3' });
+    const resolved = await resolveTarget('./file-fixture', { file: tarball });
+
+    assert.match(resolved.resolutionError, /requires a component name, not a path/);
+    assert.equal(resolved.source, null);
+  });
+
+  it('inherits the tarball safety screening from the local-tarball resolver', async () => {
+    const root = makeTmpDir();
+    const wrapper = path.join(root, 'zylos-file-fixture');
+    fs.mkdirSync(wrapper, { recursive: true });
+    fs.writeFileSync(path.join(wrapper, 'SKILL.md'), '---\nname: file-fixture\nversion: 1.0.0\n---\n', 'utf8');
+    fs.symlinkSync('../../outside', path.join(wrapper, 'escape'));
+    const tarball = path.join(root, 'zylos-file-fixture.tar.gz');
+    execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+
+    const resolved = await resolveTarget('file-fixture', { file: tarball });
+
+    assert.match(resolved.resolutionError, /symbolic or hard link/);
+    assert.equal(resolved.source, null);
+  });
+});

--- a/cli/lib/__tests__/official-file-delivery.e2e.test.js
+++ b/cli/lib/__tests__/official-file-delivery.e2e.test.js
@@ -53,17 +53,30 @@ function sha256(filePath) {
 }
 
 /**
- * A curl that always fails: any network attempt during a --file install
- * breaks the test, proving the flow is fully offline.
+ * A curl that records every invocation to a marker file and fails.
+ * Failing alone only proves offline *tolerance* (fallback chains may swallow
+ * the error); the marker lets tests assert curl was NEVER invoked at all.
  */
 function poisonNetwork(root) {
   const fakeBin = path.join(root, 'bin');
+  const marker = path.join(root, 'curl-invoked.marker');
   fs.mkdirSync(fakeBin, { recursive: true });
-  fs.writeFileSync(path.join(fakeBin, 'curl'), '#!/bin/sh\nexit 7\n', { mode: 0o755 });
+  fs.writeFileSync(
+    path.join(fakeBin, 'curl'),
+    `#!/bin/sh\necho "$@" >> "${marker}"\nexit 7\n`,
+    { mode: 0o755 }
+  );
   return {
-    PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
-    GITHUB_TOKEN: '',
-    GH_TOKEN: '',
+    env: {
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+      GITHUB_TOKEN: '',
+      GH_TOKEN: '',
+    },
+    assertNoNetwork() {
+      if (fs.existsSync(marker)) {
+        assert.fail(`curl was invoked during an offline --file flow:\n${fs.readFileSync(marker, 'utf8')}`);
+      }
+    },
   };
 }
 
@@ -89,14 +102,15 @@ describe('zylos add --file official delivery E2E', () => {
   it('installs an official component from a verified tarball with zero network', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root);
-    const env = poisonNetwork(root);
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env,
+      cwd: root, zylosDir, env: net.env,
       args: ['add', `${COMPONENT}@1.0.0`, '--file', tarball, '--sha256', sha256(tarball), '--json'],
     });
 
     assert.equal(result.status, 0, `add failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    net.assertNoNetwork();
     const output = JSON.parse(result.stdout);
     assert.equal(output.success, true);
     assert.equal(output.component, COMPONENT);
@@ -125,9 +139,10 @@ describe('zylos add --file official delivery E2E', () => {
   it('fails closed with no residue when the target version mismatches the archive', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root, { version: '1.0.0' });
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', `${COMPONENT}@2.0.0`, '--file', tarball, '--sha256', sha256(tarball), '--json'],
     });
 
@@ -136,14 +151,16 @@ describe('zylos add --file official delivery E2E', () => {
     assert.equal(output.success, false);
     assert.match(output.message, /Version mismatch/);
     assertNoResidue(zylosDir);
+    net.assertNoNetwork();
   });
 
   it('fails closed before unpacking when the sha256 does not match', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root);
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', `${COMPONENT}@1.0.0`, '--file', tarball, '--sha256', 'a'.repeat(64), '--json'],
     });
 
@@ -151,17 +168,20 @@ describe('zylos add --file official delivery E2E', () => {
     const output = JSON.parse(result.stdout);
     assert.equal(output.error, 'checksum_mismatch');
     assertNoResidue(zylosDir);
+    net.assertNoNetwork();
   });
 
   it('leaves the installed component on the normal upgrade path', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root);
+    const net = poisonNetwork(root);
 
     const install = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', COMPONENT, '--file', tarball, '--sha256', sha256(tarball), '--json'],
     });
     assert.equal(install.status, 0, install.stdout);
+    net.assertNoNetwork();
 
     // Fake GitHub tag listing: the official repo has a newer release
     const fakeBin = path.join(root, 'upgrade-bin');
@@ -195,13 +215,15 @@ describe('zylos add --file official delivery E2E', () => {
   it('records an unverified install with --trust-file and warns in list output', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root);
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', COMPONENT, '--file', tarball, '--trust-file', '--json'],
     });
 
     assert.equal(result.status, 0, result.stdout);
+    net.assertNoNetwork();
     const entry = readComponents(zylosDir)[COMPONENT];
     assert.equal(entry.deliveredVia.verified, false);
     assert.equal(entry.deliveredVia.sha256, null);
@@ -214,55 +236,63 @@ describe('zylos add --file official delivery E2E', () => {
   it('rejects --file without --sha256 or --trust-file', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root);
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', COMPONENT, '--file', tarball, '--json'],
     });
 
     assert.equal(result.status, 1);
     assert.equal(JSON.parse(result.stdout).error, 'checksum_required');
     assertNoResidue(zylosDir);
+    net.assertNoNetwork();
   });
 
   it('rejects --file combined with --branch', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root);
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', COMPONENT, '--file', tarball, '--trust-file', '--branch', 'main', '--json'],
     });
 
     assert.equal(result.status, 1);
     assert.equal(JSON.parse(result.stdout).error, 'conflict');
     assertNoResidue(zylosDir);
+    net.assertNoNetwork();
   });
 
   it('rejects a component name missing from the offline registry', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root, { name: 'unknown-component' });
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', 'unknown-component', '--file', tarball, '--sha256', sha256(tarball), '--json'],
     });
 
     assert.equal(result.status, 1);
     assert.match(JSON.parse(result.stdout).message, /not in the offline registry/);
     assertNoResidue(zylosDir);
+    net.assertNoNetwork();
   });
 
   it('shows offline component info with verification status in --check mode', () => {
     const { root, zylosDir } = makeFixture();
     const tarball = makeTarball(root);
+    const net = poisonNetwork(root);
 
     const result = runCli({
-      cwd: root, zylosDir, env: poisonNetwork(root),
+      cwd: root, zylosDir, env: net.env,
       args: ['add', `${COMPONENT}@1.0.0`, '--file', tarball, '--sha256', sha256(tarball), '--check', '--json'],
     });
 
     assert.equal(result.status, 0, result.stdout);
+    net.assertNoNetwork();
     const output = JSON.parse(result.stdout);
     assert.equal(output.success, true);
     assert.equal(output.version, '1.0.0');

--- a/cli/lib/__tests__/official-file-delivery.e2e.test.js
+++ b/cli/lib/__tests__/official-file-delivery.e2e.test.js
@@ -1,0 +1,279 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { afterEach, describe, it } from 'node:test';
+
+const CLI = path.join(import.meta.dirname, '..', '..', 'zylos.js');
+const COMPONENT = 'file-e2e';
+const REPO = 'example/zylos-file-e2e';
+const tmpDirs = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zylos-file-delivery-e2e-'));
+  tmpDirs.push(root);
+  const zylosDir = path.join(root, 'zylos-home');
+  fs.mkdirSync(path.join(zylosDir, '.zylos'), { recursive: true });
+  fs.writeFileSync(path.join(zylosDir, '.zylos', 'components.json'), '{}\n', 'utf8');
+  // Offline registry override: maps the fixture name to its official repo
+  fs.writeFileSync(
+    path.join(zylosDir, '.zylos', 'registry.json'),
+    JSON.stringify({ components: { [COMPONENT]: { repo: REPO, type: 'service' } } }),
+    'utf8'
+  );
+  return { root, zylosDir };
+}
+
+function makeTarball(root, { name = COMPONENT, version = '1.0.0' } = {}) {
+  const wrapper = path.join(root, `zylos-${name}`);
+  fs.mkdirSync(wrapper, { recursive: true });
+  const versionLine = version ? `\nversion: ${version}` : '';
+  fs.writeFileSync(
+    path.join(wrapper, 'SKILL.md'),
+    `---\nname: ${name}${versionLine}\ndescription: Official file delivery E2E fixture\n---\n\n# Fixture\n`,
+    'utf8'
+  );
+  fs.writeFileSync(path.join(wrapper, 'payload.txt'), `${name} payload\n`, 'utf8');
+  const tarball = path.join(root, `zylos-${name}-${version || 'unversioned'}.tar.gz`);
+  execFileSync('tar', ['czf', tarball, '-C', root, path.basename(wrapper)]);
+  fs.rmSync(wrapper, { recursive: true, force: true });
+  return tarball;
+}
+
+function sha256(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+/**
+ * A curl that always fails: any network attempt during a --file install
+ * breaks the test, proving the flow is fully offline.
+ */
+function poisonNetwork(root) {
+  const fakeBin = path.join(root, 'bin');
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.writeFileSync(path.join(fakeBin, 'curl'), '#!/bin/sh\nexit 7\n', { mode: 0o755 });
+  return {
+    PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+    GITHUB_TOKEN: '',
+    GH_TOKEN: '',
+  };
+}
+
+function runCli({ cwd, zylosDir, args, env = {} }) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    env: { ...process.env, ZYLOS_DIR: zylosDir, ...env },
+    encoding: 'utf8',
+    timeout: 30000,
+  });
+}
+
+function readComponents(zylosDir) {
+  return JSON.parse(fs.readFileSync(path.join(zylosDir, '.zylos', 'components.json'), 'utf8'));
+}
+
+function assertNoResidue(zylosDir) {
+  assert.deepEqual(readComponents(zylosDir), {});
+  assert.equal(fs.existsSync(path.join(zylosDir, '.claude', 'skills', COMPONENT)), false);
+}
+
+describe('zylos add --file official delivery E2E', () => {
+  it('installs an official component from a verified tarball with zero network', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root);
+    const env = poisonNetwork(root);
+
+    const result = runCli({
+      cwd: root, zylosDir, env,
+      args: ['add', `${COMPONENT}@1.0.0`, '--file', tarball, '--sha256', sha256(tarball), '--json'],
+    });
+
+    assert.equal(result.status, 0, `add failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.success, true);
+    assert.equal(output.component, COMPONENT);
+    assert.equal(output.version, '1.0.0');
+
+    const entry = readComponents(zylosDir)[COMPONENT];
+    assert.equal(entry.version, '1.0.0');
+    assert.equal(entry.repo, REPO);
+    assert.equal(entry.isThirdParty, false);
+    assert.deepEqual(entry.source, {
+      type: 'github-release',
+      repo: REPO,
+      ref: '1.0.0',
+      refType: 'tag',
+    });
+    assert.equal(entry.deliveredVia.type, 'file');
+    assert.equal(entry.deliveredVia.path, tarball);
+    assert.equal(entry.deliveredVia.sha256, sha256(tarball));
+    assert.equal(entry.deliveredVia.verified, true);
+
+    const skillDir = path.join(zylosDir, '.claude', 'skills', COMPONENT);
+    assert.equal(fs.readFileSync(path.join(skillDir, 'payload.txt'), 'utf8'), `${COMPONENT} payload\n`);
+    assert.equal(fs.existsSync(path.join(skillDir, '.zylos', 'manifest.json')), true);
+  });
+
+  it('fails closed with no residue when the target version mismatches the archive', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root, { version: '1.0.0' });
+
+    const result = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', `${COMPONENT}@2.0.0`, '--file', tarball, '--sha256', sha256(tarball), '--json'],
+    });
+
+    assert.equal(result.status, 1);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.success, false);
+    assert.match(output.message, /Version mismatch/);
+    assertNoResidue(zylosDir);
+  });
+
+  it('fails closed before unpacking when the sha256 does not match', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root);
+
+    const result = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', `${COMPONENT}@1.0.0`, '--file', tarball, '--sha256', 'a'.repeat(64), '--json'],
+    });
+
+    assert.equal(result.status, 1);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.error, 'checksum_mismatch');
+    assertNoResidue(zylosDir);
+  });
+
+  it('leaves the installed component on the normal upgrade path', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root);
+
+    const install = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', COMPONENT, '--file', tarball, '--sha256', sha256(tarball), '--json'],
+    });
+    assert.equal(install.status, 0, install.stdout);
+
+    // Fake GitHub tag listing: the official repo has a newer release
+    const fakeBin = path.join(root, 'upgrade-bin');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, 'curl'),
+      '#!/bin/sh\ncat >/dev/null\nprintf \'%s\\n\' \'[{"name":"v2.0.0"}]\'\n',
+      { mode: 0o755 }
+    );
+
+    const result = runCli({
+      cwd: root, zylosDir,
+      args: ['upgrade', COMPONENT, '--check', '--json'],
+      env: {
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+        GITHUB_TOKEN: 'test-token',
+        GH_TOKEN: '',
+      },
+    });
+
+    assert.equal(result.status, 0, result.stdout);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.success, true);
+    assert.notEqual(output.error, 'local_source_upgrade_unsupported');
+    assert.equal(output.hasUpdate, true);
+    assert.equal(output.current, '1.0.0');
+    assert.equal(output.latest, '2.0.0');
+    assert.equal(output.repo, REPO);
+  });
+
+  it('records an unverified install with --trust-file and warns in list output', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root);
+
+    const result = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', COMPONENT, '--file', tarball, '--trust-file', '--json'],
+    });
+
+    assert.equal(result.status, 0, result.stdout);
+    const entry = readComponents(zylosDir)[COMPONENT];
+    assert.equal(entry.deliveredVia.verified, false);
+    assert.equal(entry.deliveredVia.sha256, null);
+
+    const list = runCli({ cwd: root, zylosDir, args: ['list'] });
+    assert.equal(list.status, 0);
+    assert.match(list.stdout, /checksum NOT verified/);
+  });
+
+  it('rejects --file without --sha256 or --trust-file', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root);
+
+    const result = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', COMPONENT, '--file', tarball, '--json'],
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stdout).error, 'checksum_required');
+    assertNoResidue(zylosDir);
+  });
+
+  it('rejects --file combined with --branch', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root);
+
+    const result = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', COMPONENT, '--file', tarball, '--trust-file', '--branch', 'main', '--json'],
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stdout).error, 'conflict');
+    assertNoResidue(zylosDir);
+  });
+
+  it('rejects a component name missing from the offline registry', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root, { name: 'unknown-component' });
+
+    const result = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', 'unknown-component', '--file', tarball, '--sha256', sha256(tarball), '--json'],
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(JSON.parse(result.stdout).message, /not in the offline registry/);
+    assertNoResidue(zylosDir);
+  });
+
+  it('shows offline component info with verification status in --check mode', () => {
+    const { root, zylosDir } = makeFixture();
+    const tarball = makeTarball(root);
+
+    const result = runCli({
+      cwd: root, zylosDir, env: poisonNetwork(root),
+      args: ['add', `${COMPONENT}@1.0.0`, '--file', tarball, '--sha256', sha256(tarball), '--check', '--json'],
+    });
+
+    assert.equal(result.status, 0, result.stdout);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.success, true);
+    assert.equal(output.version, '1.0.0');
+    assert.deepEqual(output.source, {
+      type: 'github-release',
+      repo: REPO,
+      ref: '1.0.0',
+      refType: 'tag',
+    });
+    assert.equal(output.deliveredVia.verified, true);
+    assert.match(output.reply, /sha256 verified/);
+    assertNoResidue(zylosDir);
+  });
+});

--- a/cli/lib/checksum.js
+++ b/cli/lib/checksum.js
@@ -1,0 +1,23 @@
+/**
+ * Checksum utilities for file-delivered component installs.
+ */
+
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+
+/**
+ * Validate a sha256 hex digest string (64 hex characters).
+ */
+export function isValidSha256Hex(value) {
+  return typeof value === 'string' && /^[0-9a-fA-F]{64}$/.test(value);
+}
+
+/**
+ * Compute the sha256 hex digest of a file.
+ *
+ * @param {string} filePath
+ * @returns {string} Lowercase hex digest
+ */
+export function sha256File(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}

--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -138,9 +138,14 @@ export async function resolveTarget(nameOrUrl, { branch = null, file = null } = 
 /**
  * Registry metadata is presentation-only. Local sources must remain fully
  * offline, so they never trigger the remote registry fallback chain.
+ * File-delivered targets keep their repo identity but are equally offline,
+ * so they read the built-in/local registry only.
  */
 export async function loadTargetRegistryInfo(resolved) {
   if (!resolved.repo) return {};
+  if (resolved.acquisition) {
+    return loadLocalRegistry()[resolved.name] || {};
+  }
   const registry = await loadRegistry();
   return registry[resolved.name] || {};
 }

--- a/cli/lib/components.js
+++ b/cli/lib/components.js
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { COMPONENTS_FILE } from './config.js';
-import { loadRegistry } from './registry.js';
+import { loadRegistry, loadLocalRegistry } from './registry.js';
 import { fetchLatestTag } from './github.js';
 import { inspectLocalSource, resolveLocalPath } from './download.js';
 
@@ -38,10 +38,14 @@ export function saveComponents(components) {
  * the same descriptor can be persisted and consumed by a future upgrade flow.
  *
  * @param {string} nameOrUrl
- * @param {{ branch?: string | null }} [options]
+ * @param {{ branch?: string | null, file?: string | null }} [options]
  * @returns {Promise<object>}
  */
-export async function resolveTarget(nameOrUrl, { branch = null } = {}) {
+export async function resolveTarget(nameOrUrl, { branch = null, file = null } = {}) {
+  if (file) {
+    return resolveFileTarget(nameOrUrl, file);
+  }
+
   if (isLocalPathSpecifier(nameOrUrl)) {
     try {
       const inspected = inspectLocalSource(nameOrUrl);
@@ -172,6 +176,90 @@ function resolveGitHubTarget({
     sourceReplyLabel: 'Repo',
     installTarget,
   };
+}
+
+/**
+ * Resolve a file-delivered official component (`zylos add <name>[@<ver>] --file <tar.gz>`).
+ *
+ * Identity and transport are deliberately split: the persisted `source` records
+ * the official github-release identity (so upgrades work unchanged), while the
+ * one-shot `acquisition` descriptor points at the local tarball used for this
+ * install. Resolution is fully offline — only the built-in/local registry is
+ * consulted, and version/name checks fail closed.
+ */
+function resolveFileTarget(nameOrUrl, file) {
+  let version = null;
+  let name = nameOrUrl;
+  if (nameOrUrl.includes('@')) {
+    const atIndex = nameOrUrl.lastIndexOf('@');
+    name = nameOrUrl.substring(0, atIndex);
+    version = nameOrUrl.substring(atIndex + 1);
+  }
+
+  const fail = (message) => ({
+    name,
+    repo: null,
+    version: null,
+    fetchError: null,
+    isThirdParty: false,
+    source: null,
+    sourceLabel: resolveLocalPath(file),
+    installTarget: nameOrUrl,
+    resolutionError: message,
+  });
+
+  if (isLocalPathSpecifier(name)) {
+    return fail(`--file requires a component name, not a path: ${name}`);
+  }
+
+  const registry = loadLocalRegistry();
+  const repo = registry[name]?.repo;
+  if (!repo) {
+    return fail(`Component "${name}" is not in the offline registry. --file installs are limited to known official components.`);
+  }
+
+  let inspected;
+  try {
+    inspected = inspectLocalSource(file);
+  } catch (err) {
+    return fail(err.message);
+  }
+  if (inspected.source.type !== 'local-tarball') {
+    return fail(`--file requires a .tar.gz archive: ${resolveLocalPath(file)}`);
+  }
+
+  if (inspected.name !== name) {
+    return fail(`Component name mismatch: command says "${name}" but the archive says "${inspected.name}".`);
+  }
+
+  const explicitVersion = normalizeVersion(version);
+  const metadataVersion = normalizeVersion(inspected.version);
+  if (explicitVersion && metadataVersion && explicitVersion !== metadataVersion) {
+    return fail(`Version mismatch: command says "${explicitVersion}" but the archive metadata says "${metadataVersion}".`);
+  }
+  const resolvedVersion = explicitVersion || metadataVersion;
+  if (!resolvedVersion) {
+    return fail(`The archive has no version metadata (SKILL.md, VERSION, or package.json). Specify one explicitly: zylos add ${name}@<version> --file ...`);
+  }
+
+  return {
+    ...resolveGitHubTarget({
+      name,
+      repo,
+      version: resolvedVersion,
+      branch: null,
+      tryFetchLatestTag: null,
+      installTarget: nameOrUrl,
+      isThirdParty: false,
+    }),
+    acquisition: { type: 'local-tarball', path: resolveLocalPath(file) },
+  };
+}
+
+function normalizeVersion(value) {
+  if (value == null) return null;
+  const version = String(value).trim().replace(/^v/, '');
+  return version || null;
 }
 
 export function isLocalPathSpecifier(value) {


### PR DESCRIPTION
Closes #707.

Implements offline file delivery for official components per the locked plan (see [#707 decision comment](https://github.com/zylos-ai/zylos-core/issues/707#issuecomment-5277609204)):

```
zylos add <name>[@<version>] --file <path.tar.gz> [--sha256 <hex> | --trust-file]
```

## Design (as agreed)

- **Identity/transport split**: persisted `source` records the `github-release` identity (`{type, repo, ref: <version, no v prefix>, refType: 'tag'}`) — identical to a direct GitHub install, so **`upgrade.js` has zero changes** and the upgrade path opens naturally. A one-shot `acquisition` descriptor (`{type: 'local-tarball', path}`) reuses the #700 resolver, inheriting its tar safety screening (absolute paths / `..` / links rejected before extraction).
- **Fully offline**: `<name>` resolves against the built-in + local registry only (`loadLocalRegistry()`); no remote registry, no `fetchLatestTag`. E2E proves it with a poisoned `curl` in PATH.
- **Fail-closed verification**: `--sha256` is checked against the archive **before any unpacking**; a mismatch aborts with no residue. `--trust-file` explicitly skips verification, recorded as `verified: false` and flagged by `zylos list`. Neither flag → refuse to install.
- **Fail-closed consistency**: explicit `@version` vs archive metadata mismatch → abort; archive `SKILL.md` name vs command name mismatch → abort; no version source at all → abort.
- **Audit record**: `components.json` gains `deliveredVia: {type: 'file', path, sha256|null, verified, at}` — audit-only, never consulted by add/upgrade logic.
- `--file` is mutually exclusive with `--branch`; `--check`/`--json`/`--yes` compose normally (`--check` shows offline info + verification status).

## Tests

- **Unit** (`file-delivery.test.js`, hermetic sandboxed registry): checksum utils; split identity/acquisition resolution; v-prefix normalization; every fail-closed branch (registry miss, version conflict, version missing, name mismatch, directory/missing/path-as-name inputs); safety-screening inheritance.
- **E2E** (`official-file-delivery.e2e.test.js`, real CLI spawns): all four acceptance tests from the Nicholas alignment —
  1. correct sha256 → zero-network install, official repo/version recorded;
  2. target version ≠ archive metadata → fail, no partial install;
  3. wrong sha256 → fail before unpack, no residue;
  4. installed component passes `zylos upgrade --check` (no `local_source_upgrade_unsupported`, update visible);
  plus `--trust-file` audit + list warning, mandatory-checksum refusal, `--file`/`--branch` conflict, registry-miss, and `--check` output.
- **Regression**: Jest 147/147 green; node tests green except the pre-existing `instruction-split` template-hash pin failure on main (#749, fix pending separately — unrelated to this change).

No version bump — release is cut separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)