### PR TITLE
fix(test): update system-template hash pins missed by #742

### DIFF
--- a/cli/lib/__tests__/instruction-split.test.js
+++ b/cli/lib/__tests__/instruction-split.test.js
@@ -86,8 +86,8 @@ describe('split instruction assembler', () => {
     // pins alongside the reviewed content change (issue #722 content redraft).
     const managedHeader = '> **Zylos-managed system instructions.** This file is replaced during upgrades. Put all custom instructions in `~/zylos/ZYLOS.md`.\n\n';
     const expected = {
-      claude: '5465ea8a6e7cf01e2f0b36c737ad243f371bf0318cadc1e73edba78a29452032',
-      codex: 'dd04b5bdd994f278696c96bd2a6728fef1eb6cd0bcf6d1bad397971f0d9ad034',
+      claude: '09960a6f3912f0ef51a13a3c383ec3ded78076a37db686d6885b7bab52b6c3e8',
+      codex: 'e60fecca708e7f6cc5775e95583f63635d4dd0a953f5e3e6701035ce3876dec6',
     };
     for (const runtime of ['claude', 'codex']) {
       const content = fs.readFileSync(path.join(TEMPLATES_DIR, `${runtime}-system.md`), 'utf8');


### PR DESCRIPTION
Closes #749.

## What
Two-line fix: update the SHA-256 pins in `cli/lib/__tests__/instruction-split.test.js` to the current approved template bytes.

## Why
#742 (fcc9bf7) edited `templates/claude-system.md` and `templates/codex-system.md` but did not update the reintroduction-guard pins — the guard fired as designed, leaving main's node suite red at 829/830 since 08-12. The #742 content change itself was reviewed and merged, so per the guard's own comment the pins are updated to acknowledge the reviewed edit.

## Verification
- Templates untouched since #742 (`git log -- templates/`: fcc9bf7 is the last commit) — current bytes are the reviewed state
- Hashes recomputed independently from template bytes minus the managed header (matches the guard's computation)
- `npm run test:node`: **830/830 pass** on this branch (was 829/830 on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)