### PR TITLE
feat(codex): add named OrcaRouter provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Automatically when no TTY is available — e.g. Docker containers (without `-it`
 | `--setup-token <token>` | Claude [setup token](https://code.claude.com/docs/en/authentication) (starts with `sk-ant-oat`) | — |
 | `--api-key <key>` | Anthropic API key (starts with `sk-ant-`) | — |
 | `--codex-api-key <key>` | OpenAI API key for Codex runtime (starts with `sk-`) | — |
+| `--codex-provider <name>` | Named Codex provider preset: `orcarouter` | — |
 | `--base-url <url>` | Custom API base URL for Claude Code | — |
 | `--codex-base-url <url>` | Custom API base URL for Codex | — |
 | `--timezone <tz>` | [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. `Asia/Shanghai`, `America/New_York`, `Europe/London` | System default |
@@ -91,6 +92,7 @@ Flags can also be set via environment variables during `zylos init`. Resolution 
 | `ANTHROPIC_BASE_URL` | `--base-url` |
 | `OPENAI_API_KEY` | `--codex-api-key` |
 | `OPENAI_BASE_URL` | `--codex-base-url` |
+| `ORCAROUTER_API_KEY` | `--codex-provider orcarouter` (API key) |
 | `ZYLOS_DOMAIN` | `--domain` |
 | `ZYLOS_PROTOCOL` (`https` or `http`) | `--https` / `--no-https` |
 | `ZYLOS_WEB_PASSWORD` | `--web-password` |
@@ -286,6 +288,22 @@ Other frameworks charge per API token. Community reports show monthly bills of $
 ### Powered by Best-in-Class AI Runtimes
 
 Zylos supports Claude Code (Anthropic) and Codex (OpenAI) as interchangeable AI runtimes. Start with one, switch to the other anytime with `zylos runtime codex` — your memory, skills, and channels are preserved. When AI providers ship new capabilities, your agent benefits automatically. And because both runtimes can program, your AI writes new skills, integrates services, and evolves with your needs.
+
+### Codex Runtime on [OrcaRouter](https://www.orcarouter.ai)
+
+The Codex runtime can also be pointed at [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible AI gateway. Pass a single named provider flag and your OrcaRouter API key — Zylos wires the Codex runtime to `https://api.orcarouter.ai/v1` and verifies the key against it.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash -s -- -y --runtime codex --codex-provider orcarouter --codex-api-key sk-orca-...
+```
+
+Or via environment variables:
+
+```bash
+ORCAROUTER_API_KEY=sk-orca-... zylos init --runtime codex --codex-provider orcarouter
+```
+
+The gateway supports a single endpoint with multiple model families (OpenAI, Anthropic, Google, DeepSeek and more), so the Codex runtime can switch models without changing configuration.
 
 ---
 

--- a/cli/commands/init.js
+++ b/cli/commands/init.js
@@ -445,14 +445,21 @@ function verifyApiKey(apiKey) {
 
 /**
  * Verify an OpenAI API key by making a lightweight GET request to /v1/models.
+ * Uses the configured Codex base URL when provided (e.g. an OpenAI-compatible
+ * gateway preset), so a key is verified against the endpoint it will actually
+ * be used with.
  * @param {string} apiKey - The OpenAI API key (sk-...)
+ * @param {string} baseUrl - Codex base URL override (optional, default api.openai.com)
  * @returns {Promise<true|false|null>} true=valid (200), false=invalid (401), null=network error
  */
-function verifyCodexApiKey(apiKey) {
+function verifyCodexApiKey(apiKey, baseUrl) {
+  const url = new URL('/v1/models', baseUrl || 'https://api.openai.com');
+  const hostname = url.hostname;
+  const pathWithQuery = url.pathname + url.search;
   return new Promise((resolve) => {
     const req = https.request({
-      hostname: 'api.openai.com',
-      path: '/v1/models',
+      hostname,
+      path: pathWithQuery,
       method: 'GET',
       headers: { 'Authorization': `Bearer ${apiKey}` },
       timeout: 10000,
@@ -1636,6 +1643,7 @@ export function parseInitFlags(args) {
     setupToken: null,
     apiKey: null,
     codexApiKey: null,
+    codexProvider: null, // named provider preset for Codex runtime (e.g. 'orcarouter')
     baseUrl: null,
     codexBaseUrl: null,
     domain: null,
@@ -1666,6 +1674,7 @@ export function parseInitFlags(args) {
       case '--setup-token':
       case '--api-key':
       case '--codex-api-key':
+      case '--codex-provider':
       case '--base-url':
       case '--codex-base-url':
       case '--domain':
@@ -1680,6 +1689,7 @@ export function parseInitFlags(args) {
         else if (arg === '--setup-token') opts.setupToken = val;
         else if (arg === '--api-key') opts.apiKey = val;
         else if (arg === '--codex-api-key') opts.codexApiKey = val;
+        else if (arg === '--codex-provider') opts.codexProvider = val;
         else if (arg === '--base-url') opts.baseUrl = val;
         else if (arg === '--codex-base-url') opts.codexBaseUrl = val;
         else if (arg === '--domain') opts.domain = val;
@@ -1733,6 +1743,9 @@ export function resolveFromEnv(opts) {
   if (opts.codexApiKey === null && (process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY)) {
     opts.codexApiKey = process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY;
   }
+  if (opts.codexProvider === null && process.env.CODEX_PROVIDER) {
+    opts.codexProvider = process.env.CODEX_PROVIDER;
+  }
   if (opts.baseUrl === null && process.env.ANTHROPIC_BASE_URL) {
     opts.baseUrl = process.env.ANTHROPIC_BASE_URL;
   }
@@ -1743,6 +1756,44 @@ export function resolveFromEnv(opts) {
   // Docker containers often have TZ=UTC set by default, which would silently
   // overwrite user-configured timezones on re-init. Only --timezone flag applies.
   // The auto-detect in configureTimezone() will handle the default case.
+}
+
+/**
+ * Named Codex provider presets.
+ *
+ * A preset is a curated OpenAI-compatible gateway that users can opt into by
+ * name instead of hand-wiring `--codex-base-url` + an API key. Selecting a
+ * preset resolves the gateway base URL and its API key source so the rest of
+ * the Codex setup path works unchanged.
+ *
+ * @type {Record<string, { name: string, baseUrl: string, apiKeyEnv: string }>}
+ */
+export const CODEX_PROVIDER_PRESETS = {
+  orcarouter: {
+    name: 'OrcaRouter',
+    baseUrl: 'https://api.orcarouter.ai/v1',
+    apiKeyEnv: 'ORCAROUTER_API_KEY',
+  },
+};
+
+/**
+ * Apply a named Codex provider preset, resolving its base URL and API key.
+ *
+ * Mutates `opts` in place. Explicit flags always win over the preset — a preset
+ * only fills base URL / API key that the user did not already provide.
+ *
+ * @param {object} opts - Parsed init options (mutated in place)
+ */
+export function resolveProviderPresets(opts) {
+  if (!opts.codexProvider) return;
+  const preset = CODEX_PROVIDER_PRESETS[opts.codexProvider];
+  if (!preset) return;
+  if (opts.codexBaseUrl === null) {
+    opts.codexBaseUrl = preset.baseUrl;
+  }
+  if (opts.codexApiKey === null && process.env[preset.apiKeyEnv]) {
+    opts.codexApiKey = process.env[preset.apiKeyEnv];
+  }
 }
 
 export function validateInitOptions(opts) {
@@ -1767,6 +1818,12 @@ export function validateInitOptions(opts) {
   // Runtime validation
   if (opts.runtime && !['claude', 'codex'].includes(opts.runtime)) {
     return `Invalid runtime: "${opts.runtime}".\n  Supported: claude, codex\n  Example: zylos init --runtime codex`;
+  }
+
+  // Named Codex provider preset validation
+  if (opts.codexProvider && !CODEX_PROVIDER_PRESETS[opts.codexProvider]) {
+    const available = Object.keys(CODEX_PROVIDER_PRESETS).join(', ');
+    return `Invalid Codex provider: "${opts.codexProvider}".\n  Available: ${available}\n  Example: zylos init --runtime codex --codex-provider orcarouter`;
   }
 
   // Timezone validation
@@ -1813,6 +1870,7 @@ Options:
   --setup-token <token>      Authenticate with Claude setup token
   --api-key <key>            Authenticate with Anthropic API key
   --codex-api-key <key>      Authenticate Codex with OpenAI API key (sk-...)
+  --codex-provider <name>    Named Codex provider preset (orcarouter)
   --base-url <url>           Custom API base URL for Claude Code
   --codex-base-url <url>     Custom API base URL for Codex
   --domain <domain>          Configure Caddy with this domain
@@ -1827,7 +1885,8 @@ Non-interactive mode:
 
 Environment variables:
   CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, ZYLOS_RUNTIME,
-  OPENAI_API_KEY (or CODEX_API_KEY), ZYLOS_DOMAIN, ZYLOS_PROTOCOL, ZYLOS_WEB_PASSWORD
+  OPENAI_API_KEY (or CODEX_API_KEY), ORCAROUTER_API_KEY, ZYLOS_DOMAIN,
+  ZYLOS_PROTOCOL, ZYLOS_WEB_PASSWORD
 
   Resolution: CLI flag > env var > .env/config.json > interactive prompt
 
@@ -1850,6 +1909,11 @@ export async function initCommand(args) {
 
   // Resolve from environment variables
   resolveFromEnv(opts);
+
+  // Apply named provider presets (e.g. --codex-provider orcarouter) before
+  // validation so a preset's base URL / API key flow through the same path
+  // as explicit flags.
+  resolveProviderPresets(opts);
 
   // Validate options
   const validationErr = validateInitOptions(opts);
@@ -2033,7 +2097,7 @@ export async function initCommand(args) {
         // Do NOT save before verifying: a bad key in process.env causes isCodexAuthenticated()
         // to report "authenticated" even when the key is invalid (path 1 check is existence-only).
         if (!quiet) console.log(`  ${dim('Verifying Codex API key...')}`);
-        const verifyResult = await verifyCodexApiKey(opts.codexApiKey);
+        const verifyResult = await verifyCodexApiKey(opts.codexApiKey, pendingCodexBaseUrl || undefined);
         if (verifyResult === true) {
           if (saveCodexApiKey(opts.codexApiKey)) {
             codexAuthenticated = true;

--- a/cli/commands/runtime.js
+++ b/cli/commands/runtime.js
@@ -6,6 +6,7 @@
  *   zylos runtime status                        Show the currently configured runtime
  *   zylos runtime <name> --save-apikey <key>    Save API key and switch (all runtimes)
  *   zylos runtime <name> --save-base-url <url>  Save base URL and switch
+ *   zylos runtime codex --provider <name>       Apply a named provider preset (e.g. orcarouter)
  *   zylos runtime claude --save-setup-token <t> Save Claude setup token and switch
  *   zylos runtime <name> --no-validate          Skip switch-time auth probe
  */
@@ -32,6 +33,7 @@ import {
   saveCodexApiKeyToEnv,
   writeCodexConfig,
 } from '../lib/runtime-setup.js';
+import { CODEX_PROVIDER_PRESETS } from './init.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -132,14 +134,17 @@ export function parseRuntimeFlags(flags) {
   const apiKeyIdx = flags.indexOf('--save-apikey');
   const setupTokenIdx = flags.indexOf('--save-setup-token');
   const baseUrlIdx = flags.indexOf('--save-base-url');
+  const providerIdx = flags.indexOf('--provider');
 
   return {
     apiKey: apiKeyIdx >= 0 ? flags[apiKeyIdx + 1] : null,
     setupToken: setupTokenIdx >= 0 ? flags[setupTokenIdx + 1] : null,
     baseUrl: baseUrlIdx >= 0 ? flags[baseUrlIdx + 1] : null,
+    provider: providerIdx >= 0 ? flags[providerIdx + 1] : null,
     hasApiKey: apiKeyIdx >= 0,
     hasSetupToken: setupTokenIdx >= 0,
     hasBaseUrl: baseUrlIdx >= 0,
+    hasProvider: providerIdx >= 0,
     noValidate: flags.includes('--no-validate'),
   };
 }
@@ -173,6 +178,25 @@ export function validateRuntimeFlags(target, parsed) {
       example: target === 'codex'
         ? 'zylos runtime codex --save-base-url https://proxy.example.com/v1'
         : 'zylos runtime claude --save-base-url https://claude-proxy.example.com',
+    };
+  }
+  if (parsed.hasProvider && (!parsed.provider || parsed.provider.startsWith('--'))) {
+    return {
+      error: 'Missing value for --provider.',
+      example: 'zylos runtime codex --provider orcarouter',
+    };
+  }
+  if (parsed.provider && !CODEX_PROVIDER_PRESETS[parsed.provider]) {
+    const available = Object.keys(CODEX_PROVIDER_PRESETS).join(', ');
+    return {
+      error: `Unknown provider: "${parsed.provider}".`,
+      example: `Available providers: ${available}`,
+    };
+  }
+  if (parsed.provider && target !== 'codex') {
+    return {
+      error: '--provider is only supported for the codex runtime.',
+      example: 'zylos runtime codex --provider orcarouter',
     };
   }
   return null;
@@ -255,11 +279,25 @@ async function switchRuntime(target, flags) {
     process.exit(1);
   }
 
-  const { apiKey, setupToken, baseUrl } = parsed;
+  const { apiKey, setupToken, baseUrl, provider } = parsed;
 
-  if (current === target && !apiKey && !setupToken && !baseUrl) {
+  if (current === target && !apiKey && !setupToken && !baseUrl && !provider) {
     console.log(`Already on ${bold(target)} runtime.`);
     return;
+  }
+
+  // Resolve a named provider preset (e.g. --provider orcarouter) into the
+  // gateway base URL and API key before the rest of the switch flow.
+  let resolvedBaseUrl = baseUrl;
+  let resolvedApiKey = apiKey;
+  if (provider) {
+    const preset = CODEX_PROVIDER_PRESETS[provider];
+    if (preset) {
+      if (!resolvedBaseUrl) resolvedBaseUrl = preset.baseUrl;
+      if (!resolvedApiKey && process.env[preset.apiKeyEnv]) {
+        resolvedApiKey = process.env[preset.apiKeyEnv];
+      }
+    }
   }
 
   // Step 1: Ensure target runtime CLI is installed.
@@ -279,18 +317,18 @@ async function switchRuntime(target, flags) {
   }
 
   // Step 2: Apply credentials if provided via flags.
-  if (apiKey || setupToken) {
+  if (resolvedApiKey || setupToken) {
     console.log(`Saving credentials for ${bold(target)}...`);
-    if (!applyCredentials(target, { apiKey, setupToken })) {
+    if (!applyCredentials(target, { apiKey: resolvedApiKey, setupToken })) {
       console.error(red(`\nFailed to save credentials.`));
       process.exit(1);
     }
     console.log(`  ${green('✓')} credentials saved`);
   }
 
-  if (baseUrl) {
+  if (resolvedBaseUrl) {
     console.log(`Saving base URL for ${bold(target)}...`);
-    if (!applyBaseUrl(target, baseUrl)) {
+    if (!applyBaseUrl(target, resolvedBaseUrl)) {
       console.error(red(`\nFailed to save base URL.`));
       process.exit(1);
     }
@@ -373,6 +411,7 @@ Authentication options (if not already authenticated):
            claude auth login               Browser OAuth (then retry)
   Codex:   --save-apikey <sk-...>          OpenAI API key
            --save-base-url <url>           Codex base URL
+           --provider <name>               Named Codex provider preset (orcarouter)
            codex login --device-auth       Device auth (headless)
            codex login                     Browser login (then retry)
 
@@ -393,6 +432,7 @@ Examples:
   zylos runtime claude --save-setup-token sk-ant-oat-xxx
   zylos runtime codex --save-apikey sk-proj-xxx
   zylos runtime codex --save-base-url https://proxy.example.com/v1
+  zylos runtime codex --provider orcarouter
   zylos runtime codex --no-validate
 `);
 }

--- a/cli/lib/__tests__/init-base-url.test.js
+++ b/cli/lib/__tests__/init-base-url.test.js
@@ -155,6 +155,104 @@ describe('base URL support', () => {
   });
 });
 
+describe('named Codex provider presets', () => {
+  test('parseInitFlags accepts --codex-provider and printInitHelp shows it', async () => {
+    const initModule = await import('../../commands/init.js');
+    const opts = initModule.parseInitFlags([
+      '--runtime', 'codex',
+      '--codex-provider', 'orcarouter',
+    ]);
+
+    assert.equal(opts.runtime, 'codex');
+    assert.equal(opts.codexProvider, 'orcarouter');
+
+    const originalLog = console.log;
+    let output = '';
+    console.log = (line = '') => {
+      output += `${line}\n`;
+    };
+
+    try {
+      initModule.printInitHelp();
+    } finally {
+      console.log = originalLog;
+    }
+
+    assert.match(output, /--codex-provider <name>/);
+  });
+
+  test('CODEX_PROVIDER_PRESETS maps orcarouter to base URL and key env', async () => {
+    const { CODEX_PROVIDER_PRESETS } = await import('../../commands/init.js');
+    assert.equal(CODEX_PROVIDER_PRESETS.orcarouter.baseUrl, 'https://api.orcarouter.ai/v1');
+    assert.equal(CODEX_PROVIDER_PRESETS.orcarouter.apiKeyEnv, 'ORCAROUTER_API_KEY');
+  });
+
+  test('resolveProviderPresets fills base URL and API key from the preset', async () => {
+    const { resolveProviderPresets, CODEX_PROVIDER_PRESETS } = await import('../../commands/init.js');
+    const originalKey = process.env.ORCAROUTER_API_KEY;
+    process.env.ORCAROUTER_API_KEY = 'sk-orca-test';
+
+    try {
+      const opts = {
+        codexProvider: 'orcarouter',
+        codexBaseUrl: null,
+        codexApiKey: null,
+      };
+      resolveProviderPresets(opts);
+      assert.equal(opts.codexBaseUrl, CODEX_PROVIDER_PRESETS.orcarouter.baseUrl);
+      assert.equal(opts.codexApiKey, 'sk-orca-test');
+    } finally {
+      if (originalKey === undefined) delete process.env.ORCAROUTER_API_KEY;
+      else process.env.ORCAROUTER_API_KEY = originalKey;
+    }
+  });
+
+  test('resolveProviderPresets does not override explicit flags', async () => {
+    const { resolveProviderPresets, CODEX_PROVIDER_PRESETS } = await import('../../commands/init.js');
+    const originalKey = process.env.ORCAROUTER_API_KEY;
+    process.env.ORCAROUTER_API_KEY = 'sk-orca-test';
+
+    try {
+      const opts = {
+        codexProvider: 'orcarouter',
+        codexBaseUrl: 'https://user-proxy.example.com/v1',
+        codexApiKey: 'sk-user',
+      };
+      resolveProviderPresets(opts);
+      assert.equal(opts.codexBaseUrl, 'https://user-proxy.example.com/v1');
+      assert.equal(opts.codexApiKey, 'sk-user');
+    } finally {
+      if (originalKey === undefined) delete process.env.ORCAROUTER_API_KEY;
+      else process.env.ORCAROUTER_API_KEY = originalKey;
+    }
+  });
+
+  test('resolveProviderPresets is a no-op without a codexProvider', async () => {
+    const { resolveProviderPresets } = await import('../../commands/init.js');
+    const opts = { codexProvider: null, codexBaseUrl: null, codexApiKey: null };
+    resolveProviderPresets(opts);
+    assert.equal(opts.codexBaseUrl, null);
+    assert.equal(opts.codexApiKey, null);
+  });
+
+  test('validateInitOptions rejects unknown provider names', async () => {
+    const { validateInitOptions } = await import('../../commands/init.js');
+    const error = validateInitOptions({
+      setupToken: null,
+      apiKey: null,
+      runtime: 'codex',
+      timezone: null,
+      domain: null,
+      baseUrl: null,
+      codexBaseUrl: null,
+      codexProvider: 'not-a-provider',
+    });
+
+    assert.match(error, /Invalid Codex provider/);
+    assert.match(error, /orcarouter/);
+  });
+});
+
 describe('fresh install new-session threshold default', () => {
   test('seeds 30 when fresh install config has no Claude threshold', async () => {
     const { seedFreshInstallNewSessionThresholdDefault } = await import('../../commands/init.js');

--- a/cli/lib/__tests__/runtime-base-url.test.js
+++ b/cli/lib/__tests__/runtime-base-url.test.js
@@ -58,6 +58,31 @@ describe('runtime base URL support', () => {
     assert.match(output, /--no-validate/);
   });
 
+  test('parseRuntimeFlags accepts --provider and validateRuntimeFlags accepts a known provider', async () => {
+    const runtimeModule = await import('../../commands/runtime.js');
+    const flags = runtimeModule.parseRuntimeFlags([
+      '--save-apikey', 'sk-orca-test',
+      '--provider', 'orcarouter',
+    ]);
+
+    assert.equal(flags.apiKey, 'sk-orca-test');
+    assert.equal(flags.provider, 'orcarouter');
+    assert.equal(flags.hasProvider, true);
+
+    assert.equal(runtimeModule.validateRuntimeFlags('codex', flags), null);
+  });
+
+  test('validateRuntimeFlags rejects unknown providers and --provider on claude', async () => {
+    const runtimeModule = await import('../../commands/runtime.js');
+
+    const unknown = runtimeModule.validateRuntimeFlags('codex', { provider: 'not-a-provider', hasProvider: true });
+    assert.match(unknown.error, /Unknown provider/);
+    assert.match(unknown.example, /orcarouter/);
+
+    const wrongRuntime = runtimeModule.validateRuntimeFlags('claude', { provider: 'orcarouter', hasProvider: true });
+    assert.match(wrongRuntime.error, /only supported for the codex runtime/);
+  });
+
   test('checkRuntimeAuthGate skips adapter probe for standalone --no-validate', async () => {
     const { checkRuntimeAuthGate, parseRuntimeFlags } = await import('../../commands/runtime.js');
     let checkAuthCalls = 0;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       # Option B: Anthropic API key (usage-based billing)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Option C: Codex runtime — OpenAI API key, or OrcaRouter gateway preset
+      # (use --codex-provider orcarouter to wire the Codex runtime to OrcaRouter)
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ORCAROUTER_API_KEY: ${ORCAROUTER_API_KEY:-}
 
       # ── Core config ───────────────────────────────────────────────────────
       TZ: ${TZ:-UTC}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,8 +36,8 @@ step 1 "Checking authentication..."
 if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && \
    [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${CODEX_API_KEY:-}" ]; then
   # Check mounted .env as fallback
-  if ! grep -qE '^(ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN|OPENAI_API_KEY|CODEX_API_KEY)=' "${ENV_FILE}" 2>/dev/null; then
-    error "No auth configured. Set ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN (Claude) or OPENAI_API_KEY / CODEX_API_KEY (Codex)."
+  if ! grep -qE '^(ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN|OPENAI_API_KEY|CODEX_API_KEY|ORCAROUTER_API_KEY)=' "${ENV_FILE}" 2>/dev/null; then
+    error "No auth configured. Set ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN (Claude) or OPENAI_API_KEY / CODEX_API_KEY / ORCAROUTER_API_KEY (Codex)."
     exit 1
   fi
 fi
@@ -68,7 +68,7 @@ if [ -z "${ZYLOS_RUNTIME:-}" ]; then
   HAS_CLAUDE_AUTH=false
   HAS_CODEX_AUTH=false
   [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && HAS_CLAUDE_AUTH=true
-  [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${CODEX_API_KEY:-}" ] && HAS_CODEX_AUTH=true
+  [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${CODEX_API_KEY:-}" ] || [ -n "${ORCAROUTER_API_KEY:-}" ] && HAS_CODEX_AUTH=true
   if [ "${HAS_CODEX_AUTH}" = true ] && [ "${HAS_CLAUDE_AUTH}" = false ]; then
     RUNTIME_FLAG="--runtime codex"
   fi
@@ -79,6 +79,16 @@ INIT_ARGS="--yes --quiet"
 [ -n "${TZ:-}" ] && INIT_ARGS="${INIT_ARGS} --timezone ${TZ}"
 [ -n "${AUTH_FLAG}" ] && INIT_ARGS="${INIT_ARGS} ${AUTH_FLAG}"
 [ -n "${RUNTIME_FLAG}" ] && INIT_ARGS="${INIT_ARGS} ${RUNTIME_FLAG}"
+
+# OrcaRouter — named Codex provider preset. When only an OrcaRouter key is
+# present, select the preset (resolves base URL https://api.orcarouter.ai/v1)
+# and pass the key through the Codex auth path. Runtime defaulting to codex is
+# already handled by RUNTIME_FLAG above (ORCAROUTER_API_KEY counts as Codex auth).
+ORCA_FLAG=""
+if [ -n "${ORCAROUTER_API_KEY:-}" ]; then
+  ORCA_FLAG="--codex-provider orcarouter --codex-api-key ${ORCAROUTER_API_KEY}"
+  INIT_ARGS="${INIT_ARGS} ${ORCA_FLAG}"
+fi
 
 # shellcheck disable=SC2086
 if ! zylos init ${INIT_ARGS}; then
@@ -112,6 +122,10 @@ upsert_env "CODEX_BYPASS_PERMISSIONS" "${CODEX_BYPASS_PERMISSIONS:-true}"
 # on subsequent restarts without relying on Docker's environment re-injection.
 upsert_env "OPENAI_API_KEY" "${OPENAI_API_KEY:-}"
 upsert_env "CODEX_API_KEY" "${CODEX_API_KEY:-}"
+# OrcaRouter — named Codex provider preset key. Persisted to .env so the tmux
+# session and PM2 services can resolve it on restarts without relying on Docker
+# re-injecting the environment variable.
+upsert_env "ORCAROUTER_API_KEY" "${ORCAROUTER_API_KEY:-}"
 
 # Save current PATH so PM2 services can find claude and node
 upsert_env "SYSTEM_PATH" "${PATH}"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -119,6 +119,8 @@ Set variables in `docker-compose.yml`, a `.env` file alongside `docker-compose.y
 |---|---|
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code token (Pro/Max subscription) |
 | `ANTHROPIC_API_KEY` | Anthropic API key (usage-based billing) |
+| `OPENAI_API_KEY` / `CODEX_API_KEY` | Codex runtime — OpenAI API key |
+| `ORCAROUTER_API_KEY` | Codex runtime — [OrcaRouter](https://www.orcarouter.ai) gateway key (`--codex-provider orcarouter`) |
 
 ### Optional
 
@@ -126,6 +128,7 @@ Set variables in `docker-compose.yml`, a `.env` file alongside `docker-compose.y
 |---|---|---|
 | `TZ` | `UTC` | Timezone for scheduler (IANA format, e.g. `Asia/Singapore`) |
 | `CLAUDE_BYPASS_PERMISSIONS` | `true` | Run Claude with `--dangerously-skip-permissions` |
+| `CODEX_BYPASS_PERMISSIONS` | `true` | Run Codex with `--dangerously-bypass-approvals-and-sandbox` |
 | `TELEGRAM_BOT_TOKEN` | — | Telegram channel token |
 | `LARK_APP_ID` / `LARK_APP_SECRET` | — | Lark/Feishu app credentials |
 | `ZYLOS_WEB_PASSWORD` | — | Web console password (auto-generated if not set) |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@
 # Install with custom API base URLs:
 #   curl -fsSL .../install.sh | bash -s -- -y --base-url https://claude-proxy.example.com
 #   curl -fsSL .../install.sh | bash -s -- -y --runtime codex --codex-base-url https://proxy.example.com/v1
+#   curl -fsSL .../install.sh | bash -s -- -y --runtime codex --codex-provider orcarouter
 #
 # Install environment only (no init):
 #   curl -fsSL .../install.sh | bash -s -- --no-init
@@ -49,7 +50,7 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     # Flags that take a value — forward both flag and value to zylos init
-    --timezone|--setup-token|--api-key|--codex-api-key|--base-url|--codex-base-url|--domain|--web-password|--runtime)
+    --timezone|--setup-token|--api-key|--codex-api-key|--codex-provider|--base-url|--codex-base-url|--domain|--web-password|--runtime)
       if [ -z "${2:-}" ]; then
         echo "[zylos] Error: $1 requires a value" >&2
         exit 1

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -29,6 +29,10 @@ CLAUDE_BYPASS_PERMISSIONS=true
 # OPENAI_API_KEY=sk-xxx
 # Optional: custom OpenAI-compatible base URL for Codex
 # OPENAI_BASE_URL=https://api.example.com/v1
+# Optional: OrcaRouter gateway preset for the Codex runtime.
+# Selecting the orcarouter provider wires Codex to https://api.orcarouter.ai/v1
+# (run: zylos init --runtime codex --codex-provider orcarouter)
+# ORCAROUTER_API_KEY=sk-orca-xxx
 # Proxy (if needed for external API access)
 # HTTP_PROXY=http://proxy:port
 # HTTPS_PROXY=http://proxy:port


### PR DESCRIPTION
# Add named OrcaRouter provider preset for the Codex runtime

## Summary

Adds `--codex-provider orcarouter` to `zylos init` (and `--provider` to `zylos runtime`) so users can wire the Codex runtime to [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible AI gateway, with a single named flag instead of hand-wiring a custom base URL and API key.

## Why

Zylos already supports custom base URLs for both runtimes (`--base-url`, `--codex-base-url`). This adds a curated named preset for [OrcaRouter](https://www.orcarouter.ai), a gateway that serves OpenAI, Anthropic, Google, DeepSeek and other model families from a single endpoint. Selecting the preset resolves the base URL (`https://api.orcarouter.ai/v1`) and reads the key from `ORCAROUTER_API_KEY`, so the rest of the Codex setup path works unchanged.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `cli/commands/init.js`: add `--codex-provider` flag, `CODEX_PROVIDER_PRESETS` registry, and `resolveProviderPresets()`; key verification now probes the configured base URL (not just `api.openai.com`).
- `cli/commands/runtime.js`: add `--provider` flag to `zylos runtime codex` for switching runtimes to the OrcaRouter preset.
- `docker/entrypoint.sh` / `docker-compose.yml` / `scripts/install.sh`: pass `ORCAROUTER_API_KEY` through and forward the new flag; OrcaRouter counts as Codex-runtime auth.
- `README.md` / `docs/docker.md` / `templates/.env.example`: document the preset.

## Validation

- `node --test` suite: 860/861 pass (the 1 failure — `instruction-split.test.js` — is pre-existing on upstream `main` and unrelated).
- Jest suite: 132 tests pass (2 suites fail to load only because of a missing native `better-sqlite3` module, pre-existing on `main`).
- L3 live check: `GET https://api.orcarouter.ai/v1/models` with an OrcaRouter key returns HTTP 200, and `POST /v1/chat/completions` and `/v1/responses` both return 200, confirming the OpenAI-compatible endpoint works for the Codex runtime.
- `bash -n` on `docker/entrypoint.sh` and `scripts/install.sh`; `git diff --check` clean.

## Test plan

```bash
curl -fsSL https://raw.githubusercontent.com/zylos-ai/zylos-core/main/scripts/install.sh | bash -s -- -y --runtime codex --codex-provider orcarouter --codex-api-key sk-orca-...
# or
ORCAROUTER_API_KEY=sk-orca-... zylos init --runtime codex --codex-provider orcarouter
# switch an existing install:
zylos runtime codex --provider orcarouter
```

Disclosure: I'm an engineer on the OrcaRouter team.
