### PR TITLE
fix: actionable Codex CLI version error when hooks/list lacks currentHash (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Actionable error for Codex CLI versions without `currentHash`**: on Codex CLI ≤ 0.128.0, `hooks/list` does not report `currentHash` (field added in 0.129.0), so the hook trust gate found zero trustable hooks and failed with an opaque `empty_trust_snapshot` error. The trust helper now counts candidate hooks and missing hashes, and the gate reports a clear `missing_current_hash` error naming the detected Codex version and the minimum supported one (0.129.0+, 0.146+ recommended). Behavior stays fail-closed: no hash-less trust downgrade. (#752)
+
 ## [0.7.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supports Claude Code (Anthropic) and Codex (OpenAI). Fully compatible with the [
 
 ## Quick Start
 
-**Prerequisites:** A Linux server (or Mac), a [Claude](https://claude.ai) subscription (or [OpenAI Codex](https://github.com/openai/codex) as an alternative runtime).
+**Prerequisites:** A Linux server (or Mac), a [Claude](https://claude.ai) subscription (or [OpenAI Codex](https://github.com/openai/codex) as an alternative runtime — Codex CLI v0.129.0+ required, 0.146+ recommended).
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash

--- a/cli/lib/__tests__/codex-hooks.test.js
+++ b/cli/lib/__tests__/codex-hooks.test.js
@@ -445,6 +445,12 @@ describe('Codex hook trust backstop', () => {
       ...(withHash ? { currentHash: `sha256:hash-${i}` } : {}),
     });
 
+    // Non-candidates: managed and keyless hooks must be excluded from every count.
+    const makeNonCandidates = (withHash) => [
+      { ...makeHook(90, withHash), isManaged: true },
+      (({ key, ...rest }) => rest)(makeHook(91, withHash)),
+    ];
+
     const writeFakeCodexBin = (name, hooks) => {
       const stubPath = path.join(root, name);
       fs.writeFileSync(stubPath, [
@@ -474,8 +480,14 @@ describe('Codex hook trust backstop', () => {
       return stubPath;
     };
 
-    const hashlessBin = writeFakeCodexBin('fake-codex-no-hash.js', [0, 1, 2].map(i => makeHook(i, false)));
-    const hashedBin = writeFakeCodexBin('fake-codex-with-hash.js', [0, 1, 2].map(i => makeHook(i, true)));
+    const hashlessBin = writeFakeCodexBin('fake-codex-no-hash.js', [
+      ...[0, 1, 2].map(i => makeHook(i, false)),
+      ...makeNonCandidates(false),
+    ]);
+    const hashedBin = writeFakeCodexBin('fake-codex-with-hash.js', [
+      ...[0, 1, 2].map(i => makeHook(i, true)),
+      ...makeNonCandidates(true),
+    ]);
 
     const missing = trustCodexHooksWithAppServer({ zylosDir, codexBin: hashlessBin });
     assert.equal(missing.ok, true);

--- a/cli/lib/__tests__/codex-hooks.test.js
+++ b/cli/lib/__tests__/codex-hooks.test.js
@@ -18,6 +18,7 @@ import {
   installCoreCodexHook,
   isCodexTrustValid,
   readHooksState,
+  trustCodexHooksWithAppServer,
   uninstallCoreCodexHook,
 } from '../codex-hooks.js';
 
@@ -385,5 +386,107 @@ describe('Codex hook trust backstop', () => {
       }),
       /Codex hook trust failed \(empty_trust_snapshot\)/
     );
+  });
+
+  it('reports actionable version guidance when hooks/list omits currentHash (issue #752)', () => {
+    const { homeDir, zylosDir } = makeEnv();
+    installCoreCodexHook({ zylosDir });
+
+    assert.throws(
+      () => ensureCodexHooksTrusted({
+        zylosDir,
+        projectDir: zylosDir,
+        homeDir,
+        execFileSyncImpl: () => 'codex-cli 0.128.0\n',
+        spawnSyncImpl: () => ({
+          status: 0,
+          stdout: JSON.stringify({ ok: true, trusted: 0, candidates: 14, missingHash: 14 }) + '\n',
+          stderr: '',
+        }),
+      }),
+      (error) => {
+        assert.match(error.message, /missing_current_hash/);
+        assert.match(error.message, /0\.128\.0/);
+        assert.match(error.message, /0\.129\.0/);
+        return true;
+      }
+    );
+  });
+
+  it('keeps empty_trust_snapshot for zero-candidate results without missing hashes', () => {
+    const { homeDir, zylosDir } = makeEnv();
+    installCoreCodexHook({ zylosDir });
+
+    assert.throws(
+      () => ensureCodexHooksTrusted({
+        zylosDir,
+        projectDir: zylosDir,
+        homeDir,
+        execFileSyncImpl: () => 'codex-cli 0.142.2\n',
+        spawnSyncImpl: () => ({
+          status: 0,
+          stdout: JSON.stringify({ ok: true, trusted: 0, candidates: 0, missingHash: 0 }) + '\n',
+          stderr: '',
+        }),
+      }),
+      /Codex hook trust failed \(empty_trust_snapshot\)/
+    );
+  });
+
+  it('counts candidates and missing currentHash through the real trust helper against a stub app-server', () => {
+    const { root, zylosDir } = makeEnv();
+
+    const makeHook = (i, withHash) => ({
+      key: `/tmp/hooks.json:session_start:0:${i}`,
+      eventName: 'SessionStart',
+      command: ['node', `/tmp/hook-${i}.js`],
+      enabled: true,
+      isManaged: false,
+      ...(withHash ? { currentHash: `sha256:hash-${i}` } : {}),
+    });
+
+    const writeFakeCodexBin = (name, hooks) => {
+      const stubPath = path.join(root, name);
+      fs.writeFileSync(stubPath, [
+        '#!/usr/bin/env node',
+        `const HOOKS = ${JSON.stringify(hooks)};`,
+        "let buf = '';",
+        'process.stdin.on(\'data\', chunk => {',
+        '  buf += chunk.toString();',
+        "  const lines = buf.split('\\n');",
+        '  buf = lines.pop();',
+        '  for (const line of lines) {',
+        '    if (!line.trim()) continue;',
+        '    let msg;',
+        '    try { msg = JSON.parse(line); } catch { continue; }',
+        '    if (msg.id === undefined) continue;',
+        "    if (msg.method === 'initialize') {",
+        "      process.stdout.write(JSON.stringify({ id: msg.id, result: {} }) + '\\n');",
+        "    } else if (msg.method === 'hooks/list') {",
+        "      process.stdout.write(JSON.stringify({ id: msg.id, result: { data: [{ hooks: HOOKS }] } }) + '\\n');",
+        "    } else if (msg.method === 'config/batchWrite') {",
+        "      process.stdout.write(JSON.stringify({ id: msg.id, result: { status: 'ok' } }) + '\\n');",
+        '    }',
+        '  }',
+        '});',
+        '',
+      ].join('\n'), { mode: 0o755 });
+      return stubPath;
+    };
+
+    const hashlessBin = writeFakeCodexBin('fake-codex-no-hash.js', [0, 1, 2].map(i => makeHook(i, false)));
+    const hashedBin = writeFakeCodexBin('fake-codex-with-hash.js', [0, 1, 2].map(i => makeHook(i, true)));
+
+    const missing = trustCodexHooksWithAppServer({ zylosDir, codexBin: hashlessBin });
+    assert.equal(missing.ok, true);
+    assert.equal(missing.trusted, 0);
+    assert.equal(missing.candidates, 3);
+    assert.equal(missing.missingHash, 3);
+
+    const present = trustCodexHooksWithAppServer({ zylosDir, codexBin: hashedBin });
+    assert.equal(present.ok, true);
+    assert.equal(present.trusted, 3);
+    assert.equal(present.candidates, 3);
+    assert.equal(present.missingHash, 0);
   });
 });

--- a/cli/lib/codex-hooks.js
+++ b/cli/lib/codex-hooks.js
@@ -356,6 +356,8 @@ let stderr = '';
 let nextId = 0;
 let finished = false;
 let trustedCount = 0;
+let candidateCount = 0;
+let missingHashCount = 0;
 
 function send(method, params) {
   const id = nextId++;
@@ -415,7 +417,12 @@ app.stdout.on('data', chunk => {
       const state = {};
       for (const entry of msg.result?.data || []) {
         for (const hook of entry.hooks || []) {
-          if (hook.isManaged || !hook.key || !hook.currentHash) continue;
+          if (hook.isManaged || !hook.key) continue;
+          candidateCount++;
+          if (!hook.currentHash) {
+            missingHashCount++;
+            continue;
+          }
           state[hook.key] = { enabled: true, trusted_hash: hook.currentHash };
         }
       }
@@ -437,7 +444,13 @@ app.stdout.on('data', chunk => {
       if (msg.error) {
         finish({ ok: false, reason: 'config_batch_write_error', error: msg.error });
       } else {
-        finish({ ok: true, trusted: trustedCount, status: msg.result?.status || 'ok' });
+        finish({
+          ok: true,
+          trusted: trustedCount,
+          candidates: candidateCount,
+          missingHash: missingHashCount,
+          status: msg.result?.status || 'ok'
+        });
       }
     }
   }
@@ -501,6 +514,13 @@ export function ensureCodexHooksTrusted({
   const trust = trustCodexHooksWithAppServer({ zylosDir, codexBin, spawnSyncImpl });
   if (!trust.ok) {
     throw new Error(`Codex hook trust failed (${trust.reason || 'unknown'}). Native SessionStart bootstrap may not run.`);
+  }
+  if (trust.trusted === 0 && trust.missingHash > 0) {
+    throw new Error(
+      `Codex hook trust failed (missing_current_hash): Codex CLI "${codexVersion}" does not report currentHash in hooks/list ` +
+      '(field added in Codex CLI 0.129.0). Upgrade Codex CLI to 0.129.0 or later (0.146+ recommended). ' +
+      'Native SessionStart bootstrap may not run.'
+    );
   }
 
   const hooksPath = codexHooksPath(zylosDir);


### PR DESCRIPTION
Fixes #752.

## Problem

On Codex CLI ≤ 0.128.0, `hooks/list` does not report `currentHash` — the field was added in rust-v0.129.0 (2026-05-07); the hooks engine itself dates to rust-v0.114.0 (2026-03-11), so 0.114.0–0.128.0 is the affected window. The trust helper's filter (`!hook.currentHash`) therefore dropped every hook, and `ensureCodexHooksTrusted` failed with an opaque `empty_trust_snapshot` error that gave the operator no clue the Codex version was the cause.

## Verification evidence (two independent machines)

- **luna.coco** (DGX, Codex 0.146.1): confirmed via the official rust-v0.128.0 `HookMetadata` schema that `currentHash` is genuinely absent in that version; present in 0.146.1 with no repro there. KB node `01a0000e-08b7-7ea2-9c21-da643259e4d4`.
- **jinglever** (macOS): ran the real 0.128.0 binary — `hooks/list` returned `currentHash` 0/14 against sibling fields 14/14; the installed filter dropped all 14 hooks and sandboxed `ensureCodexHooksTrusted` threw `empty_trust_snapshot`. Same-host 0.147.0 positive control: 14/14 with hashes, no error. KB node `01a00014-bdf0-724b-aff0-9bf1d34fd3fb`.
- Full verification write-up: https://github.com/zylos-ai/zylos-core/issues/752#issuecomment-5292906991

## Fix (direction approved by Howard: keep fail-closed, no hash-less trust)

- Trust helper now counts `candidates` (non-managed hooks with a key) and `missingHash` (candidates lacking `currentHash`) and returns both alongside `trusted`.
- `ensureCodexHooksTrusted`: when the helper succeeds but `trusted === 0 && missingHash > 0`, throw an actionable `missing_current_hash` error naming the detected Codex version and the minimum supported one (0.129.0+, 0.146+ recommended), instead of falling through to `empty_trust_snapshot`.
- `empty_trust_snapshot` remains as the backstop for genuinely-empty results not caused by missing hashes.
- README: Codex prerequisite now states the minimum version.
- CHANGELOG: entry under `## [Unreleased]` (no version bump — release PRs own that).

## Tests

- Mocked ensure-level: `{trusted:0, candidates:14, missingHash:14}` + version `0.128.0` → throws `missing_current_hash` naming 0.128.0 and 0.129.0.
- Negative control: `{trusted:0, candidates:0, missingHash:0}` → still `empty_trust_snapshot` (the two failure paths stay distinct).
- Discriminating real-helper test: real `spawnSync` drives the actual embedded helper against an executable stub app-server speaking the stdio protocol (initialize → hooks/list → config/batchWrite); asserts `{trusted:0, candidates:3, missingHash:3}` for hash-less hooks and `{trusted:3, missingHash:0}` for the positive control.
- Full suite green: Jest 150/150, Node 853/853 (850 baseline + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)