### PR TITLE
fix(scheduler): reject stored fixed run IDs

### DIFF
--- a/skills/scheduler/SKILL.md
+++ b/skills/scheduler/SKILL.md
@@ -24,7 +24,7 @@ Enables Claude to work autonomously by dispatching scheduled tasks via C4 comm-b
 | `add <prompt> [options]` | Add a new task | `references/add.md` |
 | `update <task-id> [options]` | Update an existing task | `references/update.md` |
 | `list` / `next` / `running` / `history` | Query tasks | `references/query.md` |
-| `done` / `remove` / `pause` / `resume` | Task lifecycle | `references/lifecycle.md` |
+| `done <task-id> --run-id <history-id>` / `remove` / `pause` / `resume` | Task lifecycle | `references/lifecycle.md` |
 
 ## Timezone
 

--- a/skills/scheduler/references/lifecycle.md
+++ b/skills/scheduler/references/lifecycle.md
@@ -8,7 +8,14 @@ All commands support partial task ID matching.
 
 Completes only the exact active run. Get the run ID and ready-to-copy command from `cli.js running`. Late, duplicate, or mismatched run IDs fail without changing the task. For recurring/interval tasks, the daemon will automatically calculate the next run time.
 
-Before upgrading from a version whose dispatched prompts did not include `--run-id`, wait until `cli.js running` reports no active tasks. An old prompt cannot be completed safely after the new CLI is installed because it has no exact run identity.
+Before upgrading from a version whose dispatched prompts did not include `--run-id`, run both cutover gates against each machine independently:
+
+```bash
+node scripts/run-id-cutover-check.js
+cli.js running
+```
+
+The read-only cutover check exits non-zero when that machine's stored task prompts contain an unbound `cli.js done` or `scheduler done` instruction. Remove or rewrite those prompt instructions before installation; do not reuse counts from another machine. Then wait until `cli.js running` reports no active tasks. An old in-flight prompt cannot be completed safely after the new CLI is installed because it has no exact run identity.
 
 ## remove
 

--- a/skills/scheduler/references/lifecycle.md
+++ b/skills/scheduler/references/lifecycle.md
@@ -15,7 +15,7 @@ node scripts/run-id-cutover-check.js
 cli.js running
 ```
 
-The read-only cutover check exits non-zero when that machine's stored task prompts contain an unbound `cli.js done` or `scheduler done` instruction. Remove or rewrite those prompt instructions before installation; do not reuse counts from another machine. Then wait until `cli.js running` reports no active tasks. An old in-flight prompt cannot be completed safely after the new CLI is installed because it has no exact run identity.
+The read-only cutover check exits non-zero when that machine's stored task prompts contain any static `cli.js done` or `scheduler done` instruction, even if it already contains `--run-id`. Remove those stored completion instructions before installation; never rewrite one with a fixed run ID, because run IDs are created per dispatch and a stored value will become stale. Do not reuse counts from another machine. Then wait until `cli.js running` reports no active tasks. An old in-flight prompt cannot be completed safely after the new CLI is installed because it has no exact run identity.
 
 ## remove
 

--- a/skills/scheduler/references/lifecycle.md
+++ b/skills/scheduler/references/lifecycle.md
@@ -4,9 +4,11 @@ All commands support partial task ID matching.
 
 ## done
 
-`cli.js done <task-id>`
+`cli.js done <task-id> --run-id <history-id>`
 
-Marks a task as completed. For recurring/interval tasks, the daemon will automatically calculate the next run time.
+Completes only the exact active run. Get the run ID and ready-to-copy command from `cli.js running`. Late, duplicate, or mismatched run IDs fail without changing the task. For recurring/interval tasks, the daemon will automatically calculate the next run time.
+
+Before upgrading from a version whose dispatched prompts did not include `--run-id`, wait until `cli.js running` reports no active tasks. An old prompt cannot be completed safely after the new CLI is installed because it has no exact run identity.
 
 ## remove
 
@@ -27,7 +29,7 @@ Pauses a pending task. Paused tasks are skipped by the daemon.
 Resumes a paused task back to pending status.
 
 ```bash
-cli.js done task-abc
+cli.js done task-abc --run-id 42
 cli.js remove task-abc
 cli.js pause task-abc
 cli.js resume task-abc

--- a/skills/scheduler/references/query.md
+++ b/skills/scheduler/references/query.md
@@ -9,6 +9,8 @@ Shows all active tasks (excluding completed one-time tasks; failed one-time task
 - `--json` — machine-readable output: a JSON array of full task rows (untruncated `id`, `type`, `status`, `last_error`, `reply_channel`, `reply_endpoint`, `next_run_at`, and all other columns). Outputs `[]` when no tasks match.
 - `--reply-channel "<ch>"` — only tasks whose reply channel equals `<ch>` exactly. Works with or without `--json`.
 
+`failed_at` and `last_error` describe the latest run failure that has not yet been recovered by a successful exact-run completion. They are execution-outcome fields, separate from lifecycle `status`, so a recurring task can be `pending` or `running` while they remain populated. For legacy rows migrated into this model, `failed_at` is the best timestamp available from existing task and history data and may not be the exact original failure time.
+
 ## next
 
 `cli.js next`
@@ -19,7 +21,7 @@ Shows the 5 nearest pending tasks with relative time.
 
 `cli.js running`
 
-Shows tasks currently in `running` status. Useful to check before session compaction.
+Shows tasks currently in `running` status, their active history IDs, and exact `done ... --run-id ...` commands. Useful before session compaction or a scheduler upgrade.
 
 ## history
 

--- a/skills/scheduler/scripts/__tests__/cli.test.js
+++ b/skills/scheduler/scripts/__tests__/cli.test.js
@@ -266,15 +266,109 @@ describe('cli list', () => {
 });
 
 describe('cli done', () => {
-  it('completes a task and updates history', () => {
+  it('rejects completion without a run ID and leaves the active run unchanged', () => {
+    withTmpDir(({ dbPath, env }) => {
+      cli(['add', 'identity required', '--cron', '0 9 * * *'], env);
+      const db = new Database(dbPath);
+      try {
+        const task = db.prepare('SELECT id FROM tasks LIMIT 1').get();
+        const currentTime = Math.floor(Date.now() / 1000);
+        db.prepare("UPDATE tasks SET status = 'running', updated_at = ? WHERE id = ?")
+          .run(currentTime, task.id);
+        const run = db.prepare(`
+          INSERT INTO task_history (task_id, executed_at, status)
+          VALUES (?, ?, 'started')
+        `).run(task.id, currentTime);
+
+        const result = cliRaw(['done', task.id], env);
+
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /run ID/i);
+        assert.equal(db.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id).status, 'running');
+        assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(run.lastInsertRowid).status, 'started');
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it('completes the exact active run and clears its failure outcome', () => {
     withTmpDir(({ dbPath, env }) => {
       cli(['add', 'complete me', '--cron', '0 9 * * *'], env);
       const db = new Database(dbPath);
       try {
         const task = db.prepare('SELECT id FROM tasks LIMIT 1').get();
-        cli(['done', task.id], env);
-        const updated = db.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id);
+        const currentTime = Math.floor(Date.now() / 1000);
+        db.prepare(`
+          UPDATE tasks
+          SET status = 'running', failed_at = ?, last_error = 'prior timeout', updated_at = ?
+          WHERE id = ?
+        `).run(currentTime - 60, currentTime, task.id);
+        const run = db.prepare(`
+          INSERT INTO task_history (task_id, executed_at, status)
+          VALUES (?, ?, 'started')
+        `).run(task.id, currentTime);
+
+        cli(['done', task.id, '--run-id', String(run.lastInsertRowid)], env);
+
+        const updated = db.prepare('SELECT status, failed_at, last_error FROM tasks WHERE id = ?').get(task.id);
         assert.equal(updated.status, 'completed');
+        assert.equal(updated.failed_at, null);
+        assert.equal(updated.last_error, null);
+        assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(run.lastInsertRowid).status, 'success');
+
+        const snapshot = {
+          task: db.prepare('SELECT status, failed_at, last_error, last_run_at FROM tasks WHERE id = ?').get(task.id),
+          history: db.prepare('SELECT status, completed_at, duration_ms FROM task_history WHERE id = ?').get(run.lastInsertRowid)
+        };
+        const duplicate = cliRaw(['done', task.id, '--run-id', String(run.lastInsertRowid)], env);
+        assert.notEqual(duplicate.status, 0);
+        assert.deepEqual(
+          {
+            task: db.prepare('SELECT status, failed_at, last_error, last_run_at FROM tasks WHERE id = ?').get(task.id),
+            history: db.prepare('SELECT status, completed_at, duration_ms FROM task_history WHERE id = ?').get(run.lastInsertRowid)
+          },
+          snapshot
+        );
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it('rejects an older timed-out run while a newer run is active', () => {
+    withTmpDir(({ dbPath, env }) => {
+      cli(['add', 'generation safe', '--every', '1 hour'], env);
+      const db = new Database(dbPath);
+      try {
+        const task = db.prepare('SELECT id FROM tasks LIMIT 1').get();
+        const currentTime = Math.floor(Date.now() / 1000);
+        const oldRun = db.prepare(`
+          INSERT INTO task_history (task_id, executed_at, completed_at, status, error)
+          VALUES (?, ?, ?, 'timeout', 'Task timed out')
+        `).run(task.id, currentTime - 7200, currentTime - 3600);
+        const activeRun = db.prepare(`
+          INSERT INTO task_history (task_id, executed_at, status)
+          VALUES (?, ?, 'started')
+        `).run(task.id, currentTime);
+        db.prepare(`
+          UPDATE tasks
+          SET status = 'running', failed_at = ?, last_error = 'Task timed out', updated_at = ?
+          WHERE id = ?
+        `).run(currentTime - 3600, currentTime, task.id);
+
+        const late = cliRaw(['done', task.id, '--run-id', String(oldRun.lastInsertRowid)], env);
+
+        assert.notEqual(late.status, 0);
+        assert.deepEqual(
+          db.prepare('SELECT status, failed_at, last_error FROM tasks WHERE id = ?').get(task.id),
+          { status: 'running', failed_at: currentTime - 3600, last_error: 'Task timed out' }
+        );
+        assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(oldRun.lastInsertRowid).status, 'timeout');
+        assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(activeRun.lastInsertRowid).status, 'started');
+
+        cli(['done', task.id, '--run-id', String(activeRun.lastInsertRowid)], env);
+        assert.equal(db.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id).status, 'completed');
       } finally {
         db.close();
       }
@@ -477,6 +571,31 @@ describe('cli running', () => {
       assert.ok(output.includes('No running') || output.includes('Safe to compact'));
     });
   });
+
+  it('shows the exact completion command for each active run', () => {
+    withTmpDir(({ dbPath, env }) => {
+      cli(['add', 'running task', '--cron', '0 9 * * *'], env);
+      const db = new Database(dbPath);
+      let task;
+      let run;
+      try {
+        task = db.prepare('SELECT id FROM tasks LIMIT 1').get();
+        const currentTime = Math.floor(Date.now() / 1000);
+        db.prepare("UPDATE tasks SET status = 'running', updated_at = ? WHERE id = ?")
+          .run(currentTime, task.id);
+        run = db.prepare(`
+          INSERT INTO task_history (task_id, executed_at, status)
+          VALUES (?, ?, 'started')
+        `).run(task.id, currentTime);
+      } finally {
+        db.close();
+      }
+
+      const output = cli(['running'], env);
+
+      assert.match(output, new RegExp(`done ${task.id} --run-id ${run.lastInsertRowid}`));
+    });
+  });
 });
 
 describe('cli help', () => {
@@ -511,8 +630,15 @@ describe('cli partial ID match', () => {
       const db = new Database(dbPath);
       try {
         const task = db.prepare('SELECT id FROM tasks LIMIT 1').get();
+        const currentTime = Math.floor(Date.now() / 1000);
+        db.prepare("UPDATE tasks SET status = 'running', updated_at = ? WHERE id = ?")
+          .run(currentTime, task.id);
+        const run = db.prepare(`
+          INSERT INTO task_history (task_id, executed_at, status)
+          VALUES (?, ?, 'started')
+        `).run(task.id, currentTime);
         const prefix = task.id.substring(0, 10);
-        cli(['done', prefix], env);
+        cli(['done', prefix, '--run-id', String(run.lastInsertRowid)], env);
         const updated = db.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id);
         assert.equal(updated.status, 'completed');
       } finally {

--- a/skills/scheduler/scripts/__tests__/cli.test.js
+++ b/skills/scheduler/scripts/__tests__/cli.test.js
@@ -279,13 +279,23 @@ describe('cli done', () => {
           INSERT INTO task_history (task_id, executed_at, status)
           VALUES (?, ?, 'started')
         `).run(task.id, currentTime);
+        const before = {
+          task: db.prepare('SELECT * FROM tasks WHERE id = ?').get(task.id),
+          history: db.prepare('SELECT * FROM task_history WHERE task_id = ? ORDER BY id').all(task.id)
+        };
 
         const result = cliRaw(['done', task.id], env);
 
         assert.notEqual(result.status, 0);
         assert.match(result.stderr, /run ID/i);
-        assert.equal(db.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id).status, 'running');
-        assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(run.lastInsertRowid).status, 'started');
+        assert.deepEqual(
+          {
+            task: db.prepare('SELECT * FROM tasks WHERE id = ?').get(task.id),
+            history: db.prepare('SELECT * FROM task_history WHERE task_id = ? ORDER BY id').all(task.id)
+          },
+          before
+        );
+        assert.equal(before.history[0].id, run.lastInsertRowid);
       } finally {
         db.close();
       }

--- a/skills/scheduler/scripts/__tests__/daemon-tasks.test.js
+++ b/skills/scheduler/scripts/__tests__/daemon-tasks.test.js
@@ -4,7 +4,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { updateNextRunTime, processCompletedTasks, handleStaleRunningTasks, TASK_TIMEOUT } from '../daemon-tasks.js';
+import {
+  failMissedOneTimeTask,
+  updateNextRunTime,
+  processCompletedTasks,
+  handleStaleRunningTasks,
+  TASK_TIMEOUT
+} from '../daemon-tasks.js';
 import { now } from '../database.js';
 
 async function withDb(fn) {
@@ -121,13 +127,136 @@ describe('updateNextRunTime', () => {
         const utcRow = db.prepare('SELECT next_run_at FROM tasks WHERE id = ?').get('task-utc');
         const shRow = db.prepare('SELECT next_run_at FROM tasks WHERE id = ?').get('task-sh');
 
-        // Shanghai 9am is 8 hours earlier in UTC than UTC 9am
-        assert.ok(shRow.next_run_at < utcRow.next_run_at,
-          `Shanghai 9am (${shRow.next_run_at}) should be before UTC 9am (${utcRow.next_run_at})`);
+        const wallClock = (timestamp, timeZone) => {
+          const parts = new Intl.DateTimeFormat('en-GB', {
+            timeZone,
+            hour: '2-digit',
+            minute: '2-digit',
+            hourCycle: 'h23'
+          }).formatToParts(new Date(timestamp * 1000));
+          const value = Object.fromEntries(parts.map(part => [part.type, part.value]));
+          return `${value.hour}:${value.minute}`;
+        };
+
+        assert.equal(wallClock(utcRow.next_run_at, 'UTC'), '09:00');
+        assert.equal(wallClock(shRow.next_run_at, 'Asia/Shanghai'), '09:00');
+        assert.ok(utcRow.next_run_at > now());
+        assert.ok(shRow.next_run_at > now());
       });
     } finally {
       if (originalTz === undefined) { delete process.env.TZ; } else { process.env.TZ = originalTz; }
     }
+  });
+
+  it('uses the current schedule when a completed task was edited after selection', async () => {
+    await withDb((db) => {
+      insertTask(db, {
+        id: 'task-edited',
+        type: 'recurring',
+        cron_expression: '0 9 * * *',
+        timezone: 'UTC',
+        status: 'completed'
+      });
+      const staleTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get('task-edited');
+      db.prepare(`
+        UPDATE tasks SET cron_expression = '0 10 * * *', updated_at = updated_at + 1
+        WHERE id = ?
+      `).run('task-edited');
+
+      updateNextRunTime(db, staleTask);
+
+      const updated = db.prepare('SELECT status, cron_expression, next_run_at FROM tasks WHERE id = ?')
+        .get('task-edited');
+      const utcHour = new Date(updated.next_run_at * 1000).getUTCHours();
+      assert.equal(updated.status, 'pending');
+      assert.equal(updated.cron_expression, '0 10 * * *');
+      assert.equal(utcHour, 10);
+    });
+  });
+
+  it('does not advance a pending task that is no longer overdue', async () => {
+    await withDb((db) => {
+      const futureRun = now() + 7200;
+      const staleTask = insertTask(db, {
+        id: 'task-no-longer-overdue',
+        type: 'interval',
+        cron_expression: null,
+        interval_seconds: 3600,
+        next_run_at: futureRun,
+        status: 'pending'
+      });
+
+      assert.equal(updateNextRunTime(db, staleTask), false);
+      assert.deepEqual(
+        db.prepare('SELECT status, next_run_at FROM tasks WHERE id = ?').get(staleTask.id),
+        { status: 'pending', next_run_at: futureRun }
+      );
+    });
+  });
+
+  it('advances the same overdue pending task only once', async () => {
+    await withDb((db) => {
+      const currentTime = now();
+      const staleTask = insertTask(db, {
+        id: 'task-repeated-missed-run',
+        type: 'interval',
+        cron_expression: null,
+        interval_seconds: 3600,
+        next_run_at: currentTime - 600,
+        status: 'pending'
+      });
+
+      assert.equal(updateNextRunTime(db, staleTask), true);
+      const firstTransition = db.prepare('SELECT status, next_run_at FROM tasks WHERE id = ?')
+        .get(staleTask.id);
+
+      assert.equal(updateNextRunTime(db, staleTask), false);
+      assert.deepEqual(
+        db.prepare('SELECT status, next_run_at FROM tasks WHERE id = ?').get(staleTask.id),
+        firstTransition
+      );
+    });
+  });
+});
+
+describe('failMissedOneTimeTask', () => {
+  it('does not fail a one-time task that was postponed after selection', async () => {
+    await withDb((db) => {
+      const currentTime = now();
+      const task = insertTask(db, {
+        type: 'one-time',
+        cron_expression: null,
+        next_run_at: currentTime - 600,
+        status: 'pending'
+      });
+      db.prepare('UPDATE tasks SET next_run_at = ?, updated_at = ? WHERE id = ?')
+        .run(currentTime + 3600, currentTime, task.id);
+
+      assert.equal(failMissedOneTimeTask(db, { taskId: task.id, currentTime }), false);
+      assert.deepEqual(
+        db.prepare('SELECT status, failed_at, last_error FROM tasks WHERE id = ?').get(task.id),
+        { status: 'pending', failed_at: null, last_error: null }
+      );
+    });
+  });
+
+  it('fails only a currently overdue one-time task', async () => {
+    await withDb((db) => {
+      const currentTime = now();
+      const task = insertTask(db, {
+        type: 'one-time',
+        cron_expression: null,
+        next_run_at: currentTime - 1,
+        miss_threshold: 0,
+        status: 'pending'
+      });
+
+      assert.equal(failMissedOneTimeTask(db, { taskId: task.id, currentTime }), true);
+      assert.deepEqual(
+        db.prepare('SELECT status, failed_at, last_error FROM tasks WHERE id = ?').get(task.id),
+        { status: 'failed', failed_at: currentTime, last_error: 'Missed execution window' }
+      );
+    });
   });
 });
 
@@ -170,9 +299,10 @@ describe('processCompletedTasks', () => {
       insertTask(db, { type: 'recurring', cron_expression: 'invalid cron expr', status: 'completed' });
       processCompletedTasks(db);
 
-      const task = db.prepare('SELECT status, last_error FROM tasks LIMIT 1').get();
+      const task = db.prepare('SELECT status, last_error, failed_at FROM tasks LIMIT 1').get();
       assert.equal(task.status, 'failed');
       assert.ok(task.last_error.includes('Invalid cron'));
+      assert.ok(Number.isSafeInteger(task.failed_at));
     });
   });
 
@@ -198,6 +328,21 @@ describe('processCompletedTasks', () => {
 // ---- handleStaleRunningTasks ----
 
 describe('handleStaleRunningTasks', () => {
+  it('leaves a stale task unchanged when its run identity is missing', async () => {
+    await withDb((db) => {
+      const staleTime = now() - TASK_TIMEOUT - 60;
+      insertTask(db, { type: 'one-time', cron_expression: null, status: 'running', updated_at: staleTime });
+
+      handleStaleRunningTasks(db);
+
+      assert.deepEqual(
+        db.prepare('SELECT status, failed_at, last_error FROM tasks LIMIT 1').get(),
+        { status: 'running', failed_at: null, last_error: null }
+      );
+      assert.equal(db.prepare('SELECT COUNT(*) AS count FROM task_history').get().count, 0);
+    });
+  });
+
   it('marks stale one-time task as failed', async () => {
     await withDb((db) => {
       const staleTime = now() - TASK_TIMEOUT - 60;
@@ -210,9 +355,10 @@ describe('handleStaleRunningTasks', () => {
 
       handleStaleRunningTasks(db);
 
-      const updated = db.prepare('SELECT status, last_error FROM tasks WHERE id = ?').get(task.id);
+      const updated = db.prepare('SELECT status, last_error, failed_at FROM tasks WHERE id = ?').get(task.id);
       assert.equal(updated.status, 'failed');
       assert.equal(updated.last_error, 'Task timed out');
+      assert.ok(updated.failed_at >= staleTime);
 
       const history = db.prepare('SELECT status FROM task_history WHERE task_id = ?').get(task.id);
       assert.equal(history.status, 'timeout');
@@ -230,9 +376,20 @@ describe('handleStaleRunningTasks', () => {
 
       handleStaleRunningTasks(db);
 
-      const updated = db.prepare('SELECT status, last_error FROM tasks WHERE id = ?').get(task.id);
+      const updated = db.prepare('SELECT status, last_error, failed_at FROM tasks WHERE id = ?').get(task.id);
       assert.equal(updated.status, 'completed');
       assert.equal(updated.last_error, 'Task timed out');
+      assert.ok(updated.failed_at >= staleTime, 'timeout must remain machine-visible while the task is retryable');
+      assert.equal(db.prepare('SELECT status FROM task_history WHERE task_id = ?').get(task.id).status, 'timeout');
+
+      processCompletedTasks(db);
+      const rescheduled = db.prepare(`
+        SELECT status, failed_at, last_error, next_run_at FROM tasks WHERE id = ?
+      `).get(task.id);
+      assert.equal(rescheduled.status, 'pending');
+      assert.equal(rescheduled.failed_at, updated.failed_at);
+      assert.equal(rescheduled.last_error, 'Task timed out');
+      assert.ok(rescheduled.next_run_at > now());
     });
   });
 
@@ -265,6 +422,12 @@ describe('handleStaleRunningTasks', () => {
       insertTask(db, { id: 'task-ot', type: 'one-time', cron_expression: null, status: 'running', updated_at: staleTime });
       insertTask(db, { id: 'task-rc', type: 'recurring', cron_expression: '0 9 * * *', status: 'running', updated_at: staleTime });
       insertTask(db, { id: 'task-iv', type: 'interval', cron_expression: null, interval_seconds: 3600, status: 'running', updated_at: staleTime });
+      for (const taskId of ['task-ot', 'task-rc', 'task-iv']) {
+        db.prepare(`
+          INSERT INTO task_history (task_id, executed_at, status)
+          VALUES (?, ?, 'started')
+        `).run(taskId, staleTime);
+      }
 
       handleStaleRunningTasks(db);
 

--- a/skills/scheduler/scripts/__tests__/database.test.js
+++ b/skills/scheduler/scripts/__tests__/database.test.js
@@ -78,6 +78,172 @@ describe('getDb', () => {
       }
     }
   });
+
+  it('migrates legacy run outcomes once without rewriting history', async () => {
+    const originalZylosDir = process.env.ZYLOS_DIR;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-migration-'));
+    const dbPath = path.join(tmpDir, 'scheduler', 'scheduler.db');
+    try {
+      process.env.ZYLOS_DIR = tmpDir;
+      const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const setup = await import(new URL(`../database.js?setup-${cacheBuster}`, import.meta.url));
+      setup.getDb().close();
+
+      const seed = new Database(dbPath);
+      const currentTime = Math.floor(Date.now() / 1000);
+      const addTask = (id, status, lastError, updatedAt = currentTime) => {
+        seed.prepare(`
+          INSERT INTO tasks (
+            id, name, prompt, type, next_run_at, status,
+            created_at, updated_at, last_error, failed_at
+          ) VALUES (?, ?, 'test', 'recurring', ?, ?, ?, ?, ?, NULL)
+        `).run(id, id, currentTime + 3600, status, currentTime, updatedAt, lastError);
+      };
+      addTask('task-recovered', 'pending', 'stale error');
+      addTask('task-timeout', 'pending', 'Task timed out');
+      addTask('task-failed-no-history', 'failed', 'dispatch failed', currentTime - 20);
+      addTask('task-failed-after-success', 'failed', 'Invalid cron expression', currentTime - 15);
+      addTask('task-failed-without-error', 'failed', null, currentTime - 10);
+      addTask('task-unknown-error', 'pending', 'legacy uncertain', currentTime - 10);
+      addTask('task-clock-rollback', 'pending', null);
+      addTask('task-newer-task-failure', 'failed', 'Missed execution window', currentTime - 200);
+      addTask('task-retrying-after-failure', 'running', 'newer unproven error', currentTime);
+      addTask('task-retrying-after-success', 'running', 'stale recovered error', currentTime);
+      addTask('task-pending-started-after-success', 'pending', 'unproven current error', currentTime - 10);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status)
+        VALUES ('task-recovered', ?, ?, 'success')
+      `).run(currentTime - 200, currentTime - 190);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status, error)
+        VALUES ('task-timeout', ?, ?, 'timeout', 'Task timed out')
+      `).run(currentTime - 100, currentTime - 90);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status)
+        VALUES ('task-failed-after-success', ?, ?, 'success')
+      `).run(currentTime - 30, currentTime - 20);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status)
+        VALUES ('task-clock-rollback', ?, ?, 'success')
+      `).run(currentTime - 100, currentTime - 90);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status, error)
+        VALUES ('task-clock-rollback', ?, ?, 'failed', 'failed after clock rollback')
+      `).run(currentTime - 200, currentTime - 190);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status, error)
+        VALUES ('task-newer-task-failure', ?, ?, 'failed', 'Failed to dispatch message')
+      `).run(currentTime - 110, currentTime - 100);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status, error)
+        VALUES ('task-retrying-after-failure', ?, ?, 'timeout', 'Task timed out')
+      `).run(currentTime - 110, currentTime - 100);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, status)
+        VALUES ('task-retrying-after-failure', ?, 'started')
+      `).run(currentTime);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status, error)
+        VALUES ('task-retrying-after-success', ?, ?, 'failed', 'old failure')
+      `).run(currentTime - 310, currentTime - 300);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status)
+        VALUES ('task-retrying-after-success', ?, ?, 'success')
+      `).run(currentTime - 210, currentTime - 200);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, status)
+        VALUES ('task-retrying-after-success', ?, 'started')
+      `).run(currentTime);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, completed_at, status)
+        VALUES ('task-pending-started-after-success', ?, ?, 'success')
+      `).run(currentTime - 210, currentTime - 200);
+      seed.prepare(`
+        INSERT INTO task_history (task_id, executed_at, status)
+        VALUES ('task-pending-started-after-success', ?, 'started')
+      `).run(currentTime - 5);
+      seed.prepare("DELETE FROM system_state WHERE key = 'scheduler_run_outcome_v1'").run();
+      const historyBefore = seed.prepare(`
+        SELECT id, task_id, executed_at, completed_at, status, duration_ms, error
+        FROM task_history ORDER BY id
+      `).all();
+      seed.close();
+
+      const migrated = await import(new URL(`../database.js?migrate-${cacheBuster}`, import.meta.url));
+      const db = migrated.getDb();
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-recovered'),
+        { failed_at: null, last_error: null }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-timeout'),
+        { failed_at: currentTime - 90, last_error: 'Task timed out' }
+      );
+      assert.equal(
+        db.prepare('SELECT failed_at FROM tasks WHERE id = ?').get('task-failed-no-history').failed_at,
+        currentTime - 20
+      );
+      assert.equal(
+        db.prepare('SELECT failed_at FROM tasks WHERE id = ?').get('task-unknown-error').failed_at,
+        currentTime - 10
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-failed-after-success'),
+        { failed_at: currentTime - 15, last_error: 'Invalid cron expression' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-failed-without-error'),
+        { failed_at: currentTime - 10, last_error: 'Task failed' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-clock-rollback'),
+        { failed_at: currentTime - 190, last_error: 'failed after clock rollback' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-newer-task-failure'),
+        { failed_at: currentTime - 200, last_error: 'Missed execution window' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-retrying-after-failure'),
+        { failed_at: currentTime, last_error: 'newer unproven error' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-retrying-after-success'),
+        { failed_at: currentTime, last_error: 'stale recovered error' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-pending-started-after-success'),
+        { failed_at: currentTime - 10, last_error: 'unproven current error' }
+      );
+      assert.deepEqual(
+        db.prepare(`
+          SELECT id, task_id, executed_at, completed_at, status, duration_ms, error
+          FROM task_history ORDER BY id
+        `).all(),
+        historyBefore
+      );
+      assert.equal(
+        db.prepare("SELECT COUNT(*) AS count FROM system_state WHERE key = 'scheduler_run_outcome_v1'").get().count,
+        1
+      );
+      const snapshot = db.prepare(`
+        SELECT id, failed_at, last_error FROM tasks ORDER BY id
+      `).all();
+      db.close();
+
+      const second = await import(new URL(`../database.js?second-${cacheBuster}`, import.meta.url));
+      const reopened = second.getDb();
+      assert.deepEqual(
+        reopened.prepare('SELECT id, failed_at, last_error FROM tasks ORDER BY id').all(),
+        snapshot
+      );
+      reopened.close();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      if (originalZylosDir === undefined) delete process.env.ZYLOS_DIR;
+      else process.env.ZYLOS_DIR = originalZylosDir;
+    }
+  });
 });
 
 describe('cleanupHistory', () => {

--- a/skills/scheduler/scripts/__tests__/database.test.js
+++ b/skills/scheduler/scripts/__tests__/database.test.js
@@ -91,13 +91,13 @@ describe('getDb', () => {
 
       const seed = new Database(dbPath);
       const currentTime = Math.floor(Date.now() / 1000);
-      const addTask = (id, status, lastError, updatedAt = currentTime) => {
+      const addTask = (id, status, lastError, updatedAt = currentTime, failedAt = null) => {
         seed.prepare(`
           INSERT INTO tasks (
             id, name, prompt, type, next_run_at, status,
             created_at, updated_at, last_error, failed_at
-          ) VALUES (?, ?, 'test', 'recurring', ?, ?, ?, ?, ?, NULL)
-        `).run(id, id, currentTime + 3600, status, currentTime, updatedAt, lastError);
+          ) VALUES (?, ?, 'test', 'recurring', ?, ?, ?, ?, ?, ?)
+        `).run(id, id, currentTime + 3600, status, currentTime, updatedAt, lastError, failedAt);
       };
       addTask('task-recovered', 'pending', 'stale error');
       addTask('task-timeout', 'pending', 'Task timed out');
@@ -110,6 +110,13 @@ describe('getDb', () => {
       addTask('task-retrying-after-failure', 'running', 'newer unproven error', currentTime);
       addTask('task-retrying-after-success', 'running', 'stale recovered error', currentTime);
       addTask('task-pending-started-after-success', 'pending', 'unproven current error', currentTime - 10);
+      addTask(
+        'task-existing-failure-timestamp',
+        'pending',
+        'legacy uncertain',
+        currentTime,
+        currentTime - 500
+      );
       seed.prepare(`
         INSERT INTO task_history (task_id, executed_at, completed_at, status)
         VALUES ('task-recovered', ?, ?, 'success')
@@ -214,6 +221,10 @@ describe('getDb', () => {
       assert.deepEqual(
         db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-pending-started-after-success'),
         { failed_at: currentTime - 10, last_error: 'unproven current error' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT failed_at, last_error FROM tasks WHERE id = ?').get('task-existing-failure-timestamp'),
+        { failed_at: currentTime - 500, last_error: 'legacy uncertain' }
       );
       assert.deepEqual(
         db.prepare(`

--- a/skills/scheduler/scripts/__tests__/run-id-cutover-check.test.js
+++ b/skills/scheduler/scripts/__tests__/run-id-cutover-check.test.js
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+
+import Database from 'better-sqlite3';
+
+import { scanLegacyDonePrompts } from '../run-id-cutover-check.js';
+
+const SCRIPT = new URL('../run-id-cutover-check.js', import.meta.url).pathname;
+
+describe('run-id cutover check', () => {
+  it('blocks per-machine cutover when stored prompts contain legacy done instructions', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-cutover-check-'));
+    const dbPath = path.join(tmpDir, 'scheduler.db');
+    const db = new Database(dbPath);
+    try {
+      db.exec(`
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          type TEXT NOT NULL,
+          prompt TEXT NOT NULL
+        )
+      `);
+      const insert = db.prepare('INSERT INTO tasks (id, type, prompt) VALUES (?, ?, ?)');
+      insert.run('task-recurring-cli', 'recurring', 'Afterward run cli.js done task-recurring-cli');
+      insert.run('task-interval-oral', 'interval', '完成后 scheduler done task-interval-oral');
+      insert.run('task-one-time-cli', 'one-time', 'Run /scheduler/scripts/cli.js done task-one-time-cli');
+      insert.run(
+        'task-mixed-same-line',
+        'recurring',
+        'First cli.js done task-old; replacement cli.js done task-new --run-id 42'
+      );
+      insert.run('task-current', 'recurring', 'Use cli.js done task-current --run-id 42');
+      insert.run('task-unrelated', 'recurring', 'No completion command is stored here');
+
+      const before = fs.readFileSync(dbPath);
+      const result = scanLegacyDonePrompts(dbPath);
+      const after = fs.readFileSync(dbPath);
+
+      assert.deepEqual(result, {
+        legacy_prompt_count: 4,
+        recurring_interval_count: 3,
+        tasks: [
+          { id: 'task-interval-oral', type: 'interval' },
+          { id: 'task-mixed-same-line', type: 'recurring' },
+          { id: 'task-one-time-cli', type: 'one-time' },
+          { id: 'task-recurring-cli', type: 'recurring' }
+        ]
+      });
+      const cli = spawnSync(process.execPath, [SCRIPT, '--db', dbPath, '--json'], { encoding: 'utf8' });
+      assert.equal(cli.status, 1);
+      assert.deepEqual(JSON.parse(cli.stdout), result);
+      assert.deepEqual(after, before, 'the imported cutover gate must be read-only');
+      assert.deepEqual(fs.readFileSync(dbPath), before, 'the CLI cutover gate must be read-only');
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when stored prompts have no unbound done instruction', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-cutover-clean-'));
+    const dbPath = path.join(tmpDir, 'scheduler.db');
+    const db = new Database(dbPath);
+    try {
+      db.exec('CREATE TABLE tasks (id TEXT PRIMARY KEY, type TEXT NOT NULL, prompt TEXT NOT NULL)');
+      db.prepare('INSERT INTO tasks (id, type, prompt) VALUES (?, ?, ?)')
+        .run('task-current', 'recurring', 'Use cli.js done task-current --run-id 42');
+
+      const result = scanLegacyDonePrompts(dbPath);
+      assert.deepEqual(result, {
+        legacy_prompt_count: 0,
+        recurring_interval_count: 0,
+        tasks: []
+      });
+      const cli = spawnSync(process.execPath, [SCRIPT, '--db', dbPath, '--json'], { encoding: 'utf8' });
+      assert.equal(cli.status, 0);
+      assert.deepEqual(JSON.parse(cli.stdout), result);
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/skills/scheduler/scripts/__tests__/run-id-cutover-check.test.js
+++ b/skills/scheduler/scripts/__tests__/run-id-cutover-check.test.js
@@ -12,7 +12,7 @@ import { scanLegacyDonePrompts } from '../run-id-cutover-check.js';
 const SCRIPT = new URL('../run-id-cutover-check.js', import.meta.url).pathname;
 
 describe('run-id cutover check', () => {
-  it('blocks per-machine cutover when stored prompts contain legacy done instructions', () => {
+  it('blocks per-machine cutover when stored prompts contain static done instructions', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-cutover-check-'));
     const dbPath = path.join(tmpDir, 'scheduler.db');
     const db = new Database(dbPath);
@@ -44,11 +44,12 @@ describe('run-id cutover check', () => {
       const after = fs.readFileSync(dbPath);
 
       assert.deepEqual(result, {
-        legacy_prompt_count: 7,
-        recurring_interval_count: 5,
+        legacy_prompt_count: 8,
+        recurring_interval_count: 6,
         tasks: [
           { id: 'task-cjk-scheduler-tight', type: 'one-time' },
           { id: 'task-cjk-tight', type: 'recurring' },
+          { id: 'task-current', type: 'recurring' },
           { id: 'task-interval-oral', type: 'interval' },
           { id: 'task-middle-dot-tight', type: 'interval' },
           { id: 'task-mixed-same-line', type: 'recurring' },
@@ -67,7 +68,7 @@ describe('run-id cutover check', () => {
     }
   });
 
-  it('passes when stored prompts have no unbound done instruction', () => {
+  it('blocks a stored done instruction even when it contains a fixed run ID', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-cutover-clean-'));
     const dbPath = path.join(tmpDir, 'scheduler.db');
     const db = new Database(dbPath);
@@ -75,6 +76,30 @@ describe('run-id cutover check', () => {
       db.exec('CREATE TABLE tasks (id TEXT PRIMARY KEY, type TEXT NOT NULL, prompt TEXT NOT NULL)');
       db.prepare('INSERT INTO tasks (id, type, prompt) VALUES (?, ?, ?)')
         .run('task-current', 'recurring', 'Use cli.js done task-current --run-id 42');
+
+      const result = scanLegacyDonePrompts(dbPath);
+      assert.deepEqual(result, {
+        legacy_prompt_count: 1,
+        recurring_interval_count: 1,
+        tasks: [{ id: 'task-current', type: 'recurring' }]
+      });
+      const cli = spawnSync(process.execPath, [SCRIPT, '--db', dbPath, '--json'], { encoding: 'utf8' });
+      assert.equal(cli.status, 1);
+      assert.deepEqual(JSON.parse(cli.stdout), result);
+    } finally {
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes only when stored prompts contain no static done instruction', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-cutover-clean-'));
+    const dbPath = path.join(tmpDir, 'scheduler.db');
+    const db = new Database(dbPath);
+    try {
+      db.exec('CREATE TABLE tasks (id TEXT PRIMARY KEY, type TEXT NOT NULL, prompt TEXT NOT NULL)');
+      db.prepare('INSERT INTO tasks (id, type, prompt) VALUES (?, ?, ?)')
+        .run('task-current', 'recurring', 'No completion command is stored here');
 
       const result = scanLegacyDonePrompts(dbPath);
       assert.deepEqual(result, {

--- a/skills/scheduler/scripts/__tests__/run-id-cutover-check.test.js
+++ b/skills/scheduler/scripts/__tests__/run-id-cutover-check.test.js
@@ -28,6 +28,9 @@ describe('run-id cutover check', () => {
       insert.run('task-recurring-cli', 'recurring', 'Afterward run cli.js done task-recurring-cli');
       insert.run('task-interval-oral', 'interval', '完成后 scheduler done task-interval-oral');
       insert.run('task-one-time-cli', 'one-time', 'Run /scheduler/scripts/cli.js done task-one-time-cli');
+      insert.run('task-cjk-tight', 'recurring', '完成后cli.js done本任务。');
+      insert.run('task-middle-dot-tight', 'interval', '·cli.js done 本次。');
+      insert.run('task-cjk-scheduler-tight', 'one-time', '完成后scheduler done。');
       insert.run(
         'task-mixed-same-line',
         'recurring',
@@ -41,10 +44,13 @@ describe('run-id cutover check', () => {
       const after = fs.readFileSync(dbPath);
 
       assert.deepEqual(result, {
-        legacy_prompt_count: 4,
-        recurring_interval_count: 3,
+        legacy_prompt_count: 7,
+        recurring_interval_count: 5,
         tasks: [
+          { id: 'task-cjk-scheduler-tight', type: 'one-time' },
+          { id: 'task-cjk-tight', type: 'recurring' },
           { id: 'task-interval-oral', type: 'interval' },
+          { id: 'task-middle-dot-tight', type: 'interval' },
           { id: 'task-mixed-same-line', type: 'recurring' },
           { id: 'task-one-time-cli', type: 'one-time' },
           { id: 'task-recurring-cli', type: 'recurring' }

--- a/skills/scheduler/scripts/__tests__/task-dispatch.test.js
+++ b/skills/scheduler/scripts/__tests__/task-dispatch.test.js
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { dispatchTaskRun } from '../task-dispatch.js';
+import { completeTaskRun } from '../task-runs.js';
+
+async function withDb(fn) {
+  const originalZylosDir = process.env.ZYLOS_DIR;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-dispatch-'));
+  try {
+    process.env.ZYLOS_DIR = tmpDir;
+    const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const { getDb, now } = await import(new URL(`../database.js?${cacheBuster}`, import.meta.url));
+    const db = getDb();
+    try {
+      await fn(db, now());
+    } finally {
+      db.close();
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalZylosDir === undefined) delete process.env.ZYLOS_DIR;
+    else process.env.ZYLOS_DIR = originalZylosDir;
+  }
+}
+
+function insertPendingTask(db, currentTime, overrides = {}) {
+  const task = {
+    id: 'task-dispatch',
+    name: 'dispatch me',
+    prompt: 'perform the scheduled work',
+    type: 'recurring',
+    next_run_at: currentTime,
+    priority: 2,
+    require_idle: 1,
+    reply_channel: 'hxa-connect',
+    reply_endpoint: 'org:hxa|mylos',
+    ...overrides
+  };
+  db.prepare(`
+    INSERT INTO tasks (
+      id, name, prompt, type, next_run_at, priority, status, require_idle,
+      reply_channel, reply_endpoint, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+  `).run(
+    task.id, task.name, task.prompt, task.type, task.next_run_at, task.priority,
+    task.require_idle, task.reply_channel, task.reply_endpoint, currentTime, currentTime
+  );
+  return task;
+}
+
+describe('dispatchTaskRun', () => {
+  it('does not dispatch a task that was postponed after the daemon selected it', async () => {
+    await withDb((db, currentTime) => {
+      const staleTask = insertPendingTask(db, currentTime);
+      db.prepare('UPDATE tasks SET next_run_at = ?, updated_at = ? WHERE id = ?')
+        .run(currentTime + 3600, currentTime + 1, staleTask.id);
+      let sent = false;
+
+      const result = dispatchTaskRun(db, staleTask, () => {
+        sent = true;
+        return true;
+      }, { dispatchedAt: currentTime + 1 });
+
+      assert.equal(result.success, false);
+      assert.equal(sent, false);
+      assert.equal(db.prepare('SELECT status FROM tasks WHERE id = ?').get(staleTask.id).status, 'pending');
+      assert.equal(db.prepare('SELECT COUNT(*) AS count FROM task_history').get().count, 0);
+    });
+  });
+
+  it('does not dispatch a task whose current missed-run window has expired', async () => {
+    await withDb((db, currentTime) => {
+      const staleTask = insertPendingTask(db, currentTime - 60);
+      db.prepare('UPDATE tasks SET miss_threshold = 30, updated_at = ? WHERE id = ?')
+        .run(currentTime, staleTask.id);
+      let sent = false;
+
+      const result = dispatchTaskRun(db, staleTask, () => {
+        sent = true;
+        return true;
+      }, { dispatchedAt: currentTime });
+
+      assert.equal(result.success, false);
+      assert.equal(sent, false);
+      assert.equal(db.prepare('SELECT status FROM tasks WHERE id = ?').get(staleTask.id).status, 'pending');
+      assert.equal(db.prepare('SELECT COUNT(*) AS count FROM task_history').get().count, 0);
+    });
+  });
+
+  it('treats a zero missed-run window as immediate expiry', async () => {
+    await withDb((db, currentTime) => {
+      const task = insertPendingTask(db, currentTime - 1);
+      db.prepare('UPDATE tasks SET miss_threshold = 0 WHERE id = ?').run(task.id);
+      let sent = false;
+
+      const result = dispatchTaskRun(db, task, () => {
+        sent = true;
+        return true;
+      }, { dispatchedAt: currentTime });
+
+      assert.equal(result.success, false);
+      assert.equal(sent, false);
+    });
+  });
+
+  it('dispatches the current task content after a pending task was edited', async () => {
+    await withDb((db, currentTime) => {
+      const staleTask = insertPendingTask(db, currentTime);
+      db.prepare(`
+        UPDATE tasks
+        SET prompt = 'current prompt', priority = 1, require_idle = 0,
+            reply_channel = 'feishu', reply_endpoint = 'current-endpoint', updated_at = ?
+        WHERE id = ?
+      `).run(currentTime + 1, staleTask.id);
+      let sent;
+
+      const result = dispatchTaskRun(db, staleTask, (prompt, options) => {
+        sent = { prompt, options };
+        return true;
+      }, { dispatchedAt: currentTime + 1 });
+
+      assert.equal(result.success, true);
+      assert.match(sent.prompt, /current prompt/);
+      assert.doesNotMatch(sent.prompt, /perform the scheduled work/);
+      assert.deepEqual(sent.options, {
+        priority: 1,
+        requireIdle: false,
+        replyChannel: 'feishu',
+        replyEndpoint: 'current-endpoint'
+      });
+    });
+  });
+
+  it('sends a completion instruction bound to the atomically created run ID', async () => {
+    await withDb((db, currentTime) => {
+      const task = insertPendingTask(db, currentTime);
+      let sent;
+
+      const result = dispatchTaskRun(db, task, (prompt, options) => {
+        sent = { prompt, options };
+        return true;
+      }, { dispatchedAt: currentTime });
+
+      assert.equal(result.success, true);
+      assert.ok(Number.isSafeInteger(result.runId));
+      assert.match(sent.prompt, new RegExp(`done ${task.id} --run-id ${result.runId}$`));
+      assert.deepEqual(sent.options, {
+        priority: 2,
+        requireIdle: true,
+        replyChannel: 'hxa-connect',
+        replyEndpoint: 'org:hxa|mylos'
+      });
+      assert.equal(db.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id).status, 'running');
+      assert.deepEqual(
+        db.prepare('SELECT id, task_id, status FROM task_history').get(),
+        { id: result.runId, task_id: task.id, status: 'started' }
+      );
+    });
+  });
+
+  it('keeps a failed dispatch visible until an exact later run succeeds', async () => {
+    await withDb((db, currentTime) => {
+      const task = insertPendingTask(db, currentTime);
+
+      const failed = dispatchTaskRun(db, task, () => false, { dispatchedAt: currentTime });
+
+      assert.equal(failed.success, false);
+      assert.deepEqual(
+        db.prepare('SELECT status, failed_at, last_error FROM tasks WHERE id = ?').get(task.id),
+        { status: 'pending', failed_at: currentTime, last_error: 'Failed to dispatch message' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT status, completed_at, error FROM task_history WHERE id = ?').get(failed.runId),
+        { status: 'failed', completed_at: currentTime, error: 'Failed to dispatch message' }
+      );
+
+      const recovered = dispatchTaskRun(db, task, () => true, { dispatchedAt: currentTime + 1 });
+      assert.equal(completeTaskRun(db, {
+        taskId: task.id,
+        runId: recovered.runId,
+        completedAt: currentTime + 2
+      }), true);
+      assert.deepEqual(
+        db.prepare('SELECT status, failed_at, last_error FROM tasks WHERE id = ?').get(task.id),
+        { status: 'completed', failed_at: null, last_error: null }
+      );
+    });
+  });
+
+  it('records a thrown sender failure against the exact run', async () => {
+    await withDb((db, currentTime) => {
+      const task = insertPendingTask(db, currentTime);
+
+      const result = dispatchTaskRun(db, task, () => {
+        throw new Error('sender exploded');
+      }, { dispatchedAt: currentTime });
+
+      assert.equal(result.success, false);
+      assert.equal(result.reason, 'send-failed');
+      assert.deepEqual(
+        db.prepare('SELECT status, failed_at, last_error FROM tasks WHERE id = ?').get(task.id),
+        { status: 'pending', failed_at: currentTime, last_error: 'Failed to dispatch message' }
+      );
+      assert.deepEqual(
+        db.prepare('SELECT status, completed_at, error FROM task_history WHERE id = ?').get(result.runId),
+        { status: 'failed', completed_at: currentTime, error: 'Failed to dispatch message' }
+      );
+    });
+  });
+});

--- a/skills/scheduler/scripts/__tests__/task-runs.test.js
+++ b/skills/scheduler/scripts/__tests__/task-runs.test.js
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { completeTaskRun, startTaskRun, timeoutTaskRun } from '../task-runs.js';
+
+async function withDb(fn) {
+  const originalZylosDir = process.env.ZYLOS_DIR;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-runs-'));
+  try {
+    process.env.ZYLOS_DIR = tmpDir;
+    const cacheBuster = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const { getDb, now } = await import(new URL(`../database.js?${cacheBuster}`, import.meta.url));
+    const db = getDb();
+    try {
+      await fn(db, now());
+    } finally {
+      db.close();
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalZylosDir === undefined) delete process.env.ZYLOS_DIR;
+    else process.env.ZYLOS_DIR = originalZylosDir;
+  }
+}
+
+function insertPendingTask(db, taskId, currentTime) {
+  db.prepare(`
+    INSERT INTO tasks (id, name, prompt, type, next_run_at, status, created_at, updated_at)
+    VALUES (?, 'claim me', 'test prompt', 'one-time', ?, 'pending', ?, ?)
+  `).run(taskId, currentTime, currentTime, currentTime);
+}
+
+describe('startTaskRun', () => {
+  it('atomically claims a pending task and creates its run identity', async () => {
+    await withDb((db, currentTime) => {
+      insertPendingTask(db, 'task-claim', currentTime);
+
+      const started = startTaskRun(db, { taskId: 'task-claim', startedAt: currentTime });
+      const { runId, task } = started;
+
+      assert.ok(Number.isSafeInteger(runId));
+      assert.equal(task.id, 'task-claim');
+      assert.equal(task.status, 'running');
+      assert.equal(db.prepare("SELECT status FROM tasks WHERE id = 'task-claim'").get().status, 'running');
+      assert.deepEqual(
+        db.prepare('SELECT id, task_id, executed_at, status FROM task_history').get(),
+        { id: runId, task_id: 'task-claim', executed_at: currentTime, status: 'started' }
+      );
+
+      assert.equal(startTaskRun(db, { taskId: 'task-claim', startedAt: currentTime + 1 }), null);
+      assert.equal(db.prepare('SELECT COUNT(*) AS count FROM task_history').get().count, 1);
+    });
+  });
+
+  it('fails closed before an unsafe run ID can be dispatched', async () => {
+    await withDb((db, currentTime) => {
+      insertPendingTask(db, 'task-unsafe-run-id', currentTime);
+      db.prepare(`
+        INSERT INTO sqlite_sequence (name, seq)
+        VALUES ('task_history', ?)
+      `).run(Number.MAX_SAFE_INTEGER);
+
+      assert.throws(
+        () => startTaskRun(db, { taskId: 'task-unsafe-run-id', startedAt: currentTime }),
+        /safe-integer range/
+      );
+      assert.equal(db.prepare("SELECT status FROM tasks WHERE id = 'task-unsafe-run-id'").get().status, 'pending');
+      assert.equal(db.prepare('SELECT COUNT(*) AS count FROM task_history').get().count, 0);
+    });
+  });
+});
+
+describe('completeTaskRun', () => {
+  it('rejects an older still-started run when a newer run is active', async () => {
+    await withDb((db, currentTime) => {
+      insertPendingTask(db, 'task-complete', currentTime - 10);
+      db.prepare("UPDATE tasks SET status = 'running', updated_at = ? WHERE id = 'task-complete'")
+        .run(currentTime);
+      const olderRun = db.prepare(`
+        INSERT INTO task_history (task_id, executed_at, status)
+        VALUES ('task-complete', ?, 'started')
+      `).run(currentTime - 10);
+      const activeRun = db.prepare(`
+        INSERT INTO task_history (task_id, executed_at, status)
+        VALUES ('task-complete', ?, 'started')
+      `).run(currentTime);
+
+      assert.equal(completeTaskRun(db, {
+        taskId: 'task-complete',
+        runId: Number(olderRun.lastInsertRowid),
+        completedAt: currentTime + 1
+      }), false);
+      assert.equal(db.prepare("SELECT status FROM tasks WHERE id = 'task-complete'").get().status, 'running');
+      assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(olderRun.lastInsertRowid).status, 'started');
+      assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(activeRun.lastInsertRowid).status, 'started');
+    });
+  });
+});
+
+describe('timeoutTaskRun', () => {
+  it('rejects a timeout without an exact active run identity', async () => {
+    await withDb((db, currentTime) => {
+      insertPendingTask(db, 'task-timeout-without-run', currentTime - 7200);
+      db.prepare(`
+        UPDATE tasks
+        SET status = 'running', updated_at = ?
+        WHERE id = 'task-timeout-without-run'
+      `).run(currentTime - 7200);
+
+      assert.equal(timeoutTaskRun(db, {
+        taskId: 'task-timeout-without-run',
+        runId: null,
+        staleBefore: currentTime - 3600,
+        timedOutAt: currentTime
+      }), false);
+      assert.deepEqual(
+        db.prepare(`
+          SELECT status, failed_at, last_error
+          FROM tasks WHERE id = 'task-timeout-without-run'
+        `).get(),
+        { status: 'running', failed_at: null, last_error: null }
+      );
+      assert.equal(db.prepare('SELECT COUNT(*) AS count FROM task_history').get().count, 0);
+    });
+  });
+
+  it('times out only the latest active run and changes task outcome in the same transaction', async () => {
+    await withDb((db, currentTime) => {
+      insertPendingTask(db, 'task-timeout', currentTime - 7200);
+      db.prepare("UPDATE tasks SET type = 'recurring', status = 'running', updated_at = ? WHERE id = 'task-timeout'")
+        .run(currentTime - 7200);
+      const olderRun = db.prepare(`
+        INSERT INTO task_history (task_id, executed_at, status)
+        VALUES ('task-timeout', ?, 'started')
+      `).run(currentTime - 7200);
+      const activeRun = db.prepare(`
+        INSERT INTO task_history (task_id, executed_at, status)
+        VALUES ('task-timeout', ?, 'started')
+      `).run(currentTime - 7100);
+
+      assert.equal(timeoutTaskRun(db, {
+        taskId: 'task-timeout',
+        runId: Number(olderRun.lastInsertRowid),
+        staleBefore: currentTime - 3600,
+        timedOutAt: currentTime
+      }), false);
+      assert.equal(db.prepare("SELECT status FROM tasks WHERE id = 'task-timeout'").get().status, 'running');
+
+      assert.equal(timeoutTaskRun(db, {
+        taskId: 'task-timeout',
+        runId: Number(activeRun.lastInsertRowid),
+        staleBefore: currentTime - 3600,
+        timedOutAt: currentTime
+      }), true);
+      assert.deepEqual(
+        db.prepare("SELECT status, failed_at, last_error FROM tasks WHERE id = 'task-timeout'").get(),
+        { status: 'completed', failed_at: currentTime, last_error: 'Task timed out' }
+      );
+      assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(olderRun.lastInsertRowid).status, 'started');
+      assert.equal(db.prepare('SELECT status FROM task_history WHERE id = ?').get(activeRun.lastInsertRowid).status, 'timeout');
+    });
+  });
+});

--- a/skills/scheduler/scripts/cli.js
+++ b/skills/scheduler/scripts/cli.js
@@ -8,6 +8,7 @@ import { getDb, generateId, now } from './database.js';
 import { getNextRun, isValidCron, describeCron, getDefaultTimezone } from './cron-utils.js';
 import { parseTime, parseDuration, formatTime, getRelativeTime } from './time-utils.js';
 import { loadTimezone } from './tz.js';
+import { completeTaskRun } from './task-runs.js';
 
 const db = getDb();
 
@@ -31,7 +32,8 @@ Commands:
   add <prompt> [options]  Add a new task
   update <task-id> [options]  Update an existing task
   remove <task-id>        Remove a task
-  done <task-id>          Mark task as completed
+  done <task-id> --run-id <history-id>
+                          Complete one exact active run
   pause <task-id>         Pause a task
   resume <task-id>        Resume a paused task
   history [task-id]       Show execution history
@@ -65,13 +67,16 @@ Update Options (same as Add, plus):
                           Legacy alias: --no-require-idle
   --clear-reply           Clear reply configuration
 
+Done Options:
+  --run-id <history-id>   Required identity emitted in the scheduled task prompt
+
 Examples:
   ~/zylos/.claude/skills/scheduler/scripts/cli.js add "Say hello" --in "30 minutes"
   ~/zylos/.claude/skills/scheduler/scripts/cli.js add "Health check" --cron "0 8 * * *"
   ~/zylos/.claude/skills/scheduler/scripts/cli.js add "Check updates" --every "1 hour"
   ~/zylos/.claude/skills/scheduler/scripts/cli.js update task-abc --priority 1
   ~/zylos/.claude/skills/scheduler/scripts/cli.js update task-abc --block-queue-until-idle
-  ~/zylos/.claude/skills/scheduler/scripts/cli.js done task-abc123
+  ~/zylos/.claude/skills/scheduler/scripts/cli.js done task-abc123 --run-id 42
 `;
 
 function parseArgs(args) {
@@ -306,9 +311,10 @@ function cmdRemove(taskId) {
   console.log(`Removed task: ${tasks[0].id}`);
 }
 
-function cmdDone(taskId) {
+function cmdDone(taskId, options = {}) {
   if (!taskId) {
     console.error('Error: Task ID is required');
+    process.exitCode = 1;
     return;
   }
 
@@ -319,6 +325,7 @@ function cmdDone(taskId) {
 
   if (tasks.length === 0) {
     console.error(`Error: Task not found: ${taskId}`);
+    process.exitCode = 1;
     return;
   }
 
@@ -326,34 +333,30 @@ function cmdDone(taskId) {
     console.error(`Error: Ambiguous task ID prefix '${taskId}' matches multiple tasks:`);
     tasks.forEach(t => console.error(`  - ${t.id}`));
     console.error('Please provide a more specific prefix.');
+    process.exitCode = 1;
     return;
   }
 
   const task = tasks[0];
 
+  if (!options['run-id']) {
+    console.error('Error: Run ID is required (--run-id <history-id>)');
+    process.exitCode = 1;
+    return;
+  }
+
+  const runId = Number(options['run-id']);
+  if (!Number.isSafeInteger(runId) || runId <= 0) {
+    console.error(`Error: Invalid run ID: ${options['run-id']}`);
+    process.exitCode = 1;
+    return;
+  }
+
   const currentTime = now();
-
-  // Update task status
-  db.prepare(`
-    UPDATE tasks
-    SET status = 'completed', last_run_at = ?, updated_at = ?
-    WHERE id = ?
-  `).run(currentTime, currentTime, task.id);
-
-  // Update history entry
-  const historyEntry = db.prepare(`
-    SELECT id, executed_at FROM task_history
-    WHERE task_id = ? AND status = 'started'
-    ORDER BY executed_at DESC LIMIT 1
-  `).get(task.id);
-
-  if (historyEntry) {
-    const durationMs = (currentTime - historyEntry.executed_at) * 1000;
-    db.prepare(`
-      UPDATE task_history
-      SET status = 'success', completed_at = ?, duration_ms = ?
-      WHERE id = ?
-    `).run(currentTime, durationMs, historyEntry.id);
+  if (!completeTaskRun(db, { taskId: task.id, runId, completedAt: currentTime })) {
+    console.error(`Error: Run ${runId} is not the active run for task ${task.id}`);
+    process.exitCode = 1;
+    return;
   }
 
   console.log(`Completed task: ${task.id}`);
@@ -495,7 +498,13 @@ function cmdNext() {
 
 function cmdRunning() {
   const tasks = db.prepare(`
-    SELECT * FROM tasks
+    SELECT tasks.*,
+      (
+        SELECT id FROM task_history
+        WHERE task_id = tasks.id AND status = 'started'
+        ORDER BY id DESC LIMIT 1
+      ) AS active_run_id
+    FROM tasks
     WHERE status = 'running'
     ORDER BY updated_at ASC
   `).all();
@@ -506,18 +515,29 @@ function cmdRunning() {
   }
 
   console.log('\n  ⚠️  Running Tasks (complete these before compacting!):\n');
-  console.log('  ID              | Started            | Name');
-  console.log('  ' + '-'.repeat(60));
+  console.log('  ID              | Run ID   | Started            | Name');
+  console.log('  ' + '-'.repeat(72));
 
   for (const task of tasks) {
     const id = task.id.substring(0, 14).padEnd(14);
+    const runId = String(task.active_run_id ?? '-').padEnd(8);
     const started = formatTime(task.updated_at).padEnd(18);
     const name = task.name || task.prompt.substring(0, 30);
 
-    console.log(`  ${id} | ${started} | ${name}`);
+    console.log(`  ${id} | ${runId} | ${started} | ${name}`);
   }
 
-  console.log('\n  Run "cli.js done <task-id>" to complete them before /compact\n');
+  const completable = tasks.filter(task => task.active_run_id != null);
+  if (completable.length > 0) {
+    console.log('\n  Completion commands:');
+    for (const task of completable) {
+      console.log(`  cli.js done ${task.id} --run-id ${task.active_run_id}`);
+    }
+  }
+  if (completable.length !== tasks.length) {
+    console.log('\n  Running tasks without a run ID are legacy orphans and cannot be completed manually.');
+  }
+  console.log();
 }
 
 function cmdUpdate(taskId, options) {
@@ -721,7 +741,7 @@ function main() {
       break;
     case 'done':
     case 'complete':
-      cmdDone(args[0]);
+      cmdDone(args[0], options);
       break;
     case 'pause':
       cmdPause(args[0]);

--- a/skills/scheduler/scripts/daemon-tasks.js
+++ b/skills/scheduler/scripts/daemon-tasks.js
@@ -6,30 +6,81 @@
 import { now } from './database.js';
 import { getNextRun } from './cron-utils.js';
 import { formatTime } from './time-utils.js';
+import { timeoutTaskRun } from './task-runs.js';
 
 export const TASK_TIMEOUT = 3600;  // 1 hour
+
+/**
+ * Fail one currently overdue one-time task without trusting a stale daemon row.
+ */
+export function failMissedOneTimeTask(db, { taskId, currentTime = now() }) {
+  const failure = db.prepare(`
+    UPDATE tasks
+    SET status = 'failed', failed_at = ?,
+        last_error = 'Missed execution window', updated_at = ?
+    WHERE id = ? AND status = 'pending' AND type = 'one-time'
+      AND next_run_at + COALESCE(miss_threshold, 300) < ?
+  `).run(currentTime, currentTime, taskId, currentTime);
+  return failure.changes === 1;
+}
 
 /**
  * Update next_run_at for recurring/interval tasks after completion
  */
 export function updateNextRunTime(db, task) {
-  let nextRun;
+  const transition = db.transaction(() => {
+    const current = db.prepare(`
+      SELECT * FROM tasks WHERE id = ? AND status = ?
+    `).get(task.id, task.status);
+    if (!current) return { kind: 'unchanged' };
+    const transitionTime = now();
+    if (
+      current.status === 'pending' &&
+      current.next_run_at + (current.miss_threshold ?? 300) >= transitionTime
+    ) {
+      return { kind: 'unchanged' };
+    }
 
-  if (task.type === 'recurring' && task.cron_expression) {
-    nextRun = getNextRun(task.cron_expression, task.timezone);
-  } else if (task.type === 'interval' && task.interval_seconds) {
-    nextRun = now() + task.interval_seconds;
-  } else {
-    return; // One-time task, no update needed
-  }
+    let nextRun;
+    try {
+      if (current.type === 'recurring' && current.cron_expression) {
+        nextRun = getNextRun(current.cron_expression, current.timezone);
+      } else if (current.type === 'interval' && current.interval_seconds) {
+        nextRun = transitionTime + current.interval_seconds;
+      } else {
+        return { kind: 'unchanged' }; // One-time task, no update needed
+      }
+    } catch (error) {
+      const failedAt = transitionTime;
+      const failure = db.prepare(`
+        UPDATE tasks
+        SET status = 'failed', last_error = ?, failed_at = ?, updated_at = ?
+        WHERE id = ? AND status = ?
+      `).run(error.message, failedAt, failedAt, current.id, current.status);
+      if (failure.changes !== 1) {
+        throw new Error(`Task ${current.id} changed during reschedule failure handling`);
+      }
+      return { kind: 'failed', error };
+    }
 
-  db.prepare(`
-    UPDATE tasks
-    SET next_run_at = ?, status = 'pending', last_run_at = ?, updated_at = ?
-    WHERE id = ?
-  `).run(nextRun, now(), now(), task.id);
+    const updatedAt = transitionTime;
+    const update = db.prepare(`
+      UPDATE tasks
+      SET next_run_at = ?, status = 'pending', last_run_at = ?, updated_at = ?
+      WHERE id = ? AND status = ?
+    `).run(nextRun, updatedAt, updatedAt, current.id, current.status);
+    if (update.changes !== 1) {
+      throw new Error(`Task ${current.id} changed during rescheduling`);
+    }
+    return { kind: 'updated', nextRun };
+  });
 
-  console.log(`[${new Date().toISOString()}] Updated next run for ${task.id}: ${formatTime(nextRun)}`);
+  const outcome = transition.immediate();
+  if (outcome.kind === 'failed') throw outcome.error;
+  if (outcome.kind !== 'updated') return false;
+
+  console.log(`[${new Date().toISOString()}] Updated next run for ${task.id}: ${formatTime(outcome.nextRun)}`);
+  return true;
 }
 
 /**
@@ -49,9 +100,6 @@ export function processCompletedTasks(db) {
       updateNextRunTime(db, task);
     } catch (error) {
       console.error(`[${new Date().toISOString()}] Failed to reschedule task ${task.id}: ${error.message}`);
-      db.prepare(`
-        UPDATE tasks SET status = 'failed', last_error = ?, updated_at = ? WHERE id = ?
-      `).run(error.message, now(), task.id);
     }
   }
 }
@@ -65,32 +113,26 @@ export function handleStaleRunningTasks(db) {
   const staleThreshold = currentTime - TASK_TIMEOUT;
 
   const staleTasks = db.prepare(`
-    SELECT * FROM tasks
+    SELECT tasks.*,
+      (
+        SELECT id FROM task_history
+        WHERE task_id = tasks.id AND status = 'started'
+        ORDER BY id DESC LIMIT 1
+      ) AS active_run_id
+    FROM tasks
     WHERE status = 'running'
     AND updated_at < ?
   `).all(staleThreshold);
 
   for (const task of staleTasks) {
-    console.log(`[${new Date().toISOString()}] Task ${task.id} (${task.name}) timed out after ${TASK_TIMEOUT}s`);
-
-    db.prepare(`
-      UPDATE task_history
-      SET status = 'timeout', completed_at = ?
-      WHERE task_id = ? AND status = 'started'
-    `).run(now(), task.id);
-
-    if (task.type === 'one-time') {
-      db.prepare(`
-        UPDATE tasks
-        SET status = 'failed', last_error = 'Task timed out', updated_at = ?
-        WHERE id = ?
-      `).run(now(), task.id);
-    } else {
-      db.prepare(`
-        UPDATE tasks
-        SET status = 'completed', last_error = 'Task timed out', updated_at = ?
-        WHERE id = ?
-      `).run(now(), task.id);
+    const timedOut = timeoutTaskRun(db, {
+      taskId: task.id,
+      runId: task.active_run_id,
+      staleBefore: staleThreshold,
+      timedOutAt: currentTime
+    });
+    if (timedOut) {
+      console.log(`[${new Date().toISOString()}] Task ${task.id} (${task.name}) timed out after ${TASK_TIMEOUT}s`);
     }
   }
 }

--- a/skills/scheduler/scripts/daemon.js
+++ b/skills/scheduler/scripts/daemon.js
@@ -5,11 +5,15 @@
  */
 
 import { getDb, cleanupHistory, now } from './database.js';
-import { getNextRun } from './cron-utils.js';
 import { sendViaC4, readStatusFile } from './runtime.js';
-import { formatTime } from './time-utils.js';
 import { loadTimezone } from './tz.js';
-import { updateNextRunTime as _updateNextRunTime, processCompletedTasks as _processCompletedTasks, handleStaleRunningTasks as _handleStaleRunningTasks, TASK_TIMEOUT } from './daemon-tasks.js';
+import {
+  failMissedOneTimeTask as _failMissedOneTimeTask,
+  updateNextRunTime as _updateNextRunTime,
+  processCompletedTasks as _processCompletedTasks,
+  handleStaleRunningTasks as _handleStaleRunningTasks
+} from './daemon-tasks.js';
+import { dispatchTaskRun } from './task-dispatch.js';
 
 const CHECK_INTERVAL = 5000;  // 5 seconds
 const CLEANUP_INTERVAL = 3600000;  // 1 hour
@@ -57,64 +61,17 @@ function isRuntimeAlive() {
 function dispatchTask(task) {
   console.log(`[${new Date().toISOString()}] Dispatching task: ${task.id} (${task.name})`);
 
-  // Atomically claim the task (only if still pending)
-  const claim = db.prepare(`
-    UPDATE tasks
-    SET status = 'running', updated_at = ?
-    WHERE id = ? AND status = 'pending'
-  `).run(now(), task.id);
-
-  if (claim.changes === 0) {
+  const result = dispatchTaskRun(db, task, sendViaC4);
+  if (result.reason === 'not-pending') {
     console.log(`[${new Date().toISOString()}] Task ${task.id} already claimed/modified, skipping`);
     return false;
   }
 
-  // Create history entry
-  db.prepare(`
-    INSERT INTO task_history (task_id, executed_at, status)
-    VALUES (?, ?, 'started')
-  `).run(task.id, now());
-
-  // Build prompt with completion instruction
-  const prompt = `[Scheduled Task: ${task.id}] ${task.prompt}
-
----- After completing this task, run: ~/zylos/.claude/skills/scheduler/scripts/cli.js done ${task.id}`;
-
-  // Send via C4 Communication Bridge
-  const success = sendViaC4(prompt, {
-    priority: task.priority,
-    requireIdle: task.require_idle === 1,
-    replyChannel: task.reply_channel,
-    replyEndpoint: task.reply_endpoint
-  });
-
-  if (!success) {
+  if (!result.success) {
     console.error(`Failed to dispatch task ${task.id}`);
-
-    // Revert to pending
-    db.prepare(`
-      UPDATE tasks
-      SET status = 'pending', last_error = 'Failed to dispatch message', updated_at = ?
-      WHERE id = ?
-    `).run(now(), task.id);
-
-    // Mark task_history as failed (latest entry only)
-    const historyEntry = db.prepare(`
-      SELECT id FROM task_history
-      WHERE task_id = ? AND status = 'started'
-      ORDER BY executed_at DESC LIMIT 1
-    `).get(task.id);
-
-    if (historyEntry) {
-      db.prepare(`
-        UPDATE task_history
-        SET status = 'failed', completed_at = ?
-        WHERE id = ?
-      `).run(now(), historyEntry.id);
-    }
   }
 
-  return success;
+  return result.success;
 }
 
 function updateNextRunTime(task) {
@@ -144,15 +101,12 @@ function handleMissedTasks() {
 
   for (const task of missedTasks) {
     const overdueSeconds = currentTime - task.next_run_at;
-    const threshold = task.miss_threshold || 300;  // Default 5 minutes
+    const threshold = task.miss_threshold ?? 300;  // Default 5 minutes
 
     if (overdueSeconds > threshold) {
       // Overdue beyond threshold: skip to next schedule
       console.log(`[${new Date().toISOString()}] Task ${task.id} (${task.name}) missed by ${overdueSeconds}s (threshold: ${threshold}s), skipping to next schedule`);
-      updateNextRunTime({
-        ...task,
-        status: 'completed'
-      });
+      updateNextRunTime(task);
     } else {
       // Within threshold: try to dispatch if runtime is alive
       if (isRuntimeAlive()) {
@@ -208,7 +162,7 @@ async function mainLoop() {
       if (task) {
         const currentTime = now();
         const overdueSeconds = currentTime - task.next_run_at;
-        const threshold = task.miss_threshold || 300;
+        const threshold = task.miss_threshold ?? 300;
 
         // Check if task is overdue beyond its miss_threshold
         if (overdueSeconds > threshold) {
@@ -216,12 +170,7 @@ async function mainLoop() {
           console.log(`[${new Date().toISOString()}] Task ${task.id} (${task.name}) overdue by ${overdueSeconds}s (threshold: ${threshold}s), skipping`);
 
           if (task.type === 'one-time') {
-            // One-time tasks: mark as failed
-            db.prepare(`
-              UPDATE tasks
-              SET status = 'failed', last_error = 'Missed execution window', updated_at = ?
-              WHERE id = ?
-            `).run(currentTime, task.id);
+            _failMissedOneTimeTask(db, { taskId: task.id, currentTime });
           } else {
             // Recurring/interval tasks: schedule next run
             updateNextRunTime(task);

--- a/skills/scheduler/scripts/database.js
+++ b/skills/scheduler/scripts/database.js
@@ -13,6 +13,7 @@ const ZYLOS_DIR = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
 const DATA_DIR = path.join(ZYLOS_DIR, 'scheduler');
 const DB_PATH = path.join(DATA_DIR, 'scheduler.db');
 const HISTORY_RETENTION_DAYS = 30;
+const RUN_OUTCOME_MIGRATION_KEY = 'scheduler_run_outcome_v1';
 
 let db = null;
 
@@ -107,6 +108,136 @@ function initSchema() {
     );
   `);
 
+  migrateRunOutcomeState();
+}
+
+function historyAggregates() {
+  return db.prepare(`
+    SELECT status, COUNT(*) AS count,
+           COALESCE(SUM(id), 0) AS id_sum,
+           COALESCE(SUM(executed_at), 0) AS executed_sum,
+           COALESCE(SUM(completed_at), 0) AS completed_sum
+    FROM task_history
+    GROUP BY status
+    ORDER BY status
+  `).all();
+}
+
+/**
+ * Classify legacy task outcome fields from immutable run history.
+ * This migration is transactional, idempotent, and never rewrites history.
+ */
+function migrateRunOutcomeState() {
+  const applied = db.prepare('SELECT 1 FROM system_state WHERE key = ?').get(RUN_OUTCOME_MIGRATION_KEY);
+  if (applied) return;
+
+  const migrate = db.transaction(() => {
+    if (db.prepare('SELECT 1 FROM system_state WHERE key = ?').get(RUN_OUTCOME_MIGRATION_KEY)) return;
+
+    const beforeTaskCount = db.prepare('SELECT COUNT(*) AS count FROM tasks').get().count;
+    const beforeHistory = historyAggregates();
+    const tasks = db.prepare(`
+      SELECT id, status, last_error, failed_at, updated_at
+      FROM tasks
+    `).all();
+    const latestHistory = db.prepare(`
+      SELECT status, executed_at, completed_at, error
+      FROM task_history
+      WHERE task_id = ?
+      ORDER BY id DESC
+      LIMIT 1
+    `);
+    const updateOutcome = db.prepare(`
+      UPDATE tasks SET failed_at = ?, last_error = ? WHERE id = ?
+    `);
+
+    let recovered = 0;
+    let failed = 0;
+    let uncertain = 0;
+
+    for (const task of tasks) {
+      const latest = latestHistory.get(task.id);
+      let failedAt = task.failed_at;
+      let lastError = task.last_error;
+
+      const terminalFailed = latest?.status === 'failed' || latest?.status === 'timeout';
+      const terminalFailedAt = terminalFailed
+        ? (latest.completed_at ?? latest.executed_at)
+        : null;
+      const terminalError = terminalFailed
+        ? (latest.error || (latest.status === 'timeout' ? 'Task timed out' : 'Task failed'))
+        : null;
+      const taskFailureAt = task.failed_at ?? task.updated_at;
+      const taskFailureIsNewer = task.status === 'failed' && (
+        !terminalFailed ||
+        taskFailureAt > terminalFailedAt ||
+        (task.last_error && task.last_error !== terminalError)
+      );
+
+      if (taskFailureIsNewer) {
+        failedAt = taskFailureAt;
+        lastError = task.last_error || 'Task failed';
+        failed++;
+      } else if (latest?.status === 'failed' || latest?.status === 'timeout') {
+        failedAt = latest.completed_at ?? latest.executed_at;
+        lastError = latest.error || task.last_error ||
+          (latest.status === 'timeout' ? 'Task timed out' : 'Task failed');
+        failed++;
+      } else if (latest?.status === 'success') {
+        failedAt = null;
+        lastError = null;
+        recovered++;
+      } else if (task.last_error != null) {
+        failedAt = task.updated_at;
+        if (task.status === 'failed' && !latest) failed++;
+        else uncertain++;
+      }
+
+      if (failedAt !== task.failed_at || lastError !== task.last_error) {
+        updateOutcome.run(failedAt, lastError, task.id);
+      }
+    }
+
+    const afterTaskCount = db.prepare('SELECT COUNT(*) AS count FROM tasks').get().count;
+    const afterHistory = historyAggregates();
+    if (afterTaskCount !== beforeTaskCount || JSON.stringify(afterHistory) !== JSON.stringify(beforeHistory)) {
+      throw new Error('Run outcome migration changed task/history aggregates');
+    }
+
+    const unresolvedErrors = db.prepare(`
+      SELECT COUNT(*) AS count FROM tasks
+      WHERE last_error IS NOT NULL AND failed_at IS NULL
+    `).get().count;
+    const staleRecoverySignals = db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM tasks
+      WHERE status != 'failed'
+        AND (failed_at IS NOT NULL OR last_error IS NOT NULL)
+        AND id IN (
+          SELECT h.task_id FROM task_history h
+          WHERE h.id = (
+            SELECT h2.id FROM task_history h2
+            WHERE h2.task_id = h.task_id
+            ORDER BY h2.id DESC LIMIT 1
+          )
+          AND h.status = 'success'
+        )
+    `).get().count;
+    if (unresolvedErrors !== 0 || staleRecoverySignals !== 0) {
+      throw new Error('Run outcome migration postcondition failed');
+    }
+
+    db.prepare(`
+      INSERT INTO system_state (key, value, updated_at)
+      VALUES (?, ?, ?)
+    `).run(
+      RUN_OUTCOME_MIGRATION_KEY,
+      JSON.stringify({ tasks: beforeTaskCount, recovered, failed, uncertain }),
+      now()
+    );
+  });
+
+  migrate.immediate();
 }
 
 // Clean up old history entries (older than HISTORY_RETENTION_DAYS)

--- a/skills/scheduler/scripts/database.js
+++ b/skills/scheduler/scripts/database.js
@@ -188,7 +188,7 @@ function migrateRunOutcomeState() {
         lastError = null;
         recovered++;
       } else if (task.last_error != null) {
-        failedAt = task.updated_at;
+        failedAt = task.failed_at ?? task.updated_at;
         if (task.status === 'failed' && !latest) failed++;
         else uncertain++;
       }

--- a/skills/scheduler/scripts/run-id-cutover-check.js
+++ b/skills/scheduler/scripts/run-id-cutover-check.js
@@ -16,7 +16,7 @@ import { pathToFileURL } from 'node:url';
 
 import Database from 'better-sqlite3';
 
-const LEGACY_DONE_RE = /(?:^|[\s`'"(])(?:(?:[^\s`'"]*\/)?cli\.js|scheduler)\s+done\b(?![^\r\n;；。,.，`]*--run-id(?:\s|=))/im;
+const LEGACY_DONE_RE = /(?<![\w./-])(?:(?:[^\s`'"]*\/)?cli\.js|scheduler)\s+done\b(?![^\r\n;；。,.，`]*--run-id(?:\s|=))/im;
 
 function hasLegacyDoneInstruction(prompt) {
   return LEGACY_DONE_RE.test(String(prompt || ''));

--- a/skills/scheduler/scripts/run-id-cutover-check.js
+++ b/skills/scheduler/scripts/run-id-cutover-check.js
@@ -4,9 +4,11 @@
  *
  * Stored task prompts are per-machine data. A prompt can contain an old
  * completion instruction even when the dispatcher appends the new exact-run
- * command. This gate blocks cutover until every stored legacy instruction is
- * removed or rewritten. It never prints prompt text and never opens the DB for
- * writing.
+ * command. Every matching command in the stored prompt is static, including
+ * one with a fixed --run-id; the only safe exact-run command is generated at
+ * dispatch time. This gate therefore blocks cutover until every stored
+ * completion instruction is removed. It never prints prompt text and never
+ * opens the DB for writing.
  */
 
 import fs from 'node:fs';
@@ -16,7 +18,7 @@ import { pathToFileURL } from 'node:url';
 
 import Database from 'better-sqlite3';
 
-const LEGACY_DONE_RE = /(?<![\w./-])(?:(?:[^\s`'"]*\/)?cli\.js|scheduler)\s+done\b(?![^\r\n;；。,.，`]*--run-id(?:\s|=))/im;
+const LEGACY_DONE_RE = /(?<![\w./-])(?:(?:[^\s`'"]*\/)?cli\.js|scheduler)\s+done\b/im;
 
 function hasLegacyDoneInstruction(prompt) {
   return LEGACY_DONE_RE.test(String(prompt || ''));
@@ -77,7 +79,7 @@ function main() {
     console.log('PASS: no stored legacy scheduler done instructions found on this machine.');
   } else {
     console.error(
-      `BLOCKED: ${result.legacy_prompt_count} stored prompt(s) contain an unbound scheduler done instruction; ` +
+      `BLOCKED: ${result.legacy_prompt_count} stored prompt(s) contain a static scheduler done instruction; ` +
       `${result.recurring_interval_count} are recurring/interval. ` +
       'Update those per-machine prompts before installing the run-ID cutover.'
     );

--- a/skills/scheduler/scripts/run-id-cutover-check.js
+++ b/skills/scheduler/scripts/run-id-cutover-check.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Read-only pre-install gate for the run-bound `done --run-id` protocol.
+ *
+ * Stored task prompts are per-machine data. A prompt can contain an old
+ * completion instruction even when the dispatcher appends the new exact-run
+ * command. This gate blocks cutover until every stored legacy instruction is
+ * removed or rewritten. It never prints prompt text and never opens the DB for
+ * writing.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import Database from 'better-sqlite3';
+
+const LEGACY_DONE_RE = /(?:^|[\s`'"(])(?:(?:[^\s`'"]*\/)?cli\.js|scheduler)\s+done\b(?![^\r\n;；。,.，`]*--run-id(?:\s|=))/im;
+
+function hasLegacyDoneInstruction(prompt) {
+  return LEGACY_DONE_RE.test(String(prompt || ''));
+}
+
+export function scanLegacyDonePrompts(dbPath) {
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`Scheduler DB not found: ${dbPath}`);
+  }
+
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const rows = db.prepare(`
+      SELECT id, type, prompt
+      FROM tasks
+      ORDER BY id
+    `).all();
+    const tasks = rows
+      .filter((task) => hasLegacyDoneInstruction(task.prompt))
+      .map(({ id, type }) => ({ id, type }));
+
+    return {
+      legacy_prompt_count: tasks.length,
+      recurring_interval_count: tasks.filter((task) =>
+        task.type === 'recurring' || task.type === 'interval'
+      ).length,
+      tasks
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function defaultDbPath() {
+  const zylosDir = process.env.ZYLOS_DIR || path.join(os.homedir(), 'zylos');
+  return process.env.SCHEDULER_DB_PATH || path.join(zylosDir, 'scheduler', 'scheduler.db');
+}
+
+function readOption(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : null;
+}
+
+function main() {
+  const dbPath = readOption('--db') || defaultDbPath();
+  let result;
+  try {
+    result = scanLegacyDonePrompts(dbPath);
+  } catch (error) {
+    console.error(`Run-ID cutover check failed: ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.legacy_prompt_count === 0) {
+    console.log('PASS: no stored legacy scheduler done instructions found on this machine.');
+  } else {
+    console.error(
+      `BLOCKED: ${result.legacy_prompt_count} stored prompt(s) contain an unbound scheduler done instruction; ` +
+      `${result.recurring_interval_count} are recurring/interval. ` +
+      'Update those per-machine prompts before installing the run-ID cutover.'
+    );
+    console.error(`Task IDs: ${result.tasks.map((task) => task.id).join(', ')}`);
+  }
+
+  if (result.legacy_prompt_count > 0) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/skills/scheduler/scripts/task-dispatch.js
+++ b/skills/scheduler/scripts/task-dispatch.js
@@ -1,0 +1,58 @@
+/**
+ * Scheduler run dispatch behind one transactional run-identity interface.
+ */
+
+import { now } from './database.js';
+import { startTaskRun } from './task-runs.js';
+
+export function dispatchTaskRun(db, task, send, { dispatchedAt = now() } = {}) {
+  const started = startTaskRun(db, { taskId: task.id, startedAt: dispatchedAt });
+  if (started === null) {
+    return { success: false, runId: null, reason: 'not-pending' };
+  }
+  const { runId, task: claimedTask } = started;
+
+  const prompt = `[Scheduled Task: ${claimedTask.id}] ${claimedTask.prompt}
+
+---- After completing this task, run: ~/zylos/.claude/skills/scheduler/scripts/cli.js done ${claimedTask.id} --run-id ${runId}`;
+
+  let success = false;
+  try {
+    success = Boolean(send(prompt, {
+      priority: claimedTask.priority,
+      requireIdle: claimedTask.require_idle === 1,
+      replyChannel: claimedTask.reply_channel,
+      replyEndpoint: claimedTask.reply_endpoint
+    }));
+  } catch {
+    success = false;
+  }
+
+  if (!success) {
+    const failDispatch = db.transaction(() => {
+      const taskUpdate = db.prepare(`
+        UPDATE tasks
+        SET status = 'pending', failed_at = ?,
+            last_error = 'Failed to dispatch message', updated_at = ?
+        WHERE id = ? AND status = 'running'
+      `).run(dispatchedAt, dispatchedAt, task.id);
+
+      if (taskUpdate.changes !== 1) {
+        throw new Error(`Task ${task.id} changed during dispatch failure handling`);
+      }
+
+      const historyUpdate = db.prepare(`
+        UPDATE task_history
+        SET status = 'failed', completed_at = ?, error = 'Failed to dispatch message'
+        WHERE id = ? AND task_id = ? AND status = 'started'
+      `).run(dispatchedAt, runId, task.id);
+
+      if (historyUpdate.changes !== 1) {
+        throw new Error(`Run ${runId} changed during dispatch failure handling`);
+      }
+    });
+    failDispatch();
+  }
+
+  return { success, runId, reason: success ? null : 'send-failed' };
+}

--- a/skills/scheduler/scripts/task-runs.js
+++ b/skills/scheduler/scripts/task-runs.js
@@ -1,0 +1,149 @@
+/**
+ * Atomic lifecycle changes for individual scheduler runs.
+ */
+
+import { now } from './database.js';
+
+/**
+ * Claim one pending task and create the immutable identity for that run.
+ *
+ * Returns the claimed task and history row ID, or null when the task is no
+ * longer dispatchable.
+ */
+export function startTaskRun(db, { taskId, startedAt = now() }) {
+  const startRun = db.transaction(() => {
+    const claimedTask = db.prepare(`
+      UPDATE tasks
+      SET status = 'running', updated_at = ?
+      WHERE id = ? AND status = 'pending'
+        AND next_run_at <= ?
+        AND next_run_at + COALESCE(miss_threshold, 300) >= ?
+      RETURNING *
+    `).get(startedAt, taskId, startedAt, startedAt);
+
+    if (!claimedTask) return null;
+
+    const history = db.prepare(`
+      INSERT INTO task_history (task_id, executed_at, status)
+      VALUES (?, ?, 'started')
+    `).safeIntegers(true).run(taskId, startedAt);
+
+    const runId = Number(history.lastInsertRowid);
+    if (!Number.isSafeInteger(runId) || runId <= 0) {
+      throw new Error('Scheduler run ID exceeds the supported safe-integer range');
+    }
+
+    return { runId, task: claimedTask };
+  });
+
+  return startRun();
+}
+
+/**
+ * Record a timeout for the exact latest active run.
+ *
+ * Returns false without mutation when either the run identity or stale-task
+ * compare-and-set no longer matches.
+ */
+export function timeoutTaskRun(db, { taskId, runId, staleBefore, timedOutAt = now() }) {
+  if (!Number.isSafeInteger(runId) || runId <= 0) return false;
+
+  const timeoutRun = db.transaction(() => {
+    const active = db.prepare(`
+      SELECT type FROM tasks
+      WHERE id = ? AND status = 'running' AND updated_at < ?
+        AND ? = (
+          SELECT id FROM task_history
+          WHERE task_id = ? AND status = 'started'
+          ORDER BY id DESC LIMIT 1
+        )
+    `).get(taskId, staleBefore, runId, taskId);
+
+    if (!active) return false;
+
+    const nextStatus = active.type === 'one-time' ? 'failed' : 'completed';
+    const taskUpdate = db.prepare(`
+      UPDATE tasks
+      SET status = ?, failed_at = ?, last_error = 'Task timed out', updated_at = ?
+      WHERE id = ? AND status = 'running' AND updated_at < ?
+        AND ? = (
+          SELECT id FROM task_history
+          WHERE task_id = ? AND status = 'started'
+          ORDER BY id DESC LIMIT 1
+        )
+    `).run(
+      nextStatus, timedOutAt, timedOutAt, taskId, staleBefore,
+      runId, taskId
+    );
+
+    if (taskUpdate.changes !== 1) return false;
+
+    const historyUpdate = db.prepare(`
+      UPDATE task_history
+      SET status = 'timeout', completed_at = ?, error = 'Task timed out'
+      WHERE id = ? AND task_id = ? AND status = 'started'
+    `).run(timedOutAt, runId, taskId);
+
+    if (historyUpdate.changes !== 1) {
+      throw new Error(`Run ${runId} changed during timeout handling`);
+    }
+
+    return true;
+  });
+
+  return timeoutRun();
+}
+
+/**
+ * Complete one exact active run.
+ *
+ * Returns false without mutation when the task/run pair is no longer active.
+ */
+export function completeTaskRun(db, { taskId, runId, completedAt = now() }) {
+  const completeRun = db.transaction(() => {
+    const historyEntry = db.prepare(`
+      SELECT executed_at FROM task_history
+      WHERE id = ? AND task_id = ? AND status = 'started'
+        AND id = (
+          SELECT id FROM task_history
+          WHERE task_id = ? AND status = 'started'
+          ORDER BY id DESC LIMIT 1
+        )
+    `).get(runId, taskId, taskId);
+
+    if (!historyEntry) return false;
+
+    const taskUpdate = db.prepare(`
+      UPDATE tasks
+      SET status = 'completed', last_run_at = ?, updated_at = ?,
+          failed_at = NULL, last_error = NULL
+      WHERE id = ? AND status = 'running'
+        AND EXISTS (
+          SELECT 1 FROM task_history
+          WHERE id = ? AND task_id = ? AND status = 'started'
+        )
+        AND ? = (
+          SELECT id FROM task_history
+          WHERE task_id = ? AND status = 'started'
+          ORDER BY id DESC LIMIT 1
+        )
+    `).run(completedAt, completedAt, taskId, runId, taskId, runId, taskId);
+
+    if (taskUpdate.changes !== 1) return false;
+
+    const durationMs = Math.max(0, completedAt - historyEntry.executed_at) * 1000;
+    const historyUpdate = db.prepare(`
+      UPDATE task_history
+      SET status = 'success', completed_at = ?, duration_ms = ?
+      WHERE id = ? AND task_id = ? AND status = 'started'
+    `).run(completedAt, durationMs, runId, taskId);
+
+    if (historyUpdate.changes !== 1) {
+      throw new Error(`Run ${runId} changed during completion`);
+    }
+
+    return true;
+  });
+
+  return completeRun();
+}


### PR DESCRIPTION
## Summary

- reject legacy stored fixed run IDs during scheduler cutover validation
- require per-run IDs and update lifecycle guidance
- extend cutover regression coverage

## Verification

- scheduler suite: 125/125 passing
- independent design review: PASS
- independent implementation review: PASS

## Scope

Draft only. This PR has not been merged, installed, or deployed.

Related Feishu task: 3774993c-4778-4dc7-b0d4-33dce581ae8d
Paired dashboard PR: https://github.com/zylos-ai/zylos-dashboard/pull/295