### PR TITLE
fix: upgrade js-yaml to 4.3.1, 3.15.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.7",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.1",
         "smol-toml": "^1.6.1"
       },
       "bin": {
@@ -3132,9 +3132,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "dotenv": "^16.4.7",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "smol-toml": "^1.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
   "devDependencies": {
     "@jest/globals": "^30.2.0",
     "jest": "^30.3.0"
+  },
+  "overrides": {
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Upgrade js-yaml from 4.1.1 to 4.3.1, 3.15.1 to fix GHSA-5p4m-2wfm-xmqj.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-5p4m-2wfm-xmqj |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-5p4m-2wfm-xmqj` |
| **File** | `package-lock.json` (dependency: `js-yaml`) |
| **Assessment** | Defensive hardening |

**Description**: JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
