### PR TITLE
feat(scheduler): list --json structured output + --reply-channel filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Structured scheduler CLI output**: `scheduler cli.js list --json` emits a JSON array of full task rows (untruncated `id`, `type`, `status`, `last_error`, `reply_channel`, `reply_endpoint`, `next_run_at`, ...), and `--reply-channel <ch>` filters rows in both human and JSON modes. Human output is unchanged by default. Gives components a supported machine-readable interface to the scheduler ledger instead of parsing human tables or reading the DB. (#761)
+
 ### Fixed
 - **Actionable error for Codex CLI versions without `currentHash`**: on Codex CLI ≤ 0.128.0, `hooks/list` does not report `currentHash` (field added in 0.129.0), so the hook trust gate found zero trustable hooks and failed with an opaque `empty_trust_snapshot` error. The trust helper now counts candidate hooks and missing hashes, and the gate reports a clear `missing_current_hash` error naming the detected Codex version and the minimum supported one (0.129.0+, 0.146+ recommended). Behavior stays fail-closed: no hash-less trust downgrade. (#752)
 

--- a/skills/scheduler/references/query.md
+++ b/skills/scheduler/references/query.md
@@ -2,9 +2,12 @@
 
 ## list
 
-`cli.js list`
+`cli.js list [--json] [--reply-channel "<ch>"]`
 
-Shows all active tasks (excluding completed one-time tasks). Displays TZ header, sorted by priority then next run time.
+Shows all active tasks (excluding completed one-time tasks; failed one-time tasks remain visible). Displays TZ header, sorted by priority then next run time.
+
+- `--json` — machine-readable output: a JSON array of full task rows (untruncated `id`, `type`, `status`, `last_error`, `reply_channel`, `reply_endpoint`, `next_run_at`, and all other columns). Outputs `[]` when no tasks match.
+- `--reply-channel "<ch>"` — only tasks whose reply channel equals `<ch>` exactly. Works with or without `--json`.
 
 ## next
 
@@ -26,6 +29,8 @@ Shows the 20 most recent execution history entries. Optionally filter by task ID
 
 ```bash
 cli.js list
+cli.js list --json
+cli.js list --json --reply-channel multica
 cli.js next
 cli.js running
 cli.js history

--- a/skills/scheduler/scripts/__tests__/cli.test.js
+++ b/skills/scheduler/scripts/__tests__/cli.test.js
@@ -199,15 +199,22 @@ describe('cli list', () => {
   });
 
   it('--json outputs full task rows as a JSON array', () => {
-    withTmpDir(({ env }) => {
+    withTmpDir(({ dbPath, env }) => {
       cli(['add', 'json task', '--in', '30 minutes', '--reply-channel', 'multica', '--reply-endpoint', 'task-abc-123'], env);
+      const db = new Database(dbPath);
+      let expectedId;
+      try {
+        expectedId = db.prepare('SELECT id FROM tasks LIMIT 1').get().id;
+      } finally {
+        db.close();
+      }
       const output = cli(['list', '--json'], env);
       const rows = JSON.parse(output);
       assert.equal(rows.length, 1);
       const row = rows[0];
       // Full untruncated id plus every field the machine contract requires
-      assert.match(row.id, /^task-/);
-      assert.ok(row.id.length > 14);
+      assert.match(expectedId, /^task-/);
+      assert.equal(row.id, expectedId);
       assert.equal(row.type, 'one-time');
       assert.equal(row.status, 'pending');
       assert.equal(row.reply_channel, 'multica');

--- a/skills/scheduler/scripts/__tests__/cli.test.js
+++ b/skills/scheduler/scripts/__tests__/cli.test.js
@@ -197,6 +197,65 @@ describe('cli list', () => {
       assert.ok(output.includes('task one'));
     });
   });
+
+  it('--json outputs full task rows as a JSON array', () => {
+    withTmpDir(({ env }) => {
+      cli(['add', 'json task', '--in', '30 minutes', '--reply-channel', 'multica', '--reply-endpoint', 'task-abc-123'], env);
+      const output = cli(['list', '--json'], env);
+      const rows = JSON.parse(output);
+      assert.equal(rows.length, 1);
+      const row = rows[0];
+      // Full untruncated id plus every field the machine contract requires
+      assert.match(row.id, /^task-/);
+      assert.ok(row.id.length > 14);
+      assert.equal(row.type, 'one-time');
+      assert.equal(row.status, 'pending');
+      assert.equal(row.reply_channel, 'multica');
+      assert.equal(row.reply_endpoint, 'task-abc-123');
+      assert.equal(typeof row.next_run_at, 'number');
+      assert.ok('last_error' in row);
+    });
+  });
+
+  it('--json outputs [] when no tasks match', () => {
+    withTmpDir(({ env }) => {
+      const rows = JSON.parse(cli(['list', '--json'], env));
+      assert.deepEqual(rows, []);
+    });
+  });
+
+  it('--reply-channel filters rows in both output modes', () => {
+    withTmpDir(({ env }) => {
+      cli(['add', 'multica task', '--in', '30 minutes', '--reply-channel', 'multica', '--reply-endpoint', 'task-1'], env);
+      cli(['add', 'telegram task', '--in', '30 minutes', '--reply-channel', 'telegram', '--reply-endpoint', '123'], env);
+      cli(['add', 'no channel task', '--in', '30 minutes'], env);
+
+      const rows = JSON.parse(cli(['list', '--json', '--reply-channel', 'multica'], env));
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].reply_channel, 'multica');
+
+      const human = cli(['list', '--reply-channel', 'multica'], env);
+      assert.ok(human.includes('multica task'));
+      assert.ok(!human.includes('telegram task'));
+      assert.ok(!human.includes('no channel task'));
+    });
+  });
+
+  it('--json still includes failed one-time tasks', () => {
+    withTmpDir(({ dbPath, env }) => {
+      cli(['add', 'will fail', '--in', '30 minutes', '--reply-channel', 'multica', '--reply-endpoint', 'task-9'], env);
+      const db = new Database(dbPath);
+      try {
+        db.prepare(`UPDATE tasks SET status = 'failed', last_error = 'Missed execution window'`).run();
+      } finally {
+        db.close();
+      }
+      const rows = JSON.parse(cli(['list', '--json', '--reply-channel', 'multica'], env));
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].status, 'failed');
+      assert.equal(rows[0].last_error, 'Missed execution window');
+    });
+  });
 });
 
 describe('cli done', () => {

--- a/skills/scheduler/scripts/cli.js
+++ b/skills/scheduler/scripts/cli.js
@@ -27,7 +27,7 @@ Task CLI - Scheduler V2
 Usage: ~/zylos/.claude/skills/scheduler/scripts/cli.js <command> [options]
 
 Commands:
-  list                    List all tasks
+  list [options]          List all tasks
   add <prompt> [options]  Add a new task
   update <task-id> [options]  Update an existing task
   remove <task-id>        Remove a task
@@ -37,6 +37,12 @@ Commands:
   history [task-id]       Show execution history
   next                    Show upcoming tasks
   running                 Show currently running tasks
+
+List Options:
+  --json                  Machine-readable output: JSON array of full task rows
+                          (untruncated id, type, status, last_error, reply_channel,
+                          reply_endpoint, next_run_at, ...)
+  --reply-channel "<ch>"  Only tasks with this reply channel (works with or without --json)
 
 Add Options:
   --in "<duration>"       One-time: run in X time (e.g., "30 minutes")
@@ -83,7 +89,8 @@ function parseArgs(args) {
     'no-block-queue-until-idle',
     'require-idle',
     'no-require-idle',
-    'clear-reply'
+    'clear-reply',
+    'json'
   ]);
 
   let i = 1;
@@ -114,13 +121,24 @@ function parseArgs(args) {
 
 // ===== Commands =====
 
-function cmdList() {
+function cmdList(options = {}) {
   // Show all active tasks including failed ones (so user can see what timed out)
-  const tasks = db.prepare(`
+  let sql = `
     SELECT * FROM tasks
-    WHERE status != 'completed' OR type != 'one-time'
-    ORDER BY priority ASC, next_run_at ASC
-  `).all();
+    WHERE (status != 'completed' OR type != 'one-time')
+  `;
+  const params = [];
+  if (options['reply-channel']) {
+    sql += ` AND reply_channel = ?`;
+    params.push(options['reply-channel']);
+  }
+  sql += ` ORDER BY priority ASC, next_run_at ASC`;
+  const tasks = db.prepare(sql).all(...params);
+
+  if (options.json) {
+    console.log(JSON.stringify(tasks, null, 2));
+    return;
+  }
 
   if (tasks.length === 0) {
     console.log('No tasks scheduled.');
@@ -688,7 +706,7 @@ function main() {
 
   switch (command) {
     case 'list':
-      cmdList();
+      cmdList(options);
       break;
     case 'add':
       cmdAdd(args, options);


### PR DESCRIPTION
## Summary

Implements #761 (minimal cut, per the scope comment on the issue):

- `cli.js list --json` — emits a JSON array of full task rows: untruncated `id`, `type`, `status`, `last_error`, `reply_channel`, `reply_endpoint`, `next_run_at`, plus all other columns (`SELECT *` fidelity).
- `cli.js list --reply-channel <ch>` — filters by the `reply_channel` column; works with and without `--json`.
- Human output unchanged by default; `--json` is additive. Empty result under `--json` prints `[]` (valid JSON), not the human empty-list message.
- Row visibility semantics unchanged: same WHERE as the human list (completed one-time tasks hidden; failed one-time tasks included — the reconciliation consumer's key case).

## Motivation

zylos-multica's due-date reconciliation (zylos-ai/zylos-multica solution.md §4.3) needs a supported machine-readable way to enumerate its own one-time tasks and read terminal state, without parsing human tables, importing scheduler-internal modules, or opening the DB. This flag is that contract.

## Tests

4 new tests in `__tests__/cli.test.js` (json fields incl. untruncated id, empty-array case, reply-channel filter in both modes, failed one-time row with `last_error` visible). Full scheduler suite: 100/100 pass.

## Release

No version bump (feature PR; CHANGELOG under Unreleased per convention). No deploy.

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)