### PR TITLE
Deduplicate early Memory Sync triggers (port of #628)

### DIFF
--- a/skills/activity-monitor/scripts/__tests__/memory-sync-gate.test.js
+++ b/skills/activity-monitor/scripts/__tests__/memory-sync-gate.test.js
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  clearMemorySyncRequest,
+  createMemorySyncControlPrompt,
+  markMemorySyncRequested,
+  shouldTriggerMemorySync,
+} from '../memory-sync-gate.js';
+
+describe('memory sync gate', () => {
+  it('skips and clears stale request state when unsummarized count is below threshold', () => {
+    const result = shouldTriggerMemorySync({
+      state: {
+        memory_sync: { status: 'requested', requested_at: 100, expires_at: 3700 },
+        last_memory_sync_trigger_at: 100,
+      },
+      now: 200,
+      unsummarizedCount: 5,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'below_checkpoint_threshold');
+    assert.deepEqual(result.nextState, {});
+  });
+
+  it('suppresses repeated requests during cooldown', () => {
+    const state = {
+      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+    };
+
+    const result = shouldTriggerMemorySync({
+      state,
+      now: 1200,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'cooldown');
+    assert.equal(result.nextState, state);
+  });
+
+  it('honors legacy trigger timestamps during cooldown', () => {
+    const result = shouldTriggerMemorySync({
+      state: { last_memory_sync_trigger_at: 1000 },
+      now: 1200,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'cooldown');
+  });
+
+  it('suppresses in-flight requests after cooldown until the TTL expires', () => {
+    const state = {
+      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+    };
+
+    const result = shouldTriggerMemorySync({
+      state,
+      now: 2000,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+      inFlightTtlSeconds: 3600,
+    });
+
+    assert.equal(result.shouldEnqueue, false);
+    assert.equal(result.reason, 'sync_request_in_flight');
+  });
+
+  it('allows a new request after the in-flight TTL expires', () => {
+    const result = shouldTriggerMemorySync({
+      state: {
+        memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+      },
+      now: 5000,
+      unsummarizedCount: 45,
+      checkpointThreshold: 30,
+      cooldownSeconds: 600,
+      inFlightTtlSeconds: 3600,
+    });
+
+    assert.equal(result.shouldEnqueue, true);
+    assert.equal(result.reason, 'eligible');
+  });
+
+  it('marks requests with a durable status and legacy timestamp', () => {
+    const nextState = markMemorySyncRequested({
+      state: { session_id: 'abc' },
+      now: 1000,
+      unsummarizedCount: 45,
+      pct: 61,
+      thresholdPct: 75,
+      inFlightTtlSeconds: 3600,
+    });
+
+    assert.equal(nextState.session_id, 'abc');
+    assert.equal(nextState.last_memory_sync_trigger_at, 1000);
+    assert.deepEqual(nextState.memory_sync, {
+      status: 'requested',
+      requested_at: 1000,
+      expires_at: 4600,
+      unsummarized_count: 45,
+      context_pct: 61,
+      session_switch_threshold_pct: 75,
+    });
+  });
+
+  it('removes memory sync request fields without touching unrelated state', () => {
+    const nextState = clearMemorySyncRequest({
+      session_id: 'abc',
+      memory_sync: { status: 'requested' },
+      last_memory_sync_trigger_at: 1000,
+    });
+
+    assert.deepEqual(nextState, { session_id: 'abc' });
+  });
+
+  it('builds a maintenance-only control prompt', () => {
+    const prompt = createMemorySyncControlPrompt({ pct: 61, thresholdPct: 75 });
+
+    assert.match(prompt, /Run Memory Sync now/);
+    assert.match(prompt, /maintenance-only/);
+    assert.match(prompt, /must not reply through C4/);
+    assert.match(prompt, /process user-facing tasks/);
+    assert.match(prompt, /modify business\/project repositories/);
+    assert.match(prompt, /Do NOT wait for completion/);
+  });
+});

--- a/skills/activity-monitor/scripts/__tests__/memory-sync-gate.test.js
+++ b/skills/activity-monitor/scripts/__tests__/memory-sync-gate.test.js
@@ -28,7 +28,7 @@ describe('memory sync gate', () => {
 
   it('suppresses repeated requests during cooldown', () => {
     const state = {
-      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 2800 },
     };
 
     const result = shouldTriggerMemorySync({
@@ -59,7 +59,7 @@ describe('memory sync gate', () => {
 
   it('suppresses in-flight requests after cooldown until the TTL expires', () => {
     const state = {
-      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+      memory_sync: { status: 'requested', requested_at: 1000, expires_at: 2800 },
     };
 
     const result = shouldTriggerMemorySync({
@@ -68,7 +68,7 @@ describe('memory sync gate', () => {
       unsummarizedCount: 45,
       checkpointThreshold: 30,
       cooldownSeconds: 600,
-      inFlightTtlSeconds: 3600,
+      inFlightTtlSeconds: 1800,
     });
 
     assert.equal(result.shouldEnqueue, false);
@@ -78,13 +78,13 @@ describe('memory sync gate', () => {
   it('allows a new request after the in-flight TTL expires', () => {
     const result = shouldTriggerMemorySync({
       state: {
-        memory_sync: { status: 'requested', requested_at: 1000, expires_at: 4600 },
+        memory_sync: { status: 'requested', requested_at: 1000, expires_at: 2800 },
       },
       now: 5000,
       unsummarizedCount: 45,
       checkpointThreshold: 30,
       cooldownSeconds: 600,
-      inFlightTtlSeconds: 3600,
+      inFlightTtlSeconds: 1800,
     });
 
     assert.equal(result.shouldEnqueue, true);
@@ -98,7 +98,7 @@ describe('memory sync gate', () => {
       unsummarizedCount: 45,
       pct: 61,
       thresholdPct: 75,
-      inFlightTtlSeconds: 3600,
+      inFlightTtlSeconds: 1800,
     });
 
     assert.equal(nextState.session_id, 'abc');
@@ -106,7 +106,7 @@ describe('memory sync gate', () => {
     assert.deepEqual(nextState.memory_sync, {
       status: 'requested',
       requested_at: 1000,
-      expires_at: 4600,
+      expires_at: 2800,
       unsummarized_count: 45,
       context_pct: 61,
       session_switch_threshold_pct: 75,

--- a/skills/activity-monitor/scripts/__tests__/memory-sync-integration.test.js
+++ b/skills/activity-monitor/scripts/__tests__/memory-sync-integration.test.js
@@ -1,0 +1,238 @@
+/**
+ * Integration tests for the deduplicated early Memory Sync trigger (#626/#628).
+ *
+ * Claude statusLine path: spawns the REAL context-monitor.js as a child process
+ * against a temp ZYLOS_DIR with stub c4-control.js / c4-db.js, and asserts the
+ * full chain: trigger → enqueue recorded → persisted in-flight state suppresses
+ * re-trigger across process restarts (the exact regression from #626) → state
+ * clears after sync completion (checkpoint drops unsummarized count) → TTL
+ * expiry re-arms the gate.
+ *
+ * Codex polling path: drives the real runtime-components.startContextMonitor
+ * with a fake adapter, the same stub c4-control.js as a real child process, and
+ * state persisted to disk — asserting the shared-gate behavior survives a
+ * simulated monitor restart (fresh closure over the same state file).
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONTEXT_MONITOR = path.join(__dirname, '..', 'context-monitor.js');
+
+// CHECKPOINT_THRESHOLD on main is 15 (c4-config.js single source of truth);
+// use counts safely above/below it.
+const COUNT_ABOVE = 45;
+const COUNT_BELOW = 5;
+
+const CONTROL_STUB = `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+// Resolve the temp ZYLOS_DIR from this stub's own location:
+// <tmp>/.claude/skills/comm-bridge/scripts/c4-control.js -> <tmp>
+const zylosDir = path.join(__dirname, '..', '..', '..', '..');
+fs.appendFileSync(path.join(zylosDir, 'c4-control-calls.jsonl'), JSON.stringify(process.argv.slice(2)) + '\\n');
+`;
+
+const DB_STUB = `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const countFile = path.join(__dirname, '..', '..', '..', '..', 'unsummarized-count.txt');
+let count = 0;
+try { count = parseInt(fs.readFileSync(countFile, 'utf8').trim(), 10) || 0; } catch {}
+process.stdout.write(JSON.stringify({ count }));
+`;
+
+let tmpDir;
+
+function setupTempZylosDir() {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-sync-int-'));
+  const scriptsDir = path.join(tmpDir, '.claude', 'skills', 'comm-bridge', 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  // Stubs are CommonJS on purpose: no package.json in the temp tree, so .js
+  // defaults to CJS regardless of the repo's ESM setting.
+  fs.writeFileSync(path.join(scriptsDir, 'c4-control.js'), CONTROL_STUB);
+  fs.writeFileSync(path.join(scriptsDir, 'c4-db.js'), DB_STUB);
+  setUnsummarizedCount(COUNT_ABOVE);
+}
+
+function setUnsummarizedCount(count) {
+  fs.writeFileSync(path.join(tmpDir, 'unsummarized-count.txt'), String(count));
+}
+
+function controlCalls() {
+  try {
+    return fs.readFileSync(path.join(tmpDir, 'c4-control-calls.jsonl'), 'utf8')
+      .trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+  } catch {
+    return [];
+  }
+}
+
+function memorySyncCalls() {
+  return controlCalls().filter((args) => args.join(' ').includes('Run Memory Sync now'));
+}
+
+const STATE_FILE = () => path.join(tmpDir, 'activity-monitor', 'context-monitor-state.json');
+
+function readState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE(), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeState(mutator) {
+  const state = readState() ?? {};
+  fs.writeFileSync(STATE_FILE(), JSON.stringify(mutator(state), null, 2));
+}
+
+/** Run the real context-monitor.js as a fresh process — every run IS a "restart". */
+function runContextMonitor({ usedPct }) {
+  const status = {
+    session_id: 'integration-test-session',
+    context_window: { used_percentage: usedPct },
+    cost: { total_cost_usd: 0.5 },
+  };
+  const result = spawnSync('node', [CONTEXT_MONITOR], {
+    input: JSON.stringify(status),
+    encoding: 'utf8',
+    env: { ...process.env, ZYLOS_DIR: tmpDir },
+    timeout: 15000,
+  });
+  assert.equal(result.status, 0, `context-monitor exited ${result.status}: ${result.stderr}`);
+  return result;
+}
+
+describe('memory sync trigger integration — Claude statusLine path', () => {
+  beforeEach(setupTempZylosDir);
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it('full lifecycle: trigger → restart suppression → completion clear → TTL re-arm', () => {
+    // 1. First evaluation above the early threshold: exactly one sync enqueue.
+    runContextMonitor({ usedPct: 60 });
+    assert.equal(memorySyncCalls().length, 1, 'first run should enqueue exactly one sync');
+    const call = memorySyncCalls()[0].join(' ');
+    assert.match(call, /exactly one background subagent/);
+    assert.match(call, /maintenance-only/);
+    assert.equal(readState().memory_sync.status, 'requested');
+
+    // 2. Fresh process (= monitor restart) while in flight: suppressed.
+    //    This is the #626 regression — in-memory cooldown forgot this state.
+    runContextMonitor({ usedPct: 61 });
+    runContextMonitor({ usedPct: 62 });
+    assert.equal(memorySyncCalls().length, 1, 'restarted process must not re-enqueue while in flight');
+
+    // 3. Sync completes: checkpoint drops unsummarized below threshold → state clears.
+    setUnsummarizedCount(COUNT_BELOW);
+    runContextMonitor({ usedPct: 63 });
+    assert.equal(memorySyncCalls().length, 1, 'below-threshold evaluation must not enqueue');
+    assert.equal(readState().memory_sync, undefined, 'completion must clear the request state');
+
+    // 4. New backlog + past cooldown/TTL: gate re-arms.
+    setUnsummarizedCount(COUNT_ABOVE);
+    runContextMonitor({ usedPct: 64 });
+    assert.equal(memorySyncCalls().length, 2, 'cleared gate must allow the next trigger');
+  });
+
+  it('TTL expiry re-arms a stuck in-flight request; cooldown alone does not', () => {
+    runContextMonitor({ usedPct: 60 });
+    assert.equal(memorySyncCalls().length, 1);
+
+    // Simulate a stuck sync past the 10-min cooldown but inside the 30-min TTL.
+    const now = Math.floor(Date.now() / 1000);
+    writeState((s) => ({
+      ...s,
+      memory_sync: { ...s.memory_sync, requested_at: now - 900, expires_at: now + 900 },
+      last_memory_sync_trigger_at: now - 900,
+    }));
+    runContextMonitor({ usedPct: 61 });
+    assert.equal(memorySyncCalls().length, 1, 'inside TTL: still suppressed after cooldown');
+
+    // Push past the TTL: gate must re-arm.
+    writeState((s) => ({
+      ...s,
+      memory_sync: { ...s.memory_sync, requested_at: now - 2000, expires_at: now - 200 },
+      last_memory_sync_trigger_at: now - 2000,
+    }));
+    runContextMonitor({ usedPct: 62 });
+    assert.equal(memorySyncCalls().length, 2, 'expired TTL must allow a fresh trigger');
+  });
+
+  it('does not trigger below the early-sync context threshold', () => {
+    runContextMonitor({ usedPct: 30 });
+    assert.equal(memorySyncCalls().length, 0);
+  });
+});
+
+describe('memory sync trigger integration — Codex polling path', () => {
+  beforeEach(setupTempZylosDir);
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  async function startCodexMonitor({ getUnsummarizedCount }) {
+    const { startContextMonitor } = await import('../adapters/runtime-components.js');
+    let earlyHandler;
+    const fakeAdapter = {
+      getContextMonitor: () => ({
+        threshold: 0.7,
+        startPolling: ({ onEarlyThreshold }) => { earlyHandler = onEarlyThreshold; },
+      }),
+    };
+    const stateFile = STATE_FILE();
+    fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+    startContextMonitor(fakeAdapter, {
+      getUnsummarizedCount,
+      checkpointThreshold: 15,
+      loadContextMonitorState: () => {
+        try { return JSON.parse(fs.readFileSync(stateFile, 'utf8')); } catch { return {}; }
+      },
+      saveContextMonitorState: (state) => {
+        fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+      },
+      memorySyncCooldownSeconds: 600,
+      memorySyncInFlightTtlSeconds: 1800,
+      c4ControlPath: path.join(tmpDir, '.claude', 'skills', 'comm-bridge', 'scripts', 'c4-control.js'),
+      enqueueContextRotationHandoff: () => {},
+      log: () => {},
+    });
+    return (args) => earlyHandler(args);
+  }
+
+  it('suppresses duplicate triggers across a simulated monitor restart', async () => {
+    const fire = await startCodexMonitor({ getUnsummarizedCount: () => COUNT_ABOVE });
+
+    await fire({ used: 60, ceiling: 100, ratio: 0.6 });
+    assert.equal(memorySyncCalls().length, 1, 'first poll should enqueue one sync');
+    assert.equal(readState().memory_sync.status, 'requested');
+
+    await fire({ used: 61, ceiling: 100, ratio: 0.61 });
+    assert.equal(memorySyncCalls().length, 1, 'same monitor must not re-enqueue in flight');
+
+    // Monitor restart: brand-new closure, same on-disk state.
+    const fireAfterRestart = await startCodexMonitor({ getUnsummarizedCount: () => COUNT_ABOVE });
+    await fireAfterRestart({ used: 62, ceiling: 100, ratio: 0.62 });
+    assert.equal(memorySyncCalls().length, 1, 'restarted monitor must honor persisted in-flight state');
+  });
+
+  it('clears state and re-arms after the sync completes', async () => {
+    let count = COUNT_ABOVE;
+    const fire = await startCodexMonitor({ getUnsummarizedCount: () => count });
+
+    await fire({ used: 60, ceiling: 100, ratio: 0.6 });
+    assert.equal(memorySyncCalls().length, 1);
+
+    count = COUNT_BELOW;
+    await fire({ used: 61, ceiling: 100, ratio: 0.61 });
+    assert.equal(readState().memory_sync, undefined, 'completion must clear the request state');
+
+    count = COUNT_ABOVE;
+    await fire({ used: 62, ceiling: 100, ratio: 0.62 });
+    assert.equal(memorySyncCalls().length, 2, 'cleared gate must allow the next trigger');
+  });
+});

--- a/skills/activity-monitor/scripts/adapters/runtime-components.js
+++ b/skills/activity-monitor/scripts/adapters/runtime-components.js
@@ -6,6 +6,11 @@ import { ProcSampler } from '../proc-sampler.js';
 import { ToolPipeline } from '../tool-pipeline.js';
 import { UsageMonitor } from '../usage-monitor.js';
 import { getToolRules } from '../tool-rules.js';
+import {
+  createMemorySyncControlPrompt,
+  markMemorySyncRequested,
+  shouldTriggerMemorySync,
+} from '../memory-sync-gate.js';
 
 export function createUsageMonitor(activeAdapter, options) {
   return new UsageMonitor(activeAdapter, options);
@@ -77,9 +82,10 @@ export function createGuardian(activeAdapter, activeToolPipeline, initialRuntime
 export function startContextMonitor(activeAdapter, {
   getUnsummarizedCount,
   checkpointThreshold,
-  getLastMemorySyncTriggerAt,
-  setLastMemorySyncTriggerAt,
+  loadContextMonitorState,
+  saveContextMonitorState,
   memorySyncCooldownSeconds,
+  memorySyncInFlightTtlSeconds,
   c4ControlPath,
   enqueueContextRotationHandoff,
   log,
@@ -99,24 +105,40 @@ export function startContextMonitor(activeAdapter, {
     onEarlyThreshold: async ({ used, ceiling, ratio }) => {
       const pct = Math.round(ratio * 100);
       const thresholdPct = Math.round(monitor.threshold * 100);
-      // Cooldown: prevent re-inject while sync is still running
       const now = Math.floor(Date.now() / 1000);
-      if ((now - getLastMemorySyncTriggerAt()) < memorySyncCooldownSeconds) {
-        return;
-      }
       const unsummarizedCount = getUnsummarizedCount();
-      if (unsummarizedCount <= checkpointThreshold) {
-        log(`Early memory sync skipped at ${pct}%: unsummarized=${unsummarizedCount} <= ${checkpointThreshold}`);
+      const state = loadContextMonitorState();
+      const gate = shouldTriggerMemorySync({
+        state,
+        now,
+        unsummarizedCount,
+        checkpointThreshold,
+        cooldownSeconds: memorySyncCooldownSeconds,
+        inFlightTtlSeconds: memorySyncInFlightTtlSeconds,
+      });
+
+      if (!gate.shouldEnqueue) {
+        if (gate.nextState !== state) {
+          saveContextMonitorState(gate.nextState);
+        }
+        log(`Early memory sync skipped at ${pct}%: ${gate.reason} (unsummarized=${unsummarizedCount}, threshold=${checkpointThreshold})`);
         return;
       }
       log(`Context at ${pct}% (approaching ${thresholdPct}% threshold), triggering early memory sync (unsummarized=${unsummarizedCount})`);
       try {
         execFileSync('node', [c4ControlPath, 'enqueue',
-          '--content', `Context usage at ${pct}% (approaching ${thresholdPct}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. Launch a background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. Do NOT wait for completion — continue normal work.`,
+          '--content', createMemorySyncControlPrompt({ pct, thresholdPct }),
           '--priority', '2',
           '--no-ack-suffix',
         ], { encoding: 'utf8', stdio: 'pipe', timeout: 10_000 });
-        setLastMemorySyncTriggerAt(now);
+        saveContextMonitorState(markMemorySyncRequested({
+          state,
+          now,
+          unsummarizedCount,
+          pct,
+          thresholdPct,
+          inFlightTtlSeconds: memorySyncInFlightTtlSeconds,
+        }));
         log(`Early memory sync enqueued at ${pct}%`);
       } catch (err) {
         log(`Failed to enqueue early memory sync: ${err.message}`);

--- a/skills/activity-monitor/scripts/context-monitor.js
+++ b/skills/activity-monitor/scripts/context-monitor.js
@@ -20,6 +20,11 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { CHECKPOINT_THRESHOLD } from '../../comm-bridge/scripts/c4-config.js';
+import {
+  createMemorySyncControlPrompt,
+  markMemorySyncRequested,
+  shouldTriggerMemorySync,
+} from './memory-sync-gate.js';
 
 const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const AM_DIR = path.join(ZYLOS_DIR, 'activity-monitor');
@@ -41,6 +46,7 @@ const MEMORY_SYNC_RATIO = 0.8;
 const MEMORY_SYNC_THRESHOLD = Math.round(RESTART_THRESHOLD * MEMORY_SYNC_RATIO);
 // CHECKPOINT_THRESHOLD imported from c4-config.js (single source of truth).
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
+const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 3600;  // 1 hour safety TTL for delivered-but-unacked sync prompts
 
 function readThresholdFromConfig() {
   try {
@@ -146,26 +152,38 @@ function main(raw) {
  * Only triggers when there are enough unsummarized conversations to warrant sync.
  */
 function maybeEnqueueMemorySync(usedPct) {
-  // Cooldown: prevent re-inject while sync is still running
   const now = Math.floor(Date.now() / 1000);
   const state = loadState();
-  if (state && state.last_memory_sync_trigger_at &&
-      (now - state.last_memory_sync_trigger_at) < MEMORY_SYNC_COOLDOWN_SECONDS) {
-    return;
-  }
 
   // Check unsummarized conversation count — skip if below threshold
   const unsummarizedCount = getUnsummarizedCount();
-  if (unsummarizedCount <= CHECKPOINT_THRESHOLD) {
+  const gate = shouldTriggerMemorySync({
+    state,
+    now,
+    unsummarizedCount,
+    checkpointThreshold: CHECKPOINT_THRESHOLD,
+    cooldownSeconds: MEMORY_SYNC_COOLDOWN_SECONDS,
+    inFlightTtlSeconds: MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS,
+  });
+
+  if (!gate.shouldEnqueue) {
+    if (gate.nextState !== state) {
+      saveState(gate.nextState);
+    }
+    log(`Early memory sync skipped at ${usedPct}%: ${gate.reason} (unsummarized=${unsummarizedCount}, threshold=${CHECKPOINT_THRESHOLD})`);
     return;
   }
 
+  const content = createMemorySyncControlPrompt({
+    pct: usedPct,
+    thresholdPct: RESTART_THRESHOLD,
+  });
   const MAX_RETRIES = 3;
   let enqueued = false;
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       execFileSync('node', [C4_CONTROL, 'enqueue',
-        '--content', `Context usage at ${usedPct}% (approaching ${RESTART_THRESHOLD}% session-switch threshold). Run Memory Sync now as a background task so it completes before the session switch. Launch a background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. Do NOT wait for completion — continue normal work.`,
+        '--content', content,
         '--priority', '2',
         '--no-ack-suffix'
       ], { encoding: 'utf8', stdio: 'pipe' });
@@ -179,10 +197,14 @@ function maybeEnqueueMemorySync(usedPct) {
   }
 
   if (enqueued) {
-    saveState({
-      ...state,
-      last_memory_sync_trigger_at: now,
-    });
+    saveState(markMemorySyncRequested({
+      state,
+      now,
+      unsummarizedCount,
+      pct: usedPct,
+      thresholdPct: RESTART_THRESHOLD,
+      inFlightTtlSeconds: MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS,
+    }));
   }
 }
 

--- a/skills/activity-monitor/scripts/context-monitor.js
+++ b/skills/activity-monitor/scripts/context-monitor.js
@@ -46,7 +46,7 @@ const MEMORY_SYNC_RATIO = 0.8;
 const MEMORY_SYNC_THRESHOLD = Math.round(RESTART_THRESHOLD * MEMORY_SYNC_RATIO);
 // CHECKPOINT_THRESHOLD imported from c4-config.js (single source of truth).
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
-const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 3600;  // 1 hour safety TTL for delivered-but-unacked sync prompts
+const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 1800;  // 30 min safety TTL for delivered-but-unacked sync prompts
 
 function readThresholdFromConfig() {
   try {

--- a/skills/activity-monitor/scripts/memory-sync-gate.js
+++ b/skills/activity-monitor/scripts/memory-sync-gate.js
@@ -1,0 +1,90 @@
+const DEFAULT_IN_FLIGHT_TTL_SECONDS = 3600;
+
+export function createMemorySyncControlPrompt({ pct, thresholdPct }) {
+  return `Context usage at ${pct}% (approaching ${thresholdPct}% session-switch threshold). Run Memory Sync now as a background maintenance task so it completes before the session switch.
+
+Launch exactly one background subagent for memory sync following ~/zylos/.claude/skills/zylos-memory/SKILL.md. The subagent is maintenance-only: it must not reply through C4, process user-facing tasks, modify business/project repositories, install or upgrade components, restart services, or apply runtime changes outside the memory sync flow.
+
+Do NOT wait for completion - continue normal work.`;
+}
+
+export function shouldTriggerMemorySync({
+  state,
+  now,
+  unsummarizedCount,
+  checkpointThreshold,
+  cooldownSeconds,
+  inFlightTtlSeconds = DEFAULT_IN_FLIGHT_TTL_SECONDS,
+}) {
+  if (unsummarizedCount <= checkpointThreshold) {
+    return {
+      shouldEnqueue: false,
+      reason: 'below_checkpoint_threshold',
+      nextState: clearMemorySyncRequest(state),
+    };
+  }
+
+  const memorySync = state?.memory_sync ?? {};
+  const requestedAt = Number(memorySync.requested_at ?? state?.last_memory_sync_trigger_at ?? 0);
+  const expiresAt = Number(memorySync.expires_at ?? 0);
+
+  if (requestedAt > 0 && now - requestedAt < cooldownSeconds) {
+    return {
+      shouldEnqueue: false,
+      reason: 'cooldown',
+      nextState: state ?? {},
+    };
+  }
+
+  if (
+    memorySync.status === 'requested' &&
+    requestedAt > 0 &&
+    (expiresAt > now || now - requestedAt < inFlightTtlSeconds)
+  ) {
+    return {
+      shouldEnqueue: false,
+      reason: 'sync_request_in_flight',
+      nextState: state ?? {},
+    };
+  }
+
+  return {
+    shouldEnqueue: true,
+    reason: 'eligible',
+    nextState: state ?? {},
+  };
+}
+
+export function markMemorySyncRequested({
+  state,
+  now,
+  unsummarizedCount,
+  pct,
+  thresholdPct,
+  inFlightTtlSeconds = DEFAULT_IN_FLIGHT_TTL_SECONDS,
+}) {
+  return {
+    ...(state ?? {}),
+    memory_sync: {
+      status: 'requested',
+      requested_at: now,
+      expires_at: now + inFlightTtlSeconds,
+      unsummarized_count: unsummarizedCount,
+      context_pct: pct,
+      session_switch_threshold_pct: thresholdPct,
+    },
+    // Legacy field kept for older readers of context-monitor-state.json.
+    last_memory_sync_trigger_at: now,
+  };
+}
+
+export function clearMemorySyncRequest(state) {
+  if (!state?.memory_sync && !state?.last_memory_sync_trigger_at) {
+    return state ?? {};
+  }
+
+  const nextState = { ...state };
+  delete nextState.memory_sync;
+  delete nextState.last_memory_sync_trigger_at;
+  return nextState;
+}

--- a/skills/activity-monitor/scripts/memory-sync-gate.js
+++ b/skills/activity-monitor/scripts/memory-sync-gate.js
@@ -1,4 +1,4 @@
-const DEFAULT_IN_FLIGHT_TTL_SECONDS = 3600;
+const DEFAULT_IN_FLIGHT_TTL_SECONDS = 1800;
 
 export function createMemorySyncControlPrompt({ pct, thresholdPct }) {
   return `Context usage at ${pct}% (approaching ${thresholdPct}% session-switch threshold). Run Memory Sync now as a background maintenance task so it completes before the session switch.

--- a/skills/activity-monitor/scripts/monitor.js
+++ b/skills/activity-monitor/scripts/monitor.js
@@ -568,7 +568,7 @@ function getTmuxActivity() {
 
 // CHECKPOINT_THRESHOLD imported from c4-config.js (single source of truth).
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
-const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 3600;  // 1 hour safety TTL for delivered-but-unacked sync prompts
+const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 1800;  // 30 min safety TTL for delivered-but-unacked sync prompts
 const CONTEXT_MONITOR_STATE_FILE = path.join(MONITOR_DIR, 'context-monitor-state.json');
 
 function getUnsummarizedCount() {

--- a/skills/activity-monitor/scripts/monitor.js
+++ b/skills/activity-monitor/scripts/monitor.js
@@ -568,7 +568,8 @@ function getTmuxActivity() {
 
 // CHECKPOINT_THRESHOLD imported from c4-config.js (single source of truth).
 const MEMORY_SYNC_COOLDOWN_SECONDS = 600;  // 10 min — prevent re-inject while sync is running
-let lastMemorySyncTriggerAt = 0;
+const MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS = 3600;  // 1 hour safety TTL for delivered-but-unacked sync prompts
+const CONTEXT_MONITOR_STATE_FILE = path.join(MONITOR_DIR, 'context-monitor-state.json');
 
 function getUnsummarizedCount() {
   try {
@@ -590,6 +591,25 @@ function runC4Control(args) {
     const stdout = err.stdout ? String(err.stdout).trim() : '';
     const stderr = err.stderr ? String(err.stderr).trim() : '';
     return { ok: false, output: stdout || stderr || err.message };
+  }
+}
+
+function loadContextMonitorState() {
+  try {
+    return JSON.parse(fs.readFileSync(CONTEXT_MONITOR_STATE_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveContextMonitorState(state) {
+  try {
+    if (!fs.existsSync(MONITOR_DIR)) {
+      fs.mkdirSync(MONITOR_DIR, { recursive: true });
+    }
+    atomicWriteJson(CONTEXT_MONITOR_STATE_FILE, state);
+  } catch (err) {
+    log(`Failed to write context monitor state: ${err.message}`);
   }
 }
 
@@ -932,11 +952,10 @@ function startContextMonitor(activeAdapter) {
   return startRuntimeContextMonitor(activeAdapter, {
     getUnsummarizedCount,
     checkpointThreshold: CHECKPOINT_THRESHOLD,
-    getLastMemorySyncTriggerAt: () => lastMemorySyncTriggerAt,
-    setLastMemorySyncTriggerAt: (nextValue) => {
-      lastMemorySyncTriggerAt = nextValue;
-    },
+    loadContextMonitorState,
+    saveContextMonitorState,
     memorySyncCooldownSeconds: MEMORY_SYNC_COOLDOWN_SECONDS,
+    memorySyncInFlightTtlSeconds: MEMORY_SYNC_IN_FLIGHT_TTL_SECONDS,
     c4ControlPath: C4_CONTROL_PATH,
     enqueueContextRotationHandoff,
     log,

--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -70,9 +70,7 @@ that in the handoff/status.
 
 Before starting Memory Sync, check for existing in-flight sync work: if the
 runtime exposes background-agent status, check it for a running sync subagent
-and do not start another sync writer while one is in flight. If a PM2-based
-sync was ever created by older instructions, treat stopped `memory-sync-*`
-entries as historical records and do not create replacements.
+and do not start another sync writer while one is in flight.
 
 ### Sync Flow
 

--- a/skills/zylos-memory/SKILL.md
+++ b/skills/zylos-memory/SKILL.md
@@ -42,6 +42,11 @@ This skill must be run via a runtime-appropriate background subagent mechanism. 
 Memory Sync is the highest-priority internal maintenance task.
 When triggered, run it before handling queued user messages.
 
+Memory Sync is maintenance-only. A sync subagent must not reply through C4,
+process user-facing tasks, modify business/project repositories, install or
+upgrade components, restart services, or apply runtime changes outside the
+sync flow below.
+
 ### Trigger Paths
 
 1. Session init: if C4 unsummarized count is over threshold, launch memory sync.
@@ -62,6 +67,12 @@ fork an extra `codex exec` sidecar: one-shot sync processes leave stopped
 services piling up in the PM2 list. If the session exposes no native
 background-agent capability, run the sync inline as a last resort and note
 that in the handoff/status.
+
+Before starting Memory Sync, check for existing in-flight sync work: if the
+runtime exposes background-agent status, check it for a running sync subagent
+and do not start another sync writer while one is in flight. If a PM2-based
+sync was ever created by older instructions, treat stopped `memory-sync-*`
+entries as historical records and do not create replacements.
 
 ### Sync Flow
 


### PR DESCRIPTION
## Summary

Port of #628 by @danielzhou82 (original authorship preserved on the commit), rebased onto current main. Fixes real duplicate-message reports from a production Codex deployment where the original patch kept getting wiped by upgrades.

- Add a shared, disk-persisted Memory Sync gate (`memory-sync-gate.js`) used by **both** trigger paths: Claude statusLine (`context-monitor.js`) and Codex polling monitor (`monitor.js` via `runtime-components.js` adapter)
- Persist requested/in-flight sync state to `~/zylos/activity-monitor/context-monitor-state.json` with a 1h TTL and legacy-timestamp compatibility — replaces the Codex path's in-memory cooldown that reset on every monitor restart (root cause of #626 recurring)
- Sync control prompt now instructs "exactly one background subagent" and embeds the maintenance-only constraint (no C4 replies, no user-facing tasks, no repo/component/service changes) — fixes #627
- `skills/zylos-memory/SKILL.md`: add the maintenance-only paragraph + in-flight-check guidance

## Adaptations from the original #628 (main moved since June)

- `context-monitor.js`: kept `CHECKPOINT_THRESHOLD` import from `c4-config.js` (single source of truth introduced by #674) instead of the original's local threshold
- Template changes (`templates/CLAUDE.md`, `claude-addon.md`, `codex-addon.md`, `ZYLOS.md`): **dropped** — the #723 split-layer restructure removed/replaced these files and centralized Memory Sync launch instructions into `skills/zylos-memory/SKILL.md`, so the isolation constraint now lives there (single source) and in the gate's generated control prompt
- `skills/zylos-memory/SKILL.md` Codex section: kept main's stricter no-PM2 wording, adapted the original's in-flight-check paragraph to it

## Tests

- Root suite: 838/838 pass
- `skills/activity-monitor`: 339/339 pass (includes the new `memory-sync-gate.test.js`)

Fixes #626.
Fixes #627.
Closes #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)