### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to zylos-core will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.1] - 2026-08-18
 
 ### Added
 - **Structured scheduler CLI output**: `scheduler cli.js list --json` emits a JSON array of full task rows (untruncated `id`, `type`, `status`, `last_error`, `reply_channel`, `reply_endpoint`, `next_run_at`, ...), and `--reply-channel <ch>` filters rows in both human and JSON modes. Human output is unchanged by default. Gives components a supported machine-readable interface to the scheduler ledger instead of parsing human tables or reading the DB. (#761)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "description": "Autonomous AI Agent Infrastructure",
   "main": "cli/zylos.js",


### PR DESCRIPTION
Release v0.7.1 — patch release authorized by Howard (TG, 2026-08-18).

Delta since v0.7.0:
- **Added**: `scheduler list --json` structured output + `--reply-channel` filter (#761, PR #762) — supported machine-readable scheduler interface, hard prerequisite for zylos-multica v0.1.0.
- **Fixed**: actionable Codex CLI version error when `hooks/list` lacks `currentHash` (#752, PR #759).

Mechanical version bump only: package.json + package-lock.json 0.7.0 → 0.7.1, CHANGELOG Unreleased → [0.7.1] - 2026-08-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)